### PR TITLE
Aksel v5 - byttet diverse form elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@navikt/ds-tokens": "^5.12.0",
     "@navikt/familie-backend": "^10.0.7",
     "@navikt/familie-datovelger": "0.2.0",
-    "@navikt/familie-form-elements": "^12.0.0",
+    "@navikt/familie-form-elements": "^13.0.0",
     "@navikt/familie-http": "^6.0.2",
     "@navikt/familie-logging": "^6.0.0",
     "@navikt/familie-skjema": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@navikt/ds-tokens": "^5.12.0",
     "@navikt/familie-backend": "^10.0.7",
     "@navikt/familie-datovelger": "0.2.0",
-    "@navikt/familie-form-elements": "^13.0.0",
+    "@navikt/familie-form-elements": "^14.0.0",
     "@navikt/familie-http": "^6.0.2",
     "@navikt/familie-logging": "^6.0.0",
     "@navikt/familie-skjema": "^7.0.6",

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Button, Fieldset, Modal, Radio, RadioGroup } from '@navikt/ds-react';
+import { Button, Fieldset, Modal, Radio, RadioGroup, Select } from '@navikt/ds-react';
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
-import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieInput } from '@navikt/familie-form-elements';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../context/BehandlingContext';
@@ -35,7 +35,7 @@ const StyledFieldset = styled(Fieldset)`
     }
 `;
 
-const MottakerSelect = styled(FamilieSelect)`
+const MottakerSelect = styled(Select)`
     max-width: 19rem;
 `;
 

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
@@ -32,7 +32,7 @@ const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
             <Spacer20 />
             <RadMedMargin>
                 <Column xs="6">
-                    <DetailBold size="small">Årsak(er) til revurdering</DetailBold>
+                    <DetailBold>Årsak(er) til revurdering</DetailBold>
                     {feilutbetalingFakta.faktainfo?.revurderingsårsak && (
                         <BodyShort size="small">
                             {feilutbetalingFakta.faktainfo.revurderingsårsak}
@@ -40,7 +40,7 @@ const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
                     )}
                 </Column>
                 <Column xs="6">
-                    <DetailBold size="small">Dato for revurderingsvedtak</DetailBold>
+                    <DetailBold>Dato for revurderingsvedtak</DetailBold>
                     <BodyShort size="small">
                         {formatterDatostring(feilutbetalingFakta.revurderingsvedtaksdato)}
                     </BodyShort>
@@ -48,7 +48,7 @@ const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
             </RadMedMargin>
             <RadMedMargin>
                 <Column xs="6">
-                    <DetailBold size="small">Resultat</DetailBold>
+                    <DetailBold>Resultat</DetailBold>
                     {feilutbetalingFakta.faktainfo?.revurderingsresultat && (
                         <BodyShort size="small">
                             {feilutbetalingFakta.faktainfo.revurderingsresultat}
@@ -56,7 +56,7 @@ const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
                     )}
                 </Column>
                 <Column xs="6">
-                    <DetailBold size="small">Konsekvens</DetailBold>
+                    <DetailBold>Konsekvens</DetailBold>
                     {feilutbetalingFakta.faktainfo?.konsekvensForYtelser && (
                         <BodyShort size="small">
                             {feilutbetalingFakta.faktainfo.konsekvensForYtelser?.join(', ')}
@@ -66,7 +66,7 @@ const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
             </RadMedMargin>
             <Row>
                 <Column xs="6">
-                    <DetailBold size="small">Tilbakekrevingsvalg</DetailBold>
+                    <DetailBold>Tilbakekrevingsvalg</DetailBold>
                     {feilutbetalingFakta.faktainfo?.tilbakekrevingsvalg && (
                         <BodyShort size="small">
                             {tilbakekrevingsvalg[feilutbetalingFakta.faktainfo.tilbakekrevingsvalg]}

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -64,7 +64,7 @@ const FaktaSkjema: React.FC<IProps> = ({
                     <Spacer20 />
                     <Row>
                         <Column xs="12" md="4">
-                            <DetailBold size="small">Periode med feilutbetaling</DetailBold>
+                            <DetailBold>Periode med feilutbetaling</DetailBold>
                             <BodyShort size="small">
                                 {`${formatterDatostring(
                                     feilutbetalingFakta.totalFeilutbetaltPeriode.fom
@@ -74,7 +74,7 @@ const FaktaSkjema: React.FC<IProps> = ({
                             </BodyShort>
                         </Column>
                         <Column xs="12" md="4">
-                            <DetailBold size="small">Feilutbetalt beløp totalt</DetailBold>
+                            <DetailBold>Feilutbetalt beløp totalt</DetailBold>
                             <BodyShort size="small" className={'redText'}>
                                 {`${formatCurrencyNoKr(
                                     feilutbetalingFakta.totaltFeilutbetaltBeløp
@@ -82,7 +82,7 @@ const FaktaSkjema: React.FC<IProps> = ({
                             </BodyShort>
                         </Column>
                         <Column xs="12" md="4">
-                            <DetailBold size="small">Tidligere varslet beløp</DetailBold>
+                            <DetailBold>Tidligere varslet beløp</DetailBold>
                             <BodyShort size="small">
                                 {feilutbetalingFakta.varsletBeløp
                                     ? `${formatCurrencyNoKr(feilutbetalingFakta.varsletBeløp)}`

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Column, Row } from 'nav-frontend-grid';
 
-import { BodyShort, Checkbox, Heading } from '@navikt/ds-react';
+import { BodyShort, Checkbox, Heading, Textarea } from '@navikt/ds-react';
 
 import { Ytelsetype } from '../../../kodeverk';
 import { IFeilutbetalingFakta } from '../../../typer/feilutbetalingtyper';
@@ -14,7 +14,6 @@ import {
     Spacer20,
     Spacer8,
 } from '../../Felleskomponenter/Flytelementer';
-import { FamilieTilbakeTextArea } from '../../Felleskomponenter/Skjemaelementer';
 import FeilutbetalingFaktaPerioder from './FaktaPeriode/FeilutbetalingFaktaPerioder';
 import FaktaRevurdering from './FaktaRevurdering';
 import { useFeilutbetalingFakta } from './FeilutbetalingFaktaContext';
@@ -130,10 +129,10 @@ const FaktaSkjema: React.FC<IProps> = ({
             <Spacer20 />
             <Row>
                 <Column sm="12" md="6">
-                    <FamilieTilbakeTextArea
+                    <Textarea
                         name={'begrunnelse'}
                         label={'Forklar årsaken(e) til feilutbetalingen'}
-                        erLesevisning={erLesevisning}
+                        readOnly={erLesevisning}
                         value={skjemaData.begrunnelse ? skjemaData.begrunnelse : ''}
                         onChange={event => onChangeBegrunnelse(event)}
                         maxLength={3000}

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components';
 import { Column, Row } from 'nav-frontend-grid';
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
-import { BodyLong, Heading, Link, Radio, ReadMore } from '@navikt/ds-react';
+import { BodyLong, Heading, Link, Radio, ReadMore, Textarea } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
@@ -19,7 +19,7 @@ import { IBehandling } from '../../../../typer/behandling';
 import { datoformatNorsk } from '../../../../utils';
 import { FTButton, Navigering, Spacer20, Spacer8 } from '../../../Felleskomponenter/Flytelementer';
 import PeriodeOppsummering from '../../../Felleskomponenter/Periodeinformasjon/PeriodeOppsummering';
-import { FamilieTilbakeTextArea, FTDatovelger } from '../../../Felleskomponenter/Skjemaelementer';
+import { FTDatovelger } from '../../../Felleskomponenter/Skjemaelementer';
 import PeriodeController from '../../../Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
@@ -153,13 +153,13 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
             <Spacer20 />
             <Row>
                 <Column md="8">
-                    <FamilieTilbakeTextArea
+                    <Textarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
                         id={'begrunnelse'}
                         name="begrunnelse"
                         label={'Vurdering'}
                         maxLength={3000}
-                        erLesevisning={erLesevisning}
+                        readOnly={erLesevisning}
                         value={skjema.felter.begrunnelse.verdi}
                         onChange={event =>
                             skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Journalpostvisning.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Journalpostvisning.tsx
@@ -60,7 +60,7 @@ const JournalpostVisning: React.FC<IProps> = ({ journalpost }) => {
                         dokument={dok}
                     />
                 ))}
-                <Detail size="small">
+                <Detail>
                     {`${datoRegistrertSendt ? formatterDatoOgTid(datoRegistrertSendt) : '-'} | `}
                     {typer[journalpost.journalposttype]}
                 </Detail>

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
@@ -117,7 +117,7 @@ const HistorikkInnslag: React.FC<IProps> = ({ innslag }) => {
             </Tidslinje>
             <Innhold>
                 <Label>{lagTittel()}</Label>
-                <Detail size="small">
+                <Detail>
                     {`${formatterDatoOgTidstring(innslag.opprettetTid)} | `}
                     {innslag.aktør === Aktør.VEDTAKSLØSNING
                         ? applikasjoner[innslag.applikasjon]

--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { BodyShort, Heading } from '@navikt/ds-react';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { BodyShort, Heading, Select, Textarea } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { DokumentMal, dokumentMaler } from '../../../../kodeverk';
@@ -9,7 +8,7 @@ import { IBehandling } from '../../../../typer/behandling';
 import { IFagsak, målform } from '../../../../typer/fagsak';
 import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
 import BrevmottakerListe from '../../../Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe';
-import { FamilieTilbakeTextArea, LabelMedSpråk } from '../../../Felleskomponenter/Skjemaelementer';
+import { LabelMedSpråk } from '../../../Felleskomponenter/Skjemaelementer';
 import ForhåndsvisBrev from './ForhåndsvisBrev/ForhåndsvisBrev';
 import { useSendMelding } from './SendMeldingContext';
 
@@ -59,14 +58,13 @@ const SendMelding: React.FC<IProps> = ({ fagsak, behandling }) => {
                 </div>
             )}
             <Spacer20 />
-            <FamilieSelect
+            <Select
                 {...skjema.felter.maltype.hentNavInputProps(skjema.visFeilmeldinger)}
                 id="dokumentMal"
                 label={'Mal'}
-                erLesevisning={erLesevisning}
+                readOnly={erLesevisning}
                 value={skjema.felter.maltype.verdi}
                 onChange={event => onChangeMal(event)}
-                lesevisningVerdi={'Velg brev'}
             >
                 <option disabled={true} value={''}>
                     Velg brev
@@ -76,11 +74,11 @@ const SendMelding: React.FC<IProps> = ({ fagsak, behandling }) => {
                         {dokumentMaler[mal]}
                     </option>
                 ))}
-            </FamilieSelect>
+            </Select>
             {!!skjema.felter.maltype.verdi && (
                 <>
                     <Spacer20 />
-                    <FamilieTilbakeTextArea
+                    <Textarea
                         {...skjema.felter.fritekst.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={
                             <LabelMedSpråk
@@ -89,7 +87,7 @@ const SendMelding: React.FC<IProps> = ({ fagsak, behandling }) => {
                             />
                         }
                         aria-label={tekstfeltLabel(skjema.felter.maltype.verdi)}
-                        erLesevisning={erLesevisning}
+                        readOnly={erLesevisning}
                         value={skjema.felter.fritekst.verdi}
                         onChange={event =>
                             skjema.felter.fritekst.validerOgSettFelt(event.target.value)

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -2,16 +2,13 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Alert, Link, Radio } from '@navikt/ds-react';
+import { Alert, Link, Radio, Textarea } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { behandlingssteg } from '../../../../typer/behandling';
 import ArrowBox from '../../../Felleskomponenter/ArrowBox/ArrowBox';
 import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
-import {
-    FamilieTilbakeTextArea,
-    HorisontalFamilieRadioGruppe,
-} from '../../../Felleskomponenter/Skjemaelementer';
+import { HorisontalFamilieRadioGruppe } from '../../../Felleskomponenter/Skjemaelementer';
 import Steginformasjon from '../../../Felleskomponenter/Steginformasjon/StegInformasjon';
 import { finnSideForSteg, ISide } from '../../../Felleskomponenter/Venstremeny/sider';
 import { useTotrinnskontroll } from './TotrinnskontrollContext';
@@ -121,10 +118,10 @@ const Totrinnskontroll: React.FC = () => {
                                     {vurdertIkkeGodkjent && (
                                         <>
                                             <ArrowBox alignOffset={erLesevisning ? 5 : 125}>
-                                                <FamilieTilbakeTextArea
+                                                <Textarea
                                                     name={`ikkeGodkjentBegrunnelse_${totrinnSteg.index}`}
                                                     label="Begrunnelse"
-                                                    erLesevisning={erLesevisning}
+                                                    readOnly={erLesevisning}
                                                     value={totrinnSteg.begrunnelse || ''}
                                                     maxLength={2000}
                                                     onChange={event =>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { ErrorMessage, Modal } from '@navikt/ds-react';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { ErrorMessage, Modal, Select } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/BehandlingContext';
@@ -65,13 +64,11 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ ytelse, behandling, onListEle
                     }}
                 >
                     <Modal.Body>
-                        <FamilieSelect
+                        <Select
                             {...skjema.felter.enhet.hentNavInputProps(skjema.visFeilmeldinger)}
-                            erLesevisning={false}
+                            readOnly={false}
                             name="enhet"
                             label={'Velg ny enhet'}
-                            value={skjema.felter.enhet.verdi}
-                            onChange={e => skjema.felter.enhet.validerOgSettFelt(e.target.value)}
                         >
                             <option value={''} disabled={true}>
                                 Velg ny enhet
@@ -81,7 +78,7 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ ytelse, behandling, onListEle
                                     {enhet.enhetNavn}
                                 </option>
                             ))}
-                        </FamilieSelect>
+                        </Select>
                         <Spacer8 />
                         <FamilieTilbakeTextArea
                             {...skjema.felter.begrunnelse.hentNavInputProps(

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { ErrorMessage, Modal, Select } from '@navikt/ds-react';
+import { ErrorMessage, Modal, Select, Textarea } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/BehandlingContext';
@@ -13,7 +13,6 @@ import {
     FTButton,
     Spacer8,
 } from '../../../../Felleskomponenter/Flytelementer';
-import { FamilieTilbakeTextArea } from '../../../../Felleskomponenter/Skjemaelementer';
 import { useEndreBehandlendeEnhet } from './EndreBehandlendeEnhetContext';
 
 interface IProps {
@@ -80,16 +79,12 @@ const EndreBehandlendeEnhet: React.FC<IProps> = ({ ytelse, behandling, onListEle
                             ))}
                         </Select>
                         <Spacer8 />
-                        <FamilieTilbakeTextArea
+                        <Textarea
                             {...skjema.felter.begrunnelse.hentNavInputProps(
                                 skjema.visFeilmeldinger
                             )}
                             label={'Begrunnelse'}
-                            erLesevisning={false}
-                            value={skjema.felter.begrunnelse.verdi}
-                            onChange={e =>
-                                skjema.felter.begrunnelse.validerOgSettFelt(e.target.value)
-                            }
+                            readOnly={false}
                             maxLength={400}
                         />
                         {feilmelding && (

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev.tsx
@@ -39,7 +39,7 @@ const ForhåndsvisHenleggelsesBrev: React.FC<IProps> = ({ behandling, skjema, ka
 
     return kanForhåndsvise ? (
         <StyledContainer>
-            <Detail size="small">Informer søker: </Detail>
+            <Detail>Informer søker: </Detail>
             <Link
                 href="#"
                 onMouseDown={e => e.preventDefault()}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.tsx
@@ -7,11 +7,8 @@ import {
 } from '../../../../../../typer/behandling';
 import { IFagsak, målform } from '../../../../../../typer/fagsak';
 import { FTButton, Spacer20 } from '../../../../../Felleskomponenter/Flytelementer';
-import { Modal, Select } from '@navikt/ds-react';
-import {
-    FamilieTilbakeTextArea,
-    LabelMedSpråk,
-} from '../../../../../Felleskomponenter/Skjemaelementer';
+import { Modal, Select, Textarea } from '@navikt/ds-react';
+import { LabelMedSpråk } from '../../../../../Felleskomponenter/Skjemaelementer';
 import ForhåndsvisHenleggelsesBrev from '../ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev';
 import { useHenleggBehandlingSkjema } from './HenleggBehandlingModalContext';
 
@@ -76,7 +73,7 @@ const HenleggBehandlingModal: React.FC<IProps> = ({
                         {visFritekst && (
                             <>
                                 <Spacer20 />
-                                <FamilieTilbakeTextArea
+                                <Textarea
                                     {...skjema.felter.fritekst.hentNavInputProps(
                                         skjema.visFeilmeldinger
                                     )}
@@ -91,13 +88,13 @@ const HenleggBehandlingModal: React.FC<IProps> = ({
                                     onChange={event =>
                                         skjema.felter.fritekst.validerOgSettFelt(event.target.value)
                                     }
-                                    erLesevisning={false}
+                                    readOnly={false}
                                     maxLength={1500}
                                 />
                             </>
                         )}
                         <Spacer20 />
-                        <FamilieTilbakeTextArea
+                        <Textarea
                             {...skjema.felter.begrunnelse.hentNavInputProps(
                                 skjema.visFeilmeldinger
                             )}
@@ -106,7 +103,7 @@ const HenleggBehandlingModal: React.FC<IProps> = ({
                             onChange={event =>
                                 skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
                             }
-                            erLesevisning={false}
+                            readOnly={false}
                             maxLength={200}
                         />
                     </Modal.Body>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { FamilieSelect } from '@navikt/familie-form-elements';
-
 import {
     Behandlingresultat,
     behandlingsresultater,
@@ -9,7 +7,7 @@ import {
 } from '../../../../../../typer/behandling';
 import { IFagsak, målform } from '../../../../../../typer/fagsak';
 import { FTButton, Spacer20 } from '../../../../../Felleskomponenter/Flytelementer';
-import { Modal } from '@navikt/ds-react';
+import { Modal, Select } from '@navikt/ds-react';
 import {
     FamilieTilbakeTextArea,
     LabelMedSpråk,
@@ -61,7 +59,7 @@ const HenleggBehandlingModal: React.FC<IProps> = ({
                     }}
                 >
                     <Modal.Body>
-                        <FamilieSelect
+                        <Select
                             {...skjema.felter.årsakkode.hentNavInputProps(skjema.visFeilmeldinger)}
                             label={`Velg årsak`}
                             onChange={e => onChangeÅrsakskode(e)}
@@ -74,7 +72,7 @@ const HenleggBehandlingModal: React.FC<IProps> = ({
                                     {behandlingsresultater[årsak]}
                                 </option>
                             ))}
-                        </FamilieSelect>
+                        </Select>
                         {visFritekst && (
                             <>
                                 <Spacer20 />

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
-import { ErrorMessage, Modal } from '@navikt/ds-react';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { ErrorMessage, Modal, Select } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useBehandling } from '../../../../../context/BehandlingContext';
@@ -86,12 +85,9 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
                             }
                         />
                         <Spacer20 />
-                        <FamilieSelect
-                            {...skjema.felter.årsak.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
+                        <Select
+                            {...skjema.felter.årsak.hentNavInputProps(skjema.visFeilmeldinger)}
                             label={'Årsak'}
-                            value={skjema.felter.årsak.verdi}
-                            onChange={event => skjema.felter.årsak.onChange(event)}
-                            required={true}
                         >
                             <option value="" disabled>
                                 Velg årsak
@@ -101,7 +97,7 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
                                     {venteårsaker[årsak]}
                                 </option>
                             ))}
-                        </FamilieSelect>
+                        </Select>
                         {feilmelding && feilmelding !== '' && (
                             <>
                                 <Spacer8 />

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -4,13 +4,14 @@ import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 
-import { BodyLong, ErrorMessage, Heading, Loader, Textarea } from '@navikt/ds-react';
+import { BodyLong, ErrorMessage, Heading, Loader } from '@navikt/ds-react';
 import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
 
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Vergetype, vergeTyper, vergetyper } from '../../../kodeverk/verge';
 import { hentFrontendFeilmelding } from '../../../utils';
 import { FTButton, Navigering, Spacer20, Spacer8 } from '../../Felleskomponenter/Flytelementer';
+import { FamilieTilbakeTextArea } from '../../Felleskomponenter/Skjemaelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
 import { useVerge } from './VergeContext';
 
@@ -145,13 +146,13 @@ const VergeContainer: React.FC = () => {
                     <Spacer20 />
                     <Row>
                         <Column md="12" lg="6">
-                            <Textarea
+                            <FamilieTilbakeTextArea
                                 {...skjema.felter.begrunnelse.hentNavInputProps(
                                     skjema.visFeilmeldinger
                                 )}
                                 label={'Begrunn endringene'}
                                 value={skjema.felter.begrunnelse.verdi}
-                                readOnly={erLesevisning}
+                                erLesevisning={erLesevisning}
                                 onChange={event =>
                                     skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
                                 }

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -4,14 +4,13 @@ import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 
-import { BodyLong, ErrorMessage, Heading, Loader } from '@navikt/ds-react';
+import { BodyLong, ErrorMessage, Heading, Loader, Textarea } from '@navikt/ds-react';
 import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
 
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Vergetype, vergeTyper, vergetyper } from '../../../kodeverk/verge';
 import { hentFrontendFeilmelding } from '../../../utils';
 import { FTButton, Navigering, Spacer20, Spacer8 } from '../../Felleskomponenter/Flytelementer';
-import { FamilieTilbakeTextArea } from '../../Felleskomponenter/Skjemaelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
 import { useVerge } from './VergeContext';
 
@@ -146,13 +145,13 @@ const VergeContainer: React.FC = () => {
                     <Spacer20 />
                     <Row>
                         <Column md="12" lg="6">
-                            <FamilieTilbakeTextArea
+                            <Textarea
                                 {...skjema.felter.begrunnelse.hentNavInputProps(
                                     skjema.visFeilmeldinger
                                 )}
                                 label={'Begrunn endringene'}
                                 value={skjema.felter.begrunnelse.verdi}
-                                erLesevisning={erLesevisning}
+                                readOnly={erLesevisning}
                                 onChange={event =>
                                     skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
                                 }

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/SærligeGrunnerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/SærligeGrunnerSkjema.tsx
@@ -4,14 +4,13 @@ import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 
-import { CheckboxGroup } from '@navikt/ds-react';
+import { CheckboxGroup, Textarea } from '@navikt/ds-react';
 import { ASpacing2 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieCheckbox } from '@navikt/familie-form-elements';
 import { type ISkjema } from '@navikt/familie-skjema';
 
 import { SærligeGrunner, særligegrunner, særligeGrunnerTyper } from '../../../../../kodeverk';
 import { DetailBold, Spacer20 } from '../../../../Felleskomponenter/Flytelementer';
-import { FamilieTilbakeTextArea } from '../../../../Felleskomponenter/Skjemaelementer';
 import { VilkårsvurderingSkjemaDefinisjon } from '../VilkårsvurderingPeriodeSkjemaContext';
 import ReduksjonAvBeløpSkjema from './ReduksjonAvBeløpSkjema';
 
@@ -44,14 +43,14 @@ const SærligeGrunnerSkjema: React.FC<IProps> = ({ skjema, erLesevisning }) => {
     return (
         <div>
             <DetailBold spacing>Særlige grunner 4. ledd</DetailBold>
-            <FamilieTilbakeTextArea
+            <Textarea
                 {...skjema.felter.særligeGrunnerBegrunnelse.hentNavInputProps(
                     skjema.visFeilmeldinger
                 )}
                 name="sarligGrunnerBegrunnelse"
                 label={'Vurder særlige grunner du har vektlagt for resultatet'}
                 maxLength={3000}
-                erLesevisning={erLesevisning}
+                readOnly={erLesevisning}
                 value={skjema.felter.særligeGrunnerBegrunnelse.verdi}
                 onChange={event =>
                     skjema.felter.særligeGrunnerBegrunnelse.validerOgSettFelt(event.target.value)
@@ -82,7 +81,7 @@ const SærligeGrunnerSkjema: React.FC<IProps> = ({ skjema, erLesevisning }) => {
                 <Row>
                     <Column md="1" />
                     <Column md="10">
-                        <FamilieTilbakeTextArea
+                        <Textarea
                             {...skjema.felter.særligeGrunnerAnnetBegrunnelse.hentNavInputProps(
                                 skjema.visFeilmeldinger
                             )}
@@ -90,7 +89,7 @@ const SærligeGrunnerSkjema: React.FC<IProps> = ({ skjema, erLesevisning }) => {
                             name="annetBegrunnelse"
                             aria-label="Begrunnelse: Annet"
                             maxLength={3000}
-                            erLesevisning={erLesevisning}
+                            readOnly={erLesevisning}
                             value={skjema.felter.særligeGrunnerAnnetBegrunnelse.verdi}
                             onChange={event =>
                                 skjema.felter.særligeGrunnerAnnetBegrunnelse.validerOgSettFelt(

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -270,9 +270,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                                 <FamilieSelect
                                     name="perioderForKopi"
                                     onChange={event => onKopierPeriode(event)}
-                                    label={
-                                        <Detail size="small">Kopier vilkårsvurdering fra</Detail>
-                                    }
+                                    label={<Detail>Kopier vilkårsvurdering fra</Detail>}
                                     erLesevisning={erLesevisning}
                                     size="small"
                                 >

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -4,9 +4,9 @@ import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 
-import { BodyShort, Detail, Heading, HelpText, Radio, Textarea } from '@navikt/ds-react';
+import { BodyShort, Detail, Heading, HelpText, Radio, Select, Textarea } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
-import { FamilieRadioGruppe, FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
 import {
@@ -267,11 +267,11 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                     <>
                         <Row>
                             <Column md="3">
-                                <FamilieSelect
+                                <Select
                                     name="perioderForKopi"
                                     onChange={event => onKopierPeriode(event)}
                                     label={<Detail>Kopier vilkårsvurdering fra</Detail>}
-                                    erLesevisning={erLesevisning}
+                                    readOnly={erLesevisning}
                                     size="small"
                                 >
                                     <option value="-">-</option>
@@ -285,7 +285,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                                             )} - ${formatterDatostring(per.periode.tom)}`}
                                         </option>
                                     ))}
-                                </FamilieSelect>
+                                </Select>
                             </Column>
                         </Row>
                         <Spacer20 />

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -4,7 +4,7 @@ import { styled } from 'styled-components';
 
 import { Column, Row } from 'nav-frontend-grid';
 
-import { BodyShort, Detail, Heading, HelpText, Radio } from '@navikt/ds-react';
+import { BodyShort, Detail, Heading, HelpText, Radio, Textarea } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { FamilieRadioGruppe, FamilieSelect } from '@navikt/familie-form-elements';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
@@ -25,7 +25,6 @@ import { IFagsak } from '../../../../typer/fagsak';
 import { formatterDatostring, isEmpty } from '../../../../utils';
 import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
 import PeriodeOppsummering from '../../../Felleskomponenter/Periodeinformasjon/PeriodeOppsummering';
-import { FamilieTilbakeTextArea } from '../../../Felleskomponenter/Skjemaelementer';
 import PeriodeController from '../../../Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController';
 import { useFeilutbetalingVilkårsvurdering } from '../FeilutbetalingVilkårsvurderingContext';
 import { VilkårsvurderingPeriodeSkjemaData } from '../typer/feilutbetalingVilkårsvurdering';
@@ -321,7 +320,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                                 <Heading size="small" level="2" spacing>
                                     Vilkårene for tilbakekreving
                                 </Heading>
-                                <FamilieTilbakeTextArea
+                                <Textarea
                                     {...skjema.felter.vilkårsresultatBegrunnelse.hentNavInputProps(
                                         skjema.visFeilmeldinger
                                     )}
@@ -331,7 +330,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                                         'Hvilke hendelser har ført til feilutbetalingen og vurder valg av hjemmel'
                                     }
                                     maxLength={3000}
-                                    erLesevisning={erLesevisning}
+                                    readOnly={erLesevisning}
                                     value={skjema.felter.vilkårsresultatBegrunnelse.verdi}
                                     onChange={event =>
                                         skjema.felter.vilkårsresultatBegrunnelse.validerOgSettFelt(
@@ -394,7 +393,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                                             Aktsomhet
                                         </Heading>
                                     )}
-                                    <FamilieTilbakeTextArea
+                                    <Textarea
                                         {...skjema.felter.aktsomhetBegrunnelse.hentNavInputProps(
                                             skjema.visFeilmeldinger
                                         )}
@@ -411,7 +410,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                                                 ? 'Begrunn hvorfor beløpet er i behold / er ikke i behold'
                                                 : ''
                                         }
-                                        erLesevisning={erLesevisning}
+                                        readOnly={erLesevisning}
                                         value={
                                             skjema.felter.aktsomhetBegrunnelse
                                                 ? skjema.felter.aktsomhetBegrunnelse.verdi

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { BodyLong, Heading, Modal } from '@navikt/ds-react';
+import { BodyLong, Heading, Modal, Select } from '@navikt/ds-react';
 import { ATextDanger, ASpacing8 } from '@navikt/ds-tokens/dist/tokens';
-import { FamilieSelect } from '@navikt/familie-form-elements';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import {
@@ -76,6 +75,7 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
             header={{
                 heading: 'Behandling satt på vent',
                 size: 'medium',
+                closeButton: false,
             }}
             portal={true}
             width="small"
@@ -113,15 +113,10 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
                         erLesesvisning={erVenterPåKravgrunnlag}
                     />
                     <Spacer20 />
-                    <FamilieSelect
+                    <Select
                         {...skjema.felter.årsak.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={'Årsak'}
-                        value={skjema.felter.årsak.verdi}
-                        onChange={event => skjema.felter.årsak.onChange(event)}
-                        lesevisningVerdi={
-                            skjema.felter.årsak.verdi ? venteårsaker[skjema.felter.årsak.verdi] : ''
-                        }
-                        erLesevisning={erAutomatiskVent}
+                        readOnly={erAutomatiskVent}
                     >
                         <option value="" disabled>
                             Velg årsak
@@ -131,7 +126,7 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
                                 {venteårsaker[årsak]}
                             </option>
                         ))}
-                    </FamilieSelect>
+                    </Select>
                     {feilmelding && feilmelding !== '' && (
                         <FeilContainer>
                             <BodyLong size="small">{feilmelding}</BodyLong>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,14 +1743,13 @@
     classnames "^2.3.2"
     react-select "^5.7.0"
 
-"@navikt/familie-form-elements@^13.0.0":
-  version "13.0.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-form-elements/13.0.0/c3ec85621cb87c35cece49ce4a0d59d17ab0ad7c#c3ec85621cb87c35cece49ce4a0d59d17ab0ad7c"
-  integrity sha512-C7Co3jFGad7TdS7P2QM1l58rb4T82lE31Gx6gOC7MXRaBKTDnd9MJCf8AXazUyjmxUASmWepdSoGo/bgZjtJdA==
+"@navikt/familie-form-elements@^14.0.0":
+  version "14.0.0"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-form-elements/14.0.0/2e7b6e26fde5e677096fcf1c523ed25159926bb1#2e7b6e26fde5e677096fcf1c523ed25159926bb1"
+  integrity sha512-P5cMOmDkC2UEshd4P7RmMwfzGq9Lj1z5hRyuHMOtw4KDXaiaNpY6x6CKuP9dxu/MgsOPbuy5vxMNCRBpMHALyA==
   dependencies:
-    "@types/classnames" "^2.3.1"
-    classnames "^2.3.2"
-    react-select "^5.7.0"
+    classnames "^2.5.1"
+    react-select "^5.8.0"
 
 "@navikt/familie-http@^6.0.2":
   version "6.0.2"
@@ -3807,6 +3806,11 @@ classnames@*, classnames@^2.3.0, classnames@^2.3.1, classnames@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 clean-css@^5.2.2:
   version "5.3.2"
@@ -8209,6 +8213,21 @@ react-select@^5.7.0:
   version "5.7.4"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.7.4.tgz#d8cad96e7bc9d6c8e2709bdda8f4363c5dd7ea7d"
   integrity sha512-NhuE56X+p9QDFh4BgeygHFIvJJszO1i1KSkg/JPcIJrbovyRtI+GuOEa4XzFCEpZRAEoEI8u/cAHK+jG/PgUzQ==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@floating-ui/dom" "^1.0.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^6.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+    use-isomorphic-layout-effect "^1.1.2"
+
+react-select@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.8.0.tgz#bd5c467a4df223f079dd720be9498076a3f085b5"
+  integrity sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,6 +1743,15 @@
     classnames "^2.3.2"
     react-select "^5.7.0"
 
+"@navikt/familie-form-elements@^13.0.0":
+  version "13.0.0"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-form-elements/13.0.0/c3ec85621cb87c35cece49ce4a0d59d17ab0ad7c#c3ec85621cb87c35cece49ce4a0d59d17ab0ad7c"
+  integrity sha512-C7Co3jFGad7TdS7P2QM1l58rb4T82lE31Gx6gOC7MXRaBKTDnd9MJCf8AXazUyjmxUASmWepdSoGo/bgZjtJdA==
+  dependencies:
+    "@types/classnames" "^2.3.1"
+    classnames "^2.3.2"
+    react-select "^5.7.0"
+
 "@navikt/familie-http@^6.0.2":
   version "6.0.2"
   resolved "https://npm.pkg.github.com/download/@navikt/familie-http/6.0.2/98c92e337b3638a76e43b76ad8b2cd74b62855f9#98c92e337b3638a76e43b76ad8b2cd74b62855f9"


### PR DESCRIPTION
**Aksel v5 - byttet diverse form elements**

* Fjern @deprecated/unødvendig `size=“small”` fra `Detail` komponent
* Bytt diverse `FamilieSelect` (`@navikt/familie-form-elements`) med `Select` (`@navikt/ds-react`)
* Bytt diverse `FamilieTilbakeTextArea` -> `FamilieTextarea` (`@navikt/familie-form-elements`) med `Textarea` (`@navikt/ds-react`)

_Komponentene som er byttet var de som var enklest å teste - noen gjenstår - men etter merge av denne er betraktelig færre igjen._