### PR TITLE
Ikke inkluder trailing slash dersom mottakerId ikke finnes.

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContext.tsx
@@ -373,13 +373,13 @@ const [BrevmottakerProvider, useBrevmottaker] = createUseContext(
                     adresseKilde
                 );
 
+                const mottakerIdPostfix = `${mottakerId ? `/${mottakerId}` : ''}`;
+
                 onSubmit(
                     {
                         method: mottakerId ? 'PUT' : 'POST',
                         data: manuellBrevmottakerRequest,
-                        url: `/familie-tilbake/api/brevmottaker/manuell/${
-                            behandling.behandlingId
-                        }/${mottakerId || ''}`,
+                        url: `/familie-tilbake/api/brevmottaker/manuell/${behandling.behandlingId}${mottakerIdPostfix}`,
                     },
                     (response: Ressurs<string>) => {
                         if (response.status === RessursStatus.SUKSESS) {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-15560

Nå som vi har oppdatert til spring boot 3 så er det forskjellige utslag som giis dersom det er trailing slash i et endepunkt.
Se https://www.baeldung.com/spring-boot-3-url-matching.

Siden vi bare i dette endepunktet inkluderer med trailing slash, så fikser jeg selve kallet istedenfor endepunktet for nå.