### PR TITLE
Legger til en stylized bodyshort med whitespace preline

### DIFF
--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
@@ -25,6 +25,10 @@ const Innslag = styled.div`
     flex-direction: row;
 `;
 
+const StyledBodyShort = styled(BodyShort)`
+    white-space: pre-line;
+`;
+
 const Tidslinje = styled.div`
     width: 3.5rem;
     min-width: 3.5rem;
@@ -82,7 +86,7 @@ const HistorikkInnslag: React.FC<IProps> = ({ innslag }) => {
                 </>
             );
         }
-        return <BodyShort>{innslag.tekst}</BodyShort>;
+        return <StyledBodyShort>{innslag.tekst}</StyledBodyShort>;
     };
 
     const lagBrevLink = () => {


### PR DESCRIPTION
Funksjonalitet lagt til for å støtte design endringer i favrokort: 
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12197

Legger til en styled bordy short for å få til new lines i historikk.

Gitt en slik respons fra familie-historikk:

```
        {
            "behandlingId": "9a2fb5c3-371d-4bd4-8cca-0d6026525376",
            "eksternFagsakId": "9594918",
            "fagsystem": "EF",
            "applikasjon": "FAMILIE_TILBAKE",
            "type": "HENDELSE",
            "aktør": "SAKSBEHANDLER",
            "aktørIdent": "Z994151",
            "tittel": "Bruker med utenlandsk adresse er lagt til som brevmottaker",
            "tekst": "Uy Nguyen\nFA 11\nHelsfyr\n0585\nOslo\nNorge",
            "steg": null,
            "journalpostId": null,
            "dokumentId": null,
            "opprettetTid": "2023-05-08T00:07:42.42"
        }
```

Før:
![førrr](https://user-images.githubusercontent.com/110383605/236923824-52532575-3559-477c-ab6f-f73cc3523ceb.png)

Etter:
![ettteerr](https://user-images.githubusercontent.com/110383605/236923841-5c18b154-8c45-4fbb-8de4-599cb5775ec9.png)
