### PR TITLE
NAV-12385 - Samlekort (ref: NAV-12155) Menyrekkefølge: "Legg til / fjern brevmottaker" bør komme nederst i menyen.

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -89,22 +89,6 @@ const Behandlingsmeny: React.FC<IProps> = ({ fagsak }) => {
                                             onListElementClick={() => settVisMeny(false)}
                                         />
                                     </li>
-                                    {behandling.data.støtterManuelleBrevmottakere ? (
-                                        <li>
-                                            <LeggTilFjernBrevmottakere
-                                                behandling={behandling.data}
-                                                fagsak={fagsak}
-                                                onListElementClick={() => settVisMeny(false)}
-                                            />
-                                        </li>
-                                    ) : (
-                                        <li>
-                                            <OpprettFjernVerge
-                                                behandling={behandling.data}
-                                                onListElementClick={() => settVisMeny(false)}
-                                            />
-                                        </li>
-                                    )}
                                     {!venterPåKravgrunnlag &&
                                         (behandling.data.erBehandlingPåVent || ventegrunn ? (
                                             <li>
@@ -125,6 +109,22 @@ const Behandlingsmeny: React.FC<IProps> = ({ fagsak }) => {
                                         <li>
                                             <EndreBehandlendeEnhet
                                                 ytelse={fagsak.ytelsestype}
+                                                behandling={behandling.data}
+                                                onListElementClick={() => settVisMeny(false)}
+                                            />
+                                        </li>
+                                    )}
+                                    {behandling.data.støtterManuelleBrevmottakere ? (
+                                        <li>
+                                            <LeggTilFjernBrevmottakere
+                                                behandling={behandling.data}
+                                                fagsak={fagsak}
+                                                onListElementClick={() => settVisMeny(false)}
+                                            />
+                                        </li>
+                                    ) : (
+                                        <li>
+                                            <OpprettFjernVerge
                                                 behandling={behandling.data}
                                                 onListElementClick={() => settVisMeny(false)}
                                             />

--- a/src/frontend/typer/Brevmottaker.ts
+++ b/src/frontend/typer/Brevmottaker.ts
@@ -41,7 +41,7 @@ export enum AdresseKilde {
 
 export const adresseKilder: Record<AdresseKilde, string> = {
     MANUELL_REGISTRERING: 'Manuell registrering',
-    OPPSLAG_REGISTER: 'Oppslag i register',
+    OPPSLAG_REGISTER: 'Oppslag i personregister',
     OPPSLAG_ORGANISASJONSREGISTER: 'Oppslag i organisasjonsregister',
     UDEFINERT: 'Udefinert',
 };


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-12385

NAV-12385 - Samlekort 
* ref: NAV-12155 Menyrekkefølge: Menyinnlsaget "Legg til / fjern brevmottaker" bør komme nederst i menyen, likt som i BA-sak
* ref: NAV-12164 Tekstendring: Riktig radiotekst skal være: "Oppslag i personregister"

![NAV-12385-menyinnslag-før](https://github.com/navikt/familie-tilbake-frontend/assets/126786453/96435361-2ea9-4a36-8a39-74497b839829)
![NAV-12385-menyinnslag-etter](https://github.com/navikt/familie-tilbake-frontend/assets/126786453/3b01d65a-36bc-494a-ac87-bb629cb20b97)
![NAV-12385-tekst_før](https://github.com/navikt/familie-tilbake-frontend/assets/126786453/e6630f51-1ff7-4a16-9172-24bab31c8a5f)
![NAV-12385-tekst_etter](https://github.com/navikt/familie-tilbake-frontend/assets/126786453/efa0e76c-e1ad-45c4-9f66-bb448fbb84b4)

