### PR TITLE
Skal tillate hash-tegnet i begrunnelsesfelter da lenker ofte innehold…

### DIFF
--- a/src/frontend/utils/validering.ts
+++ b/src/frontend/utils/validering.ts
@@ -5,9 +5,9 @@ import { feil, type FeltState, ok } from '@navikt/familie-skjema';
 import { isNumeric } from './miscUtils';
 
 const textRegex =
-    /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-/\n%§!?@_()+:;,="&\n]*$/;
+    /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-/\n%§!?#@_()+:;,="&\n]*$/;
 const textGyldigRegex =
-    /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-/\n%§!?@_()+:;,="&\n]*/g;
+    /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-/\n%§!?#@_()+:;,="&\n]*/g;
 
 export enum DEFINERT_FEILMELDING {
     OBLIGATORISK_FELT = 'OBLIGATORISK_FELT',

--- a/src/frontend/utils/validering.ts
+++ b/src/frontend/utils/validering.ts
@@ -5,9 +5,9 @@ import { feil, type FeltState, ok } from '@navikt/familie-skjema';
 import { isNumeric } from './miscUtils';
 
 const textRegex =
-    /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-/\n%§!?#@_()+:;,="&\n]*$/;
+    /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'‐—–\-/\n%§!?#@_()+:;,="&\n]*$/;
 const textGyldigRegex =
-    /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-/\n%§!?#@_()+:;,="&\n]*/g;
+    /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'‐—–\-/\n%§!?#@_()+:;,="&\n]*/g;
 
 export enum DEFINERT_FEILMELDING {
     OBLIGATORISK_FELT = 'OBLIGATORISK_FELT',


### PR DESCRIPTION
Min frykt var at tegnene ikke er støttet pga mustache, men ser ut som det går helt fint også der. 

Behovet er meldt inn på [teams](https://teams.microsoft.com/l/message/19:b66dafe53f1e4a50bc4e8c137037c9d2@thread.tacv2/1679483388907?tenantId=62366534-1ec3-4962-8869-9b5535279d0b&groupId=11014155-e8a7-46ad-8be0-b5c10a863a36&parentMessageId=1679483388907&teamName=Team%20enslig%20fors%C3%B8rger%20kontinuerlig%20forbedring&channelName=Feilutbetaling&createdTime=1679483388907&allowXTenantAccess=false).



<img width="495" alt="Skjermbilde 2023-03-24 kl  09 04 28" src="https://user-images.githubusercontent.com/402915/227464289-d2fad08e-2898-4f80-8ec2-1f9c7083aca5.png">
…er et anchor-element