### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/build_n_deploy/naiserator/naiserator_dev_gcp.yaml
+++ b/build_n_deploy/naiserator/naiserator_dev_gcp.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   port: 8000
   liveness:
     path: /isAlive
@@ -67,7 +66,6 @@ spec:
     - secret: familie-tilbake-frontend-redis
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/build_n_deploy/naiserator/naiserator_prod_gcp.yaml
+++ b/build_n_deploy/naiserator/naiserator_prod_gcp.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   port: 8000
   liveness:
     path: /isAlive
@@ -63,7 +62,6 @@ spec:
     - secret: familie-tilbake-frontend-redis
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/build_n_deploy/naiserator/naiserator_redis_default.yaml
+++ b/build_n_deploy/naiserator/naiserator_redis_default.yaml
@@ -16,7 +16,6 @@ spec:
     max: 1
   resources: # you need to monitor need your self
     limits:
-      cpu: 100m
       memory: 128Mi
     requests:
       cpu: 100m

--- a/build_n_deploy/naiserator/naiserator_redis_exporter.yaml
+++ b/build_n_deploy/naiserator/naiserator_redis_exporter.yaml
@@ -15,7 +15,6 @@ spec:
     max: 1
   resources:
     limits:
-      cpu: 100m 
       memory: 100Mi
     requests:
       cpu: 100m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)