### PR TITLE
Manuelle brevmottakere: Fikser bug "Ingen opplysninger oppgitt" for navn

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -31,11 +31,13 @@ const StyledFieldset = styled(Fieldset)`
 `;
 
 interface IProps {
-    navnErPreutfylt: boolean;
+    preutfyltNavn?: string;
 }
 
-const BrevmottakerSkjema: React.FC<IProps> = ({ navnErPreutfylt }) => {
+const BrevmottakerSkjema: React.FC<IProps> = ({ preutfyltNavn }) => {
     const { skjema } = useBrevmottaker();
+
+    preutfyltNavn && skjema.felter.navn.validerOgSettFelt(preutfyltNavn);
 
     return (
         <>
@@ -43,7 +45,7 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ navnErPreutfylt }) => {
                 <FamilieInput
                     {...skjema.felter.navn.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
                     label={'Navn'}
-                    erLesevisning={navnErPreutfylt}
+                    erLesevisning={!!preutfyltNavn}
                     onChange={(event): void => {
                         skjema.felter.navn.validerOgSettFelt(event.target.value);
                     }}

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -77,20 +77,11 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
     } = useBrevmottaker();
 
     const heading = brevmottakerIdTilEndring ? 'Endre brevmottaker' : 'Legg til brevmottaker';
-    const [navnErPreutfylt, settNavnErPreutfylt] = React.useState(false);
 
-    React.useEffect(() => {
-        const { mottaker, navn, land } = skjema.felter;
-        const navnSkalVærePreutfylt = erMottakerBruker(mottaker.verdi);
-        if (navnSkalVærePreutfylt || navnSkalVærePreutfylt !== navnErPreutfylt) {
-            navn.validerOgSettFelt(
-                navnSkalVærePreutfylt
-                    ? preutfyltNavnFixed(mottaker.verdi, land.verdi, bruker.navn)
-                    : ''
-            );
-        }
-        settNavnErPreutfylt(navnSkalVærePreutfylt);
-    }, [skjema.felter.mottaker.verdi, skjema.felter.land.verdi]);
+    const { mottaker, land } = skjema.felter;
+    const preutfyltNavn = erMottakerBruker(mottaker.verdi)
+        ? preutfyltNavnFixed(mottaker.verdi, land.verdi, bruker.navn)
+        : undefined;
 
     const lukkModal = () => {
         settVisBrevmottakerModal(false);
@@ -188,7 +179,7 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                             </RadioGroup>
                         )}
                     {adresseKilde === AdresseKilde.MANUELL_REGISTRERING && (
-                        <BrevmottakerSkjema navnErPreutfylt={navnErPreutfylt} />
+                        <BrevmottakerSkjema preutfyltNavn={preutfyltNavn} />
                     )}
                     {adresseKilde === AdresseKilde.OPPSLAG_REGISTER && (
                         <FamilieInput


### PR DESCRIPTION
Fikser en bug ved preutfylling av brukers navn som oppstod dersom adressekilden var oppslag i register idet preutfyllingen ble trigget som følge av endret mottakertype.

Har samtidig forenklet koden noe, da det viste seg at det ikke var nødvendig med en effect for at navnet skulle oppdatere seg automatisk ved endring av land eller mottakertype

![image](https://github.com/navikt/familie-tilbake-frontend/assets/47184872/d73bb318-5bbf-48a8-9368-6997da3d02e4)
