### PR TITLE
Legger ved suffix/prefix på dødsbo ved manuelt registrert mottaker

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -72,13 +72,22 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
     const heading = brevmottakerIdTilEndring ? 'Endre brevmottaker' : 'Legg til brevmottaker';
     const [navnErPreutfylt, settNavnErPreutfylt] = React.useState(false);
 
-    React.useEffect(() => {
-        const navnSkalVærePreutfylt = erMottakerBruker(skjema.felter.mottaker.verdi);
-        if (navnSkalVærePreutfylt !== navnErPreutfylt) {
-            skjema.felter.navn.validerOgSettFelt((navnSkalVærePreutfylt && bruker.navn) || '');
-            settNavnErPreutfylt(navnSkalVærePreutfylt);
+    const navnForDødsboMottaker = (mottaker: MottakerType | '', land: string) => {
+        if (mottaker === MottakerType.DØDSBO) {
+            return !land || land === 'NO' ? `${bruker.navn} v/dødsbo` : `Estate of ${bruker.navn}`;
         }
-    }, [skjema.felter.mottaker.verdi]);
+    };
+
+    React.useEffect(() => {
+        const { mottaker, navn, land } = skjema.felter;
+        const navnSkalVærePreutfylt = erMottakerBruker(mottaker.verdi);
+        navn.validerOgSettFelt(
+            (navnSkalVærePreutfylt &&
+                (navnForDødsboMottaker(mottaker.verdi, land.verdi) || bruker.navn)) ||
+                ''
+        );
+        settNavnErPreutfylt(navnSkalVærePreutfylt);
+    }, [skjema.felter.mottaker.verdi, skjema.felter.land.verdi]);
 
     const lukkModal = () => {
         settVisBrevmottakerModal(false);


### PR DESCRIPTION
Favrokort: [NAV-11463](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-11463)

Endringer gjelder på modal for manuelle mottakere. Dersom man velger:
Dødsbo i Norge: Legge til suffix på brukers navn "v/dødsbo"
Dødsbo i utlandet:  Legge til prefix før brukers navn "Estate of"

**Diverse screenshots:**
Bruker med utenlandsk adresse er fortsatt samme som før:

![Screenshot 2023-05-25 at 08 47 44](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/fc792a37-4a4b-4536-ad75-cc89d535d1f3)

Annet enn dødsbo og utenlandsk adresse er fortsatt er vanlig input felt:
![Screenshot 2023-05-25 at 08 48 03](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/0b9d48ad-1405-410c-bd5e-3e818ee573ee)

Dødsbo med ingen land valgt, norge valgt, og utenlandsk land valgt:
![Screenshot 2023-05-25 at 08 48 13](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/02942b91-3f94-4255-8eb8-c022ef25a274)
![Screenshot 2023-05-25 at 08 48 19](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/b9b8ff94-583a-4081-b3c3-b5b975fc748b)
![Screenshot 2023-05-25 at 08 48 26](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/ff3d59f5-5f14-41ff-aeac-d98d15929ef7)

Screenshots av der endringen treffer:
![Screenshot 2023-05-25 at 10 42 10](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/bbda5a7d-7f49-415d-bd0a-db47a6c74354)
![Screenshot 2023-05-25 at 10 42 19](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/0e8f4c18-0d50-489f-865b-919b98a7817a)
![Screenshot 2023-05-25 at 10 42 25](https://github.com/navikt/familie-tilbake-frontend/assets/8656966/77443126-a182-4e68-a746-4fb23124ba0a)
