### PR TITLE
NAV-13885 Lagt til Toast for feilmelding ved forsøk på å legge til trinn for manuelle brevmottakere på behandling som inneholder fortrolig person

### DIFF
--- a/src/frontend/context/AppContext.tsx
+++ b/src/frontend/context/AppContext.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
+import { useState } from 'react';
 
 import createUseContext from 'constate';
 
 import { HttpProvider, useHttp } from '@navikt/familie-http';
 import type { ISaksbehandler, Ressurs } from '@navikt/familie-typer';
+
+import type { IToast, ToastTyper } from '../komponenter/Felleskomponenter/Toast/typer';
 
 interface IInfo {
     appImage: string;
@@ -50,6 +53,7 @@ const [AuthProvider, useAuth] = createUseContext(
 const [AppContentProvider, useApp] = createUseContext(() => {
     const { autentisert, innloggetSaksbehandler } = useAuth();
     const { request } = useHttp();
+    const [toasts, settToasts] = useState<{ [toastId: string]: IToast }>({});
 
     const hentTilbakeInfo = (): void => {
         request<void, IInfo>({
@@ -68,6 +72,13 @@ const [AppContentProvider, useApp] = createUseContext(() => {
         autentisert,
         innloggetSaksbehandler,
         hentTilbakeInfo,
+        settToast: (toastId: ToastTyper, toast: IToast) =>
+            settToasts({
+                ...toasts,
+                [toastId]: toast,
+            }),
+        settToasts,
+        toasts,
     };
 });
 

--- a/src/frontend/komponenter/Container.tsx
+++ b/src/frontend/komponenter/Container.tsx
@@ -10,6 +10,7 @@ import Dashboard from './Felleskomponenter/Dashboard';
 import Feilmelding from './Felleskomponenter/Feilmelding';
 import FTHeader from './Felleskomponenter/FTHeader/FTHeader';
 import UgyldigSesjon from './Felleskomponenter/Modal/SesjonUtløpt';
+import Toasts from './Felleskomponenter/Toast/Toasts';
 
 const Container: React.FC = () => {
     const { autentisert, innloggetSaksbehandler } = useApp();
@@ -17,21 +18,24 @@ const Container: React.FC = () => {
     return (
         <Router>
             {autentisert ? (
-                <main>
-                    <FTHeader innloggetSaksbehandler={innloggetSaksbehandler} />
-                    <FagsakProvider>
-                        <BehandlingProvider>
-                            <Routes>
-                                <Route
-                                    path="/fagsystem/:fagsystem/fagsak/:fagsakId/*"
-                                    element={<FagsakContainer />}
-                                />
-                                <Route path="/" element={<Dashboard />} />
-                                <Route path="/*" element={<Feilmelding />} />
-                            </Routes>
-                        </BehandlingProvider>
-                    </FagsakProvider>
-                </main>
+                <>
+                    <Toasts />
+                    <main>
+                        <FTHeader innloggetSaksbehandler={innloggetSaksbehandler} />
+                        <FagsakProvider>
+                            <BehandlingProvider>
+                                <Routes>
+                                    <Route
+                                        path="/fagsystem/:fagsystem/fagsak/:fagsakId/*"
+                                        element={<FagsakContainer />}
+                                    />
+                                    <Route path="/" element={<Dashboard />} />
+                                    <Route path="/*" element={<Feilmelding />} />
+                                </Routes>
+                            </BehandlingProvider>
+                        </FagsakProvider>
+                    </main>
+                </>
             ) : (
                 <UgyldigSesjon />
             )}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilFjernBrevmottakere/LeggTilFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilFjernBrevmottakere/LeggTilFjernBrevmottakere.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { useEffect } from 'react';
 
 import { ErrorMessage } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import {
     Behandlingssteg,
@@ -13,6 +15,7 @@ import {
 import { IFagsak } from '../../../../../typer/fagsak';
 import { BehandlingsMenyButton, FTButton } from '../../../../Felleskomponenter/Flytelementer';
 import UIModalWrapper from '../../../../Felleskomponenter/Modal/UIModalWrapper';
+import { AlertType, ToastTyper } from '../../../../Felleskomponenter/Toast/typer';
 import { sider } from '../../../../Felleskomponenter/Venstremeny/sider';
 
 interface IProps {
@@ -32,6 +35,7 @@ const LeggTilFjernBrevmottakere: React.FC<IProps> = ({
     const { hentBehandlingMedBehandlingId, behandlingILesemodus, settVisBrevmottakerModal } =
         useBehandling();
     const { request } = useHttp();
+    const { settToast } = useApp();
 
     const kanFjerneManuelleBrevmottakere =
         behandling.manuelleBrevmottakere.length ||
@@ -92,6 +96,16 @@ const LeggTilFjernBrevmottakere: React.FC<IProps> = ({
             opprettBrevmottakerSteg();
         }
     };
+
+    useEffect(() => {
+        if (feilmelding && feilmelding !== '') {
+            settToast(ToastTyper.BREVMOTTAKER_IKKE_TILLAT, {
+                alertType: AlertType.WARNING,
+                tekst: feilmelding,
+            });
+            settFeilmelding('');
+        }
+    }, [feilmelding]);
 
     return (
         <>

--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef } from 'react';
+
+import styled from 'styled-components';
+
+import { Alert } from '@navikt/ds-react';
+
+import { useApp } from '../../../context/AppContext';
+import type { IToast } from './typer';
+
+const Container = styled.div`
+    grid-column: 3;
+    width: 20rem;
+    z-index: 9999;
+    margin: auto 0 1.7rem auto;
+
+    &:focus {
+        border-radius: 4px;
+        box-shadow: 0 0 0 3px #00347d;
+        outline: none;
+    }
+
+    span {
+        color: black;
+        font-family: 'Source Sans Pro', Arial, sans-serif;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-radius: 0.2rem;
+    }
+`;
+
+const Toast: React.FC<{ toastId: string; toast: IToast }> = ({ toastId, toast }) => {
+    const { toasts, settToasts } = useApp();
+    const toastRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        (toastRef.current as HTMLSpanElement).focus();
+    }, [toastRef]);
+
+    /**
+     * Vis beskjed i minst 7 sekunder og mer dersom teksten er lang.
+     *
+     * Basert på lenken under, men forenklet litt.
+     * https://ux.stackexchange.com/questions/11203/how-long-should-a-temporary-notification-toast-appear
+     */
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            // eslint-disable-next-line
+            const { [toastId]: fjernetToast, ...resterendeToast } = toasts;
+            settToasts(resterendeToast);
+        }, Math.max(...[toast.tekst.length * 50, 7000]));
+        return () => clearTimeout(timer);
+    });
+
+    return (
+        <Container ref={toastRef}>
+            <Alert variant={toast.alertType}>{toast.tekst}</Alert>
+        </Container>
+    );
+};
+
+export default Toast;

--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toasts.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { useApp } from '../../../context/AppContext';
+import Toast from './Toast';
+
+const Container = styled.div`
+    position: fixed;
+    right: 2rem;
+    float: right;
+    bottom: 0;
+    z-index: 9999;
+`;
+
+const Toasts: React.FC = () => {
+    const { toasts } = useApp();
+
+    return (
+        <Container>
+            {Object.entries(toasts).map(([toastId, toast]) => (
+                <Toast key={toastId} toastId={toastId} toast={toast} />
+            ))}
+        </Container>
+    );
+};
+
+export default Toasts;

--- a/src/frontend/komponenter/Felleskomponenter/Toast/typer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/typer.ts
@@ -1,0 +1,17 @@
+export interface IToast {
+    alertType: AlertType;
+    tekst: string;
+}
+
+export enum ToastTyper {
+    BREVMOTTAKER_IKKE_TILLAT = 'BREVMOTTAKER_IKKE_TILLATT',
+    BREVMOTTAKER_LAGRET = 'BREVMOTTAKER_LAGRET',
+    BREVMOTTAKER_FJERNET = 'BREVMOTTAKER_FJERNET',
+}
+
+export enum AlertType {
+    ERROR = 'error',
+    WARNING = 'warning',
+    INFO = 'info',
+    SUCCESS = 'success',
+}


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-13885

* Det er lagt til funksjonalitet for toasts (samme som i ba-sak-frontend)
* Det er lagt til konkret Toast for håndtering av feilmelding relatert til valg av "Legg til brevmottaker" fra behandlingsmenyen.
Dette menyvalget oppretter trinn for å administrere manuelle brevmottakere og kan i prinsippet trigges fra ulike sider - noe som gjør det nødvendig med en "global visning" av potensiell advarsel (validerings-feilmelding) - med informasjon om at det ikke er tillatt fordi behandlingen inneholder fortrolig person.(person med adressebeskyttelse STRENGT_FORTROLIG / STRENGT_FORTROLIG_UTLAND).

Ettersom det er klønete å ha feilmeldingen i menyen (ev under menypunktet) da denne lukker seg i det man klikker - vises denne validerings-feilmeldingen i "global Toast" (ref over).

Dette tillegget er testet og har ingenting å si for dagens funksjonalitet.

![NAV-1388-toast](https://github.com/navikt/familie-tilbake-frontend/assets/126786453/253e33de-f0f1-42a5-9cee-422a69b33ebc)

