### PR TITLE
Oppdatert styled-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/react-dom": "^18.0.9",
     "@types/react-modal": "^3.13.1",
     "@types/react-router-dom": "^5.3.3",
-    "@types/styled-components": "^5.1.26",
     "@types/uuid": "^8.3.4",
     "axios": "^1.6.2",
     "babel-loader": "^9.1.2",
@@ -84,7 +83,8 @@
     "react-modal": "3.16.x",
     "react-router-dom": "^6.14.1",
     "snyk": "^1.1187.0",
-    "styled-components": "^5.3.11",
+    "styled-components": "^6.1.1",
+    "stylis": "^4.3.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Route, Routes, useNavigate, useLocation } from 'react-router-dom';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyShort } from '@navikt/ds-react';
 import { ABorderDefault, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Delete, Edit } from '@navikt/ds-icons';
 import { Button, Heading } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { AddCircle } from '@navikt/ds-icons';
 import { Button, Heading } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Fieldset } from '@navikt/ds-react';
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Button, Fieldset, Heading, Modal, Radio, RadioGroup } from '@navikt/ds-react';
 import { ASpacing2, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useLocation, useParams } from 'react-router-dom';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, BodyLong, Heading, Loader } from '@navikt/ds-react';
 import { AFontWeightBold, ATextDanger, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaPeriode/FeilutbetalingFaktaPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaPeriode/FeilutbetalingFaktaPerioder.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Table } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/SplittPeriode/SplittPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/SplittPeriode/SplittPeriode.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Detail, Link } from '@navikt/ds-react';
 import { type Periode as TidslinjePeriode } from '@navikt/familie-tidslinje';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Behandlingskort/Behandlingskort.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Behandlingskort/Behandlingskort.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyShort, Heading } from '@navikt/ds-react';
 import { AGray100, AGray400, ASpacing2, ASpacing8 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentlisting.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentlisting.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, BodyLong, Loader } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentvisning.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentvisning.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ExternalLink } from '@navikt/ds-icons';
 import { Link } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Journalpostvisning.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Journalpostvisning.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Detail } from '@navikt/ds-react';
 import { AGray400, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/Historikk.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/Historikk.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { parseISO } from 'date-fns';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, BodyLong, Loader } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ExternalLink } from '@navikt/ds-icons';
 import { BodyLong, BodyShort, Detail, Label, Link } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Send, Folder, Clock, Decision, NextFilled, BackFilled } from '@navikt/ds-icons';
 import { Button, Tabs } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, Link, Radio } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ExpandFilled } from '@navikt/ds-icons';
 import { Button, Popover } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ExternalLink } from '@navikt/ds-icons';
 import { Detail, Link } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ExternalLink, Office1Filled } from '@navikt/ds-icons';
 import { Link, Tag } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Vedtak/AvsnittSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/AvsnittSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/BrevmottakereAlert.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/BrevmottakereAlert.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Search } from '@navikt/ds-icons';
 import { Alert, Button } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, BodyLong, BodyShort, Heading, Loader } from '@navikt/ds-react';
 import { AFontWeightBold, ASpacing1, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { AddCircle } from '@navikt/ds-icons';
 import { BodyShort, Link } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakPerioder.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { vurderinger } from '../../../kodeverk';
 import { BeregningsresultatPeriode } from '../../../typer/vedtakTyper';

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Heading } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/GradForsettSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/GradForsettSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/ReduksjonAvBeløpSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/ReduksjonAvBeløpSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/SærligeGrunnerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/SærligeGrunnerSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/GodTroSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/GodTroSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyShort, Radio } from '@navikt/ds-react';
 import { FamilieInput } from '@navikt/familie-form-elements';

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Detail, Link } from '@navikt/ds-react';
 import { type Periode as TidslinjePeriode } from '@navikt/familie-tidslinje';

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/TilbakekrevingAktivitetTabell.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/TilbakekrevingAktivitetTabell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Table } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Felleskomponenter/ArrowBox/ArrowBox.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/ArrowBox/ArrowBox.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ABorderStrong, ABgDefault, ASpacing3, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 

--- a/src/frontend/komponenter/Felleskomponenter/Dashboard.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Dashboard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyLong, Heading } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Felleskomponenter/FTHeader/FTHeader.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/FTHeader/FTHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Dropdown, InternalHeader } from '@navikt/ds-react';
 import {

--- a/src/frontend/komponenter/Felleskomponenter/Flytelementer.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Flytelementer.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, Button, Detail } from '@navikt/ds-react';
 import {

--- a/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { IBrevmottaker, MottakerType } from '../../../../typer/Brevmottaker';
 import { IInstitusjon } from '../../../../typer/fagsak';

--- a/src/frontend/komponenter/Felleskomponenter/Ikoner/ikonelementer.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Ikoner/ikonelementer.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { AGray300 } from '@navikt/ds-tokens/dist/tokens';
 

--- a/src/frontend/komponenter/Felleskomponenter/Informasjonsbolk/Informasjonsbolk.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Informasjonsbolk/Informasjonsbolk.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyShort, Heading } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriode.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriode.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyShort, Label } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BodyLong, Heading } from '@navikt/ds-react';
 import { ATextDanger, ASpacing8 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Felleskomponenter/Modal/UIModalWrapper.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/UIModalWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Heading, Modal } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Felleskomponenter/PdfVisningModal/PdfVisningModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PdfVisningModal/PdfVisningModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Modal, Loader, Heading, Alert } from '@navikt/ds-react';
 import { ASpacing1, ASpacing3, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Felleskomponenter/Periodeinformasjon/PeriodeOppsummering.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Periodeinformasjon/PeriodeOppsummering.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/FTDatovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/FTDatovelger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { DatepickerProps } from 'nav-datovelger/lib/Datepicker';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { FamilieDatovelger, IDatovelgerProps } from '@navikt/familie-datovelger';
 

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/FamilieTilbakeTextArea.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/FamilieTilbakeTextArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 import { IFamilieTextareaProps } from '@navikt/familie-form-elements/src/textarea';
 import { FamilieTextarea } from '@navikt/familie-form-elements';
 

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/FixedDatovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/FixedDatovelger.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { DatepickerProps } from 'nav-datovelger/lib/Datepicker';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { IDatovelgerProps } from '@navikt/familie-datovelger';
 

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/LabelMedSpråk.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/LabelMedSpråk.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Label, Tag } from '@navikt/ds-react';
 import { ASpacing2 } from '@navikt/ds-tokens/dist/tokens';

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/index.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/index.ts
@@ -8,9 +8,8 @@ export * from './FixedDatovelger';
 export * from './FTDatovelger';
 export * from './LabelMedSpråk';
 
-export const HorisontalFamilieRadioGruppe = styled(FamilieRadioGruppe)`
-    margin-bottom: ${(props: { marginbottom?: string }) =>
-        props.marginbottom ? props.marginbottom : '12px'};
+export const HorisontalFamilieRadioGruppe = styled(FamilieRadioGruppe)<{ marginbottom?: string }>`
+    margin-bottom: ${({ marginbottom }) => (marginbottom ? marginbottom : '12px')};
 
     .navds-radio {
         display: inline-block;

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/index.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/index.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';

--- a/src/frontend/komponenter/Felleskomponenter/Steginformasjon/StegInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Steginformasjon/StegInformasjon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert, BodyShort, Label } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { BackFilled, NextFilled } from '@navikt/ds-icons';
 import { Button } from '@navikt/ds-react';

--- a/src/frontend/komponenter/Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import {
     AGreen200,

--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
 

--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toasts.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import { useApp } from '../../../context/AppContext';
 import Toast from './Toast';

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 
 import {
     AGray300,

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,7 +237,7 @@
   dependencies:
     "@babel/types" "^7.23.0"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.5":
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
   integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
@@ -1211,7 +1211,7 @@
     "@babel/parser" "^7.22.5"
     "@babel/types" "^7.22.5"
 
-"@babel/traverse@^7.22.10", "@babel/traverse@^7.4.5":
+"@babel/traverse@^7.22.10":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz#329c7a06735e144a506bdb2cad0268b7f46f4ad8"
   integrity sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==
@@ -1341,7 +1341,7 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
-"@emotion/is-prop-valid@^1.1.0":
+"@emotion/is-prop-valid@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
   integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
@@ -1388,17 +1388,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
   integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
 
-"@emotion/stylis@^0.8.4":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
-  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
-
-"@emotion/unitless@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
-  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
-
-"@emotion/unitless@^0.8.1":
+"@emotion/unitless@^0.8.0", "@emotion/unitless@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
   integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
@@ -2651,14 +2641,6 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
-"@types/hoist-non-react-statics@*":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
-  dependencies:
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -2855,14 +2837,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/styled-components@^5.1.26":
-  version "5.1.26"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.26.tgz#5627e6812ee96d755028a98dae61d28e57c233af"
-  integrity sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==
-  dependencies:
-    "@types/hoist-non-react-statics" "*"
-    "@types/react" "*"
-    csstype "^3.0.2"
+"@types/stylis@^4.0.2":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.4.tgz#14b61f022e832d87d442ae1795e0f0f0b7daa879"
+  integrity sha512-36ZrGJ8fgtBr6nwNnuJ9jXIj+bn/pF6UoqmrQT7+Y99+tFFeHHsoR54+194dHdyhPjgbeoNz3Qru0oRt0l6ASQ==
 
 "@types/tapable@^1":
   version "1.0.8"
@@ -3568,17 +3546,6 @@ babel-plugin-polyfill-regenerator@^0.5.3:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.4.3"
 
-"babel-plugin-styled-components@>= 1.12.0":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz#9a1f37c7f32ef927b4b008b529feb4a2c82b1092"
-  integrity sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.22.5"
-    "@babel/helper-module-imports" "^7.22.5"
-    "@babel/plugin-syntax-jsx" "^7.22.5"
-    lodash "^4.17.21"
-    picomatch "^2.3.1"
-
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -4195,7 +4162,7 @@ css-select@^5.1.0:
     domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-to-react-native@^3.0.0:
+css-to-react-native@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
   integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
@@ -4307,7 +4274,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2:
+csstype@^3.0.2, csstype@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
@@ -5676,7 +5643,7 @@ hey-listen@^1.0.8:
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
   integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7875,7 +7842,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.21, postcss@^8.4.24:
+postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.31:
   version "8.4.31"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
@@ -8878,21 +8845,20 @@ style-value-types@5.0.0:
     hey-listen "^1.0.8"
     tslib "^2.1.0"
 
-styled-components@^5.3.11:
-  version "5.3.11"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.11.tgz#9fda7bf1108e39bf3f3e612fcc18170dedcd57a8"
-  integrity sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==
+styled-components@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.1.1.tgz#a5414ada07fb1c17b96a26a05369daa4e2ad55e5"
+  integrity sha512-cpZZP5RrKRIClBW5Eby4JM1wElLVP4NQrJbJ0h10TidTyJf4SIIwa3zLXOoPb4gJi8MsJ8mjq5mu2IrEhZIAcQ==
   dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^1.1.0"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
+    "@emotion/is-prop-valid" "^1.2.1"
+    "@emotion/unitless" "^0.8.0"
+    "@types/stylis" "^4.0.2"
+    css-to-react-native "^3.2.0"
+    csstype "^3.1.2"
+    postcss "^8.4.31"
     shallowequal "^1.1.0"
-    supports-color "^5.5.0"
+    stylis "^4.3.0"
+    tslib "^2.5.0"
 
 stylehacks@^6.0.0:
   version "6.0.0"
@@ -8907,7 +8873,12 @@ stylis@4.2.0:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+stylis@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
+  integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
+
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
Oppdatert styled-components dependency fra 5.3.11 til 6.1.1
* Ref dependabot major-dependencies group PR: https://github.com/navikt/familie-tilbake-frontend/pull/1592
* styled-components doc: https://styled-components.com/docs/faqs#what-do-i-need-to-do-to-migrate-to-v6