### PR TITLE
Feat/endre brevmottakere

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
@@ -45,7 +45,11 @@ interface IProps {
 }
 
 const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevisning }) => {
-    const { fjernBrevMottakerOgOppdaterState, settBrevmottakerTilEndring } = useBrevmottaker();
+    const {
+        fjernBrevMottakerOgOppdaterState,
+        settBrevmottakerTilEndring,
+        validerAlleSynligeFelter,
+    } = useBrevmottaker();
     const { settVisBrevmottakerModal } = useBehandling();
     const land = brevmottaker.manuellAdresseInfo
         ? CountryData.getCountryInstance('nb').findByValue(brevmottaker.manuellAdresseInfo.landkode)
@@ -114,6 +118,7 @@ const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevi
                     onClick={() => {
                         settBrevmottakerTilEndring(brevmottakerId);
                         settVisBrevmottakerModal(true);
+                        validerAlleSynligeFelter();
                     }}
                     size={'small'}
                     icon={<Edit />}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Delete } from '@navikt/ds-icons';
+import { Delete, Edit } from '@navikt/ds-icons';
 import { Button, Heading } from '@navikt/ds-react';
 import { AFontWeightBold } from '@navikt/ds-tokens/dist/tokens';
 import CountryData from '@navikt/land-verktoy';
 
+import { useBehandling } from '../../../context/BehandlingContext';
 import { IBrevmottaker, MottakerType, mottakerTypeVisningsnavn } from '../../../typer/Brevmottaker';
 import { useBrevmottaker } from './BrevmottakerContext';
 
@@ -24,8 +25,8 @@ const StyledDiv = styled.div`
 const DefinitionList = styled.dl`
     display: grid;
     grid-gap: 1rem;
-    grid-template-columns: 10rem 20rem;
-    margin-left: 1rem;
+    grid-template-columns: 10.5rem 20rem;
+    margin-left: 0.2rem;
 
     dt {
         font-weight: ${AFontWeightBold};
@@ -43,7 +44,8 @@ interface IProps {
 }
 
 const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevisning }) => {
-    const { fjernBrevMottakerOgOppdaterState } = useBrevmottaker();
+    const { fjernBrevMottakerOgOppdaterState, settBrevmottakerTilEndring } = useBrevmottaker();
+    const { settVisBrevmottakerModal } = useBehandling();
     const land = brevmottaker.manuellAdresseInfo
         ? CountryData.getCountryInstance('nb').findByValue(brevmottaker.manuellAdresseInfo.landkode)
         : undefined;
@@ -93,6 +95,19 @@ const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevi
                     </>
                 )}
             </DefinitionList>
+            {!erLesevisning && brevmottaker.type !== MottakerType.BRUKER && (
+                <Button
+                    variant={'tertiary'}
+                    onClick={() => {
+                        settBrevmottakerTilEndring(brevmottakerId);
+                        settVisBrevmottakerModal(true);
+                    }}
+                    size={'small'}
+                    icon={<Edit />}
+                >
+                    {'Endre'}
+                </Button>
+            )}
         </StyledDiv>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
@@ -47,7 +47,7 @@ interface IProps {
 const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevisning }) => {
     const {
         fjernBrevMottakerOgOppdaterState,
-        settBrevmottakerTilEndring,
+        settBrevmottakerIdTilEndring,
         validerAlleSynligeFelter,
     } = useBrevmottaker();
     const { settVisBrevmottakerModal } = useBehandling();
@@ -116,7 +116,7 @@ const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevi
                 <Button
                     variant={'tertiary'}
                     onClick={() => {
-                        settBrevmottakerTilEndring(brevmottakerId);
+                        settBrevmottakerIdTilEndring(brevmottakerId);
                         settVisBrevmottakerModal(true);
                         validerAlleSynligeFelter();
                     }}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
@@ -24,7 +24,8 @@ const StyledDiv = styled.div`
 
 const DefinitionList = styled.dl`
     display: grid;
-    grid-gap: 1rem;
+    row-gap: 1rem;
+    column-gap: 2rem;
     grid-template-columns: 10.5rem 20rem;
     margin-left: 0.2rem;
 
@@ -49,6 +50,7 @@ const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevi
     const land = brevmottaker.manuellAdresseInfo
         ? CountryData.getCountryInstance('nb').findByValue(brevmottaker.manuellAdresseInfo.landkode)
         : undefined;
+    const [organisasjonsnavn, kontaktperson] = brevmottaker.navn.split(' v/ ');
 
     return (
         <StyledDiv>
@@ -66,18 +68,29 @@ const Brevmottaker: React.FC<IProps> = ({ brevmottaker, brevmottakerId, erLesevi
                 )}
             </FlexDiv>
             <DefinitionList>
-                <dt>Navn</dt>
-                <dd>{brevmottaker.navn}</dd>
+                {brevmottaker.organisasjonsnummer ? (
+                    <>
+                        {kontaktperson && (
+                            <>
+                                <dt>Kontaktperson</dt>
+                                <dd>{kontaktperson}</dd>
+                            </>
+                        )}
+                        <dt>Organisasjonsnummer</dt>
+                        <dd>{brevmottaker.organisasjonsnummer}</dd>
+                        <dt>Organisasjonsnavn</dt>
+                        <dd>{organisasjonsnavn}</dd>
+                    </>
+                ) : (
+                    <>
+                        <dt>Navn</dt>
+                        <dd>{brevmottaker.navn}</dd>
+                    </>
+                )}
                 {brevmottaker.personIdent && (
                     <>
                         <dt>Fødselsnummer</dt>
                         <dd>{brevmottaker.personIdent}</dd>
-                    </>
-                )}
-                {brevmottaker.organisasjonsnummer && (
-                    <>
-                        <dt>Organisasjonsnummer</dt>
-                        <dd>{brevmottaker.organisasjonsnummer}</dd>
                     </>
                 )}
                 {brevmottaker.manuellAdresseInfo && (

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
@@ -201,6 +201,7 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
             nullstillSkjema,
             settSubmitRessurs,
             valideringErOk,
+            validerAlleSynligeFelter,
         } = useSkjema<ILeggTilEndreBrevmottakerSkjema, string>({
             felter: {
                 mottaker: useFelt<MottakerType | ''>({
@@ -351,6 +352,7 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
             brevmottakerTilEndring,
             settBrevmottakerTilEndring,
             bruker,
+            validerAlleSynligeFelter,
         };
     }
 );

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
@@ -94,7 +94,7 @@ const populerSkjema = (
     skjema: ISkjema<ILeggTilEndreBrevmottakerSkjema, string>,
     brevmottaker: IBrevmottaker
 ) => {
-    const eventuellKontaktperson = brevmottaker.navn.split(' v/ ')[1];
+    const [, eventuellKontaktperson] = brevmottaker.navn.split(' v/ ');
     const manuellAdresseInfo = brevmottaker.manuellAdresseInfo;
     skjema.felter.mottaker.validerOgSettFelt(brevmottaker.type);
     skjema.felter.navn.validerOgSettFelt(
@@ -146,7 +146,9 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
             [id: string]: IBrevmottaker;
         });
         const [adresseKilde, settAdresseKilde] = useState<AdresseKilde>(AdresseKilde.UDEFINERT);
-        const [brevmottakerTilEndring, settBrevmottakerTilEndring] = useState<string | undefined>();
+        const [brevmottakerIdTilEndring, settBrevmottakerIdTilEndring] = useState<
+            string | undefined
+        >();
 
         const { hentBehandlingMedBehandlingId } = useBehandling();
         const { fjernManuellBrevmottaker } = useBehandlingApi();
@@ -169,18 +171,18 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
         }, [brevmottakere]);
 
         React.useEffect(() => {
-            if (brevmottakerTilEndring) {
-                const opprinneligInput = brevmottakere[brevmottakerTilEndring];
-                populerSkjema(skjema, opprinneligInput);
+            if (brevmottakerIdTilEndring) {
+                const lagretBrevmottaker = brevmottakere[brevmottakerIdTilEndring];
+                populerSkjema(skjema, lagretBrevmottaker);
                 settAdresseKilde(
-                    opprinneligInput.personIdent
+                    lagretBrevmottaker.personIdent
                         ? AdresseKilde.OPPSLAG_REGISTER
-                        : opprinneligInput.organisasjonsnummer
+                        : lagretBrevmottaker.organisasjonsnummer
                         ? AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER
                         : AdresseKilde.MANUELL_REGISTRERING
                 );
             }
-        }, [brevmottakerTilEndring]);
+        }, [brevmottakerIdTilEndring]);
 
         const leggTilEllerOppdaterBrevmottaker = (id: string, brevmottaker: IBrevmottaker) => {
             settBrevMottakere({ ...brevmottakere, [id]: brevmottaker });
@@ -349,8 +351,8 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
             adresseKilde,
             settAdresseKilde,
             settVisfeilmeldinger,
-            brevmottakerTilEndring,
-            settBrevmottakerTilEndring,
+            brevmottakerIdTilEndring,
+            settBrevmottakerIdTilEndring,
             bruker,
             validerAlleSynligeFelter,
         };

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
@@ -62,7 +62,7 @@ const opprettManuellBrevmottakerRequest = (
 
     return {
         type: type,
-        navn: skjema.felter.navn.verdi || 'Placeholder', // Placeholder erstattes av navn fra registeroppslag
+        navn: skjema.felter.navn.verdi || ' ', // blank input erstattes med navn hentet fra register
         ...(adresseKilde === AdresseKilde.OPPSLAG_REGISTER
             ? {
                   personIdent: skjema.felter.fødselsnummer.verdi,

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -31,10 +31,10 @@ const StyledFieldset = styled(Fieldset)`
 `;
 
 interface IProps {
-    mottakerErBruker: boolean;
+    navnErPreutfylt: boolean;
 }
 
-const BrevmottakerSkjema: React.FC<IProps> = ({ mottakerErBruker }) => {
+const BrevmottakerSkjema: React.FC<IProps> = ({ navnErPreutfylt }) => {
     const { skjema } = useBrevmottaker();
 
     return (
@@ -43,7 +43,7 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ mottakerErBruker }) => {
                 <FamilieInput
                     {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     label={'Navn'}
-                    erLesevisning={mottakerErBruker}
+                    erLesevisning={navnErPreutfylt}
                     onChange={(event): void => {
                         skjema.felter.navn.validerOgSettFelt(event.target.value);
                     }}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Fieldset } from '@navikt/ds-react';
+import { Fieldset, Label } from '@navikt/ds-react';
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieInput } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -31,17 +31,40 @@ const StyledFieldset = styled(Fieldset)`
 `;
 
 const BrevmottakerSkjema: React.FC = () => {
-    const { skjema } = useBrevmottaker();
+    const { skjema, bruker } = useBrevmottaker();
+    const [mottakerErBruker, settMottakerErBruker] = React.useState(false);
+    React.useEffect(() => {
+        if (
+            skjema.felter.mottaker.verdi === MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE ||
+            skjema.felter.mottaker.verdi === MottakerType.DØDSBO
+        ) {
+            skjema.felter.navn.validerOgSettFelt(bruker.navn);
+            settMottakerErBruker(true);
+        } else {
+            mottakerErBruker && skjema.felter.navn.nullstill();
+            settMottakerErBruker(false);
+        }
+    }, [skjema.felter.mottaker.verdi]);
+
     return (
         <>
             <StyledFieldset legend="Skjema for manuell registrering av brevmottaker" hideLegend>
-                <FamilieInput
-                    {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    label={'Navn'}
-                    onChange={(event): void => {
-                        skjema.felter.navn.validerOgSettFelt(event.target.value);
-                    }}
-                />
+                {mottakerErBruker ? (
+                    <>
+                        <Label>Navn</Label>
+                        <ul>
+                            <li key="bruker">{bruker.navn}</li>
+                        </ul>
+                    </>
+                ) : (
+                    <FamilieInput
+                        {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        label={'Navn'}
+                        onChange={(event): void => {
+                            skjema.felter.navn.validerOgSettFelt(event.target.value);
+                        }}
+                    />
+                )}
                 <FamilieInput
                     {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     label={'Adresselinje 1'}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Fieldset, Label } from '@navikt/ds-react';
+import { Fieldset } from '@navikt/ds-react';
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieInput } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -30,41 +30,24 @@ const StyledFieldset = styled(Fieldset)`
     }
 `;
 
-const BrevmottakerSkjema: React.FC = () => {
-    const { skjema, bruker } = useBrevmottaker();
-    const [mottakerErBruker, settMottakerErBruker] = React.useState(false);
-    React.useEffect(() => {
-        if (
-            skjema.felter.mottaker.verdi === MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE ||
-            skjema.felter.mottaker.verdi === MottakerType.DØDSBO
-        ) {
-            skjema.felter.navn.validerOgSettFelt(bruker.navn);
-            settMottakerErBruker(true);
-        } else {
-            mottakerErBruker && skjema.felter.navn.nullstill();
-            settMottakerErBruker(false);
-        }
-    }, [skjema.felter.mottaker.verdi]);
+interface IProps {
+    mottakerErBruker: boolean;
+}
+
+const BrevmottakerSkjema: React.FC<IProps> = ({ mottakerErBruker }) => {
+    const { skjema } = useBrevmottaker();
 
     return (
         <>
             <StyledFieldset legend="Skjema for manuell registrering av brevmottaker" hideLegend>
-                {mottakerErBruker ? (
-                    <>
-                        <Label>Navn</Label>
-                        <ul>
-                            <li key="bruker">{bruker.navn}</li>
-                        </ul>
-                    </>
-                ) : (
-                    <FamilieInput
-                        {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label={'Navn'}
-                        onChange={(event): void => {
-                            skjema.felter.navn.validerOgSettFelt(event.target.value);
-                        }}
-                    />
-                )}
+                <FamilieInput
+                    {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                    label={'Navn'}
+                    erLesevisning={mottakerErBruker}
+                    onChange={(event): void => {
+                        skjema.felter.navn.validerOgSettFelt(event.target.value);
+                    }}
+                />
                 <FamilieInput
                     {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     label={'Adresselinje 1'}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -64,12 +64,12 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
         valideringErOk,
         settVisfeilmeldinger,
         lagreBrevmottakerOgOppdaterState,
-        brevmottakerTilEndring,
-        settBrevmottakerTilEndring,
+        brevmottakerIdTilEndring,
+        settBrevmottakerIdTilEndring,
         bruker,
     } = useBrevmottaker();
 
-    const heading = brevmottakerTilEndring ? 'Endre brevmottaker' : 'Legg til brevmottaker';
+    const heading = brevmottakerIdTilEndring ? 'Endre brevmottaker' : 'Legg til brevmottaker';
     const [navnErPreutfylt, settNavnErPreutfylt] = React.useState(false);
 
     React.useEffect(() => {
@@ -83,7 +83,7 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
     const lukkModal = () => {
         settVisBrevmottakerModal(false);
         settAdresseKilde(AdresseKilde.UDEFINERT);
-        settBrevmottakerTilEndring(undefined);
+        settBrevmottakerIdTilEndring(undefined);
         nullstillSkjema();
     };
 
@@ -226,10 +226,13 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                             loading={skjema.submitRessurs.status === RessursStatus.HENTER}
                             disabled={skjema.submitRessurs.status === RessursStatus.HENTER}
                             onClick={() =>
-                                lagreBrevmottakerOgOppdaterState(brevmottakerTilEndring, lukkModal)
+                                lagreBrevmottakerOgOppdaterState(
+                                    brevmottakerIdTilEndring,
+                                    lukkModal
+                                )
                             }
                         >
-                            {brevmottakerTilEndring ? 'Lagre endringer' : 'Legg til'}
+                            {brevmottakerIdTilEndring ? 'Lagre endringer' : 'Legg til'}
                         </Button>
                         <Button variant="tertiary" onClick={lukkModal}>
                             Avbryt

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -75,15 +75,21 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
     );
 
     React.useEffect(() => {
-        if (skjema.felter.mottaker.verdi && erMottakerBruker(skjema.felter.mottaker.verdi)) {
-            settMottakerErBruker(true);
+        settMottakerErBruker(
+            skjema.felter.mottaker.verdi ? erMottakerBruker(skjema.felter.mottaker.verdi) : false
+        );
+    }, [skjema.felter.mottaker.verdi]);
+
+    React.useEffect(() => {
+        if (mottakerErBruker) {
             skjema.felter.navn.validerOgSettFelt(bruker.navn);
             settAdresseKilde(AdresseKilde.MANUELL_REGISTRERING);
+            nullstillManuellAdresseInput();
         } else {
-            mottakerErBruker && skjema.felter.navn.nullstill();
-            settMottakerErBruker(false);
+            settAdresseKilde(AdresseKilde.UDEFINERT);
+            nullstillManuellAdresseInput(true);
         }
-    }, [skjema.felter.mottaker.verdi]);
+    }, [mottakerErBruker]);
 
     const lukkModal = () => {
         settVisBrevmottakerModal(false);
@@ -92,8 +98,8 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
         nullstillSkjema();
     };
 
-    const nullstillManuellAdresseInput = () => {
-        skjema.felter.navn.nullstill();
+    const nullstillManuellAdresseInput = (inkludertNavn?: boolean) => {
+        inkludertNavn && skjema.felter.navn.nullstill();
         skjema.felter.adresselinje1.nullstill();
         skjema.felter.adresselinje2.nullstill();
         skjema.felter.postnummer.nullstill();
@@ -124,6 +130,7 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                             const nyMottakerType = event.target.value as MottakerType;
                             skjema.felter.mottaker.validerOgSettFelt(nyMottakerType);
                             if (adresseKilde === AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER) {
+                                // Skjuler input-feltet for orgnr for ny mottakertype != fullmektig
                                 settAdresseKilde(AdresseKilde.UDEFINERT);
                             }
                         }}
@@ -145,7 +152,7 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                             value={adresseKilde}
                             onChange={(val: AdresseKilde) => {
                                 settAdresseKilde(val);
-                                nullstillManuellAdresseInput();
+                                nullstillManuellAdresseInput(true);
                             }}
                         >
                             <Radio

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -143,34 +143,38 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                                 </option>
                             ))}
                     </MottakerSelect>
-                    {!erMottakerBruker(skjema.felter.mottaker.verdi) && (
-                        <RadioGroup
-                            legend={'Adresse'}
-                            value={adresseKilde}
-                            onChange={(val: AdresseKilde) => {
-                                settAdresseKilde(val);
-                                nullstillManuellAdresseInput(true);
-                            }}
-                        >
-                            <Radio
-                                id={'manuell-registrering'}
-                                value={AdresseKilde.MANUELL_REGISTRERING}
+                    {skjema.felter.mottaker.verdi &&
+                        !erMottakerBruker(skjema.felter.mottaker.verdi) && (
+                            <RadioGroup
+                                legend={'Adresse'}
+                                value={adresseKilde}
+                                onChange={(val: AdresseKilde) => {
+                                    settAdresseKilde(val);
+                                    nullstillManuellAdresseInput(true);
+                                }}
                             >
-                                {adresseKilder[AdresseKilde.MANUELL_REGISTRERING]}
-                            </Radio>
-                            <Radio id={'oppslag-i-register'} value={AdresseKilde.OPPSLAG_REGISTER}>
-                                {adresseKilder[AdresseKilde.OPPSLAG_REGISTER]}
-                            </Radio>
-                            {skjema.felter.mottaker.verdi === MottakerType.FULLMEKTIG && (
                                 <Radio
-                                    id={'oppslag-i-organisasjonsregister'}
-                                    value={AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER}
+                                    id={'manuell-registrering'}
+                                    value={AdresseKilde.MANUELL_REGISTRERING}
                                 >
-                                    {adresseKilder[AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER]}
+                                    {adresseKilder[AdresseKilde.MANUELL_REGISTRERING]}
                                 </Radio>
-                            )}
-                        </RadioGroup>
-                    )}
+                                <Radio
+                                    id={'oppslag-i-register'}
+                                    value={AdresseKilde.OPPSLAG_REGISTER}
+                                >
+                                    {adresseKilder[AdresseKilde.OPPSLAG_REGISTER]}
+                                </Radio>
+                                {skjema.felter.mottaker.verdi === MottakerType.FULLMEKTIG && (
+                                    <Radio
+                                        id={'oppslag-i-organisasjonsregister'}
+                                        value={AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER}
+                                    >
+                                        {adresseKilder[AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER]}
+                                    </Radio>
+                                )}
+                            </RadioGroup>
+                        )}
                     {adresseKilde === AdresseKilde.MANUELL_REGISTRERING && (
                         <BrevmottakerSkjema navnErPreutfylt={navnErPreutfylt} />
                     )}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Fieldset, Heading, Label, Modal, Radio, RadioGroup } from '@navikt/ds-react';
+import { Button, Fieldset, Heading, Modal, Radio, RadioGroup } from '@navikt/ds-react';
 import { ASpacing2, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -145,7 +145,7 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                     </MottakerSelect>
                     {!erMottakerBruker(skjema.felter.mottaker.verdi) && (
                         <RadioGroup
-                            legend={<Label>Adresse</Label>}
+                            legend={'Adresse'}
                             value={adresseKilde}
                             onChange={(val: AdresseKilde) => {
                                 settAdresseKilde(val);
@@ -153,24 +153,18 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                             }}
                         >
                             <Radio
-                                name={'manuellRegistrering'}
-                                value={AdresseKilde.MANUELL_REGISTRERING}
                                 id={'manuell-registrering'}
+                                value={AdresseKilde.MANUELL_REGISTRERING}
                             >
                                 {adresseKilder[AdresseKilde.MANUELL_REGISTRERING]}
                             </Radio>
-                            <Radio
-                                name={'oppslagRegister'}
-                                value={AdresseKilde.OPPSLAG_REGISTER}
-                                id={'oppslag-i-register'}
-                            >
+                            <Radio id={'oppslag-i-register'} value={AdresseKilde.OPPSLAG_REGISTER}>
                                 {adresseKilder[AdresseKilde.OPPSLAG_REGISTER]}
                             </Radio>
                             {skjema.felter.mottaker.verdi === MottakerType.FULLMEKTIG && (
                                 <Radio
-                                    name={'oppslagOrgRegister'}
-                                    value={AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER}
                                     id={'oppslag-i-organisasjonsregister'}
+                                    value={AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER}
                                 >
                                     {adresseKilder[AdresseKilde.OPPSLAG_ORGANISASJONSREGISTER]}
                                 </Radio>

--- a/src/frontend/typer/Brevmottaker.ts
+++ b/src/frontend/typer/Brevmottaker.ts
@@ -31,3 +31,17 @@ export const mottakerTypeVisningsnavn: Record<MottakerType, string> = {
     DØDSBO: 'Dødsbo',
     BRUKER: 'Bruker',
 };
+
+export enum AdresseKilde {
+    MANUELL_REGISTRERING = 'MANUELL_REGISTRERING',
+    OPPSLAG_REGISTER = 'OPPSLAG_REGISTER',
+    OPPSLAG_ORGANISASJONSREGISTER = 'OPPSLAG_ORGANISASJONSREGISTER',
+    UDEFINERT = 'UDEFINERT',
+}
+
+export const adresseKilder: Record<AdresseKilde, string> = {
+    MANUELL_REGISTRERING: 'Manuell registrering',
+    OPPSLAG_REGISTER: 'Oppslag i register',
+    OPPSLAG_ORGANISASJONSREGISTER: 'Oppslag i organisasjonsregister',
+    UDEFINERT: 'Udefinert',
+};


### PR DESCRIPTION
- Løser https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12157
![image](https://user-images.githubusercontent.com/47184872/235060587-56224bdc-2a37-4cbe-be95-7fd047bcad59.png)

- Implementerer den gjenstående funksjonaliteten knyttet til radioknappene for oppslag i regsiter (forutsetter endringer i backend: https://github.com/navikt/familie-tilbake/pull/1076)
- Disabler input-feltet for navn når mottakertypen tilhører bruker (BRUKER_MED_UTENLANDS_ADRESSE, DØDSBO)
- Flytter endel repeterende kode i BrevmottakerContext til felles funksjoner

Screenshots:

![image](https://user-images.githubusercontent.com/47184872/235063778-751f18e3-56e6-4326-8155-e65c4bdf5c43.png)

![image](https://user-images.githubusercontent.com/47184872/235064023-503e588e-0cdc-4220-b512-5395253cfbfc.png)

![image](https://user-images.githubusercontent.com/47184872/235064157-cf0769d1-291b-449c-b372-f87cb1e47e76.png)

![image](https://user-images.githubusercontent.com/47184872/235064563-5ad96a97-b5d0-4e78-a77a-fe43f7cda2b0.png)

