### PR TITLE
Legg inn en validering for om Norge er valgt ulovlig, og vis feilmelding

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
@@ -195,6 +195,18 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
             }
         };
 
+        const feilNårUtenlandskAdresseHarNorgeSomLand = (
+            mottaker: MottakerType,
+            felt: FeltState<string>
+        ) => {
+            const norgeErUlovligValgt =
+                mottaker === MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE && felt.verdi === 'NO';
+
+            if (norgeErUlovligValgt) {
+                return feil(felt, 'Norge kan ikke være satt for bruker med utenlandsk adresse');
+            }
+        };
+
         const mottaker = useFelt<MottakerType | ''>({
             verdi: '',
             valideringsfunksjon: felt =>
@@ -285,24 +297,17 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
                     verdi: '',
                     avhengigheter: { adresseKilde, mottaker },
                     valideringsfunksjon: (felt, avhengigheter) => {
-                        if (
-                            avhengigheter?.adresseKilde === AdresseKilde.MANUELL_REGISTRERING ||
-                            avhengigheter?.adresseKilde === AdresseKilde.UDEFINERT
-                        ) {
-                            const norgeErUlovligValgt =
-                                avhengigheter?.mottaker.verdi ===
-                                    MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE &&
-                                felt.verdi === 'NO';
-
-                            if (norgeErUlovligValgt) {
-                                return feil(
-                                    felt,
-                                    'Norge kan ikke være satt for bruker med utenlandsk adresse'
-                                );
-                            }
-                            return felt.verdi !== '' ? ok(felt) : feil(felt, 'Feltet er påkrevd');
-                        }
-                        return ok(felt);
+                        return (
+                            feilNårUtenlandskAdresseHarNorgeSomLand(
+                                avhengigheter?.mottaker.verdi,
+                                felt
+                            ) ||
+                            validerPåkrevdFeltForManuellRegistrering(
+                                felt,
+                                avhengigheter?.adresseKilde,
+                                2
+                            )
+                        );
                     },
                 }),
             },


### PR DESCRIPTION
Favrokort: [NAV-12456](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12456)

Det skal ikke være mulig å velge Norge i mottagerliste dersom det er en utenlandsk adresse. Likevel kan Norge velges dersom man f.eks. velger Norge på Verge, men endrer mottager etterpå. Denne PR'en legger inn en fiks for dette slik at dersom man har valgt Norge på ulovligvis vil bruker få en feilmelding.

![Screenshot 2023-05-23 at 10 46 15](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/15be6f7c-e18c-400b-9639-9bef592658f1)
