### PR TITLE
NAV-13885 Lagt til feilmelding i brevmottakerskjema for validerings-feilmelding fra backend

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -14,6 +14,7 @@ import {
     MottakerType,
     mottakerTypeVisningsnavn,
 } from '../../../typer/Brevmottaker';
+import { hentFrontendFeilmelding } from '../../../utils';
 import { useBrevmottaker } from './BrevmottakerContext';
 import BrevmottakerSkjema from './BrevmottakerSkjema';
 
@@ -32,6 +33,9 @@ const FlexContainer = styled.div`
 const StyledFieldset = styled(Fieldset)`
     &.navds-fieldset > :not(:first-child):not(:empty) {
         margin-top: ${ASpacing6};
+    }
+    p.navds-error-message.navds-label {
+        max-width: 33rem;
     }
 `;
 
@@ -118,6 +122,7 @@ export const LeggTilEndreBrevmottakerModal: React.FC = () => {
                 <StyledFieldset
                     legend="Skjema for å legge til eller redigere brevmottaker"
                     hideLegend
+                    error={skjema.visFeilmeldinger && hentFrontendFeilmelding(skjema.submitRessurs)}
                 >
                     <MottakerSelect
                         {...skjema.felter.mottaker.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13885

Det er lagt til støtte for feilmelding i brevmottakerskjema - for validerings-feilmelding som kommer fra backend ved oppretting av manuell brevmottaker (egen PR backend) - dersom behandlingen inneholder fortrolig person (har adresebeskyttelse: STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND)