### PR TITLE
Chore: Gammel datovelger til DatePicker fra Aksel

### DIFF
--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
@@ -43,6 +43,8 @@ describe('Tester: ForeldelseContainer', () => {
             },
             foreldelsesvurderingstype: undefined,
             begrunnelse: undefined,
+            foreldelsesfrist: undefined,
+            oppdagelsesdato: undefined,
         },
         {
             feilutbetaltBeløp: 1333,
@@ -52,6 +54,8 @@ describe('Tester: ForeldelseContainer', () => {
             },
             foreldelsesvurderingstype: undefined,
             begrunnelse: undefined,
+            foreldelsesfrist: undefined,
+            oppdagelsesdato: undefined,
         },
     ];
 
@@ -300,7 +304,7 @@ describe('Tester: ForeldelseContainer', () => {
         const behandling = mock<IBehandling>();
         const fagsak = mock<IFagsak>();
 
-        const { getByText, getByRole, queryByText, queryByRole } = render(
+        const { getByText, getByRole, queryByText, queryByRole, getByLabelText } = render(
             <FeilutbetalingForeldelseProvider behandling={behandling} fagsak={fagsak}>
                 <ForeldelseContainer behandling={behandling} />
             </FeilutbetalingForeldelseProvider>
@@ -340,7 +344,7 @@ describe('Tester: ForeldelseContainer', () => {
 
         expect(getByText('Begrunnelse 1')).toBeTruthy();
         expect(getByText('Perioden er foreldet')).toBeTruthy();
-        expect(getByText('01.01.2021')).toBeTruthy();
+        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
 
         await user.click(
             getByRole('button', {
@@ -354,8 +358,10 @@ describe('Tester: ForeldelseContainer', () => {
         expect(
             getByText('Perioden er ikke foreldet, regel om tilleggsfrist (10 år) benyttes')
         ).toBeTruthy();
-        expect(getByText('01.01.2021')).toBeTruthy();
-        expect(getByText('24.12.2020')).toBeTruthy();
+        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
+        expect(getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
+            '24.12.2020'
+        );
 
         expect(
             queryByRole('button', {

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.test.tsx
@@ -105,7 +105,8 @@ describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
                 name: 'Bekreft',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(1);
 
         await user.type(getByLabelText('Vurdering'), 'begrunnelse');
         await user.type(
@@ -113,7 +114,7 @@ describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
                 selector: 'input',
                 exact: false,
             }),
-            '2020-09-14'
+            '14.09.2020'
         );
 
         await user.click(
@@ -121,6 +122,7 @@ describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
                 name: 'Bekreft',
             })
         );
+        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
@@ -155,7 +157,8 @@ describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
                 name: 'Bekreft',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(3);
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(2);
 
         await user.type(getByLabelText('Vurdering'), 'begrunnelse');
         await user.type(
@@ -163,9 +166,9 @@ describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
                 selector: 'input',
                 exact: false,
             }),
-            '2020-09-14'
+            '14.09.2020'
         );
-        await user.type(getByLabelText('Dato for når feilutbetaling ble oppdaget'), '2020-06-14');
+        await user.type(getByLabelText('Dato for når feilutbetaling ble oppdaget'), '14.06.2020');
 
         await user.click(
             getByRole('button', {
@@ -173,6 +176,7 @@ describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
             })
         );
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
     });
 
     test('- åpner vurdert periode med tilleggsfrist ', () => {

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -24,6 +24,8 @@ import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext'
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
 import { useForeldelsePeriodeSkjema } from './ForeldelsePeriodeSkjemaContext';
 import SplittPeriode from './SplittPeriode/SplittPeriode';
+import { isoStringTilDate } from '../../../../utils/dato';
+import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
 
 const StyledContainer = styled.div`
     border: 1px solid ${ABorderStrong};
@@ -50,7 +52,9 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
     React.useEffect(() => {
         skjema.felter.begrunnelse.onChange(periode?.begrunnelse || '');
         skjema.felter.foreldelsesvurderingstype.onChange(periode?.foreldelsesvurderingstype || '');
-        skjema.felter.foreldelsesfrist.onChange(periode?.foreldelsesfrist || '');
+        skjema.felter.foreldelsesfrist.onChange(
+            periode?.foreldelsesfrist ? isoStringTilDate(periode.foreldelsesfrist) : undefined
+        );
         skjema.felter.oppdagelsesdato.onChange(periode?.oppdagelsesdato || '');
     }, [periode]);
 
@@ -219,27 +223,12 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                     )}
                     {(erForeldet || erMedTilleggsfrist) && (
                         <>
-                            <FTDatovelger
-                                id="foreldelsesfrist"
+                            <Datovelger
+                                felt={skjema.felter.foreldelsesfrist}
                                 label="Foreldelsesfrist"
-                                description={
-                                    !erMedTilleggsfrist
-                                        ? 'Datoen kommer i vedtaksbrevet'
-                                        : undefined
-                                }
-                                erLesesvisning={erLesevisning}
-                                onChange={(nyDato?: string) => {
-                                    skjema.felter.foreldelsesfrist.validerOgSettFelt(
-                                        nyDato ? nyDato : ''
-                                    );
-                                }}
-                                value={skjema.felter.foreldelsesfrist.verdi}
-                                placeholder={datoformatNorsk.DATO}
-                                feil={
-                                    ugyldigForeldelsesfristValgt
-                                        ? skjema.felter.foreldelsesfrist.feilmelding?.toString()
-                                        : ''
-                                }
+                                description={!erMedTilleggsfrist && 'Datoen kommer i vedtaksbrevet'}
+                                visFeilmeldinger={ugyldigForeldelsesfristValgt}
+                                readOnly={erLesevisning}
                             />
                             <Spacer8 />
                             {!erLesevisning && (

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -15,10 +15,8 @@ import {
     foreldelseVurderingTyper,
 } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
-import { datoformatNorsk } from '../../../../utils';
 import { FTButton, Navigering, Spacer20, Spacer8 } from '../../../Felleskomponenter/Flytelementer';
 import PeriodeOppsummering from '../../../Felleskomponenter/Periodeinformasjon/PeriodeOppsummering';
-import { FTDatovelger } from '../../../Felleskomponenter/Skjemaelementer';
 import PeriodeController from '../../../Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
@@ -55,7 +53,9 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
         skjema.felter.foreldelsesfrist.onChange(
             periode?.foreldelsesfrist ? isoStringTilDate(periode.foreldelsesfrist) : undefined
         );
-        skjema.felter.oppdagelsesdato.onChange(periode?.oppdagelsesdato || '');
+        skjema.felter.oppdagelsesdato.onChange(
+            periode?.oppdagelsesdato ? isoStringTilDate(periode.oppdagelsesdato) : undefined
+        );
     }, [periode]);
 
     const erForeldet =
@@ -197,26 +197,13 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                 <Column md="5">
                     {erMedTilleggsfrist && (
                         <>
-                            <FTDatovelger
-                                id="oppdagelsesDato"
-                                label={'Dato for når feilutbetaling ble oppdaget'}
-                                description={'Datoen kommer i vedtaksbrevet'}
-                                erLesesvisning={erLesevisning}
-                                onChange={(nyDato?: string) => {
-                                    skjema.felter.oppdagelsesdato.validerOgSettFelt(
-                                        nyDato ? nyDato : ''
-                                    );
-                                }}
-                                value={skjema.felter.oppdagelsesdato.verdi}
-                                limitations={{
-                                    maxDate: new Date().toISOString(),
-                                }}
-                                placeholder={datoformatNorsk.DATO}
-                                feil={
-                                    ugyldigOppdagelsesdatoValgt
-                                        ? skjema.felter.oppdagelsesdato.feilmelding?.toString()
-                                        : ''
-                                }
+                            <Datovelger
+                                felt={skjema.felter.oppdagelsesdato}
+                                label="Dato for når feilutbetaling ble oppdaget"
+                                description="Datoen kommer i vedtaksbrevet"
+                                visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
+                                readOnly={erLesevisning}
+                                kanKunVelgeFortid
                             />
                             <Spacer20 />
                         </>

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
@@ -8,8 +8,14 @@ import {
 } from '@navikt/familie-skjema';
 
 import { Foreldelsevurdering } from '../../../../kodeverk';
-import { erFeltetEmpty, validerDatoFelt, validerTekstFeltMaksLengde } from '../../../../utils';
+import {
+    erFeltetEmpty,
+    validerDatoFelt,
+    validerGyldigDato,
+    validerTekstFeltMaksLengde,
+} from '../../../../utils';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
+import { dateTilIsoDatoStringEllerUndefined } from '../../../../utils/dato';
 
 const avhengigheterOppfyltForeldelsesfrist = (avhengigheter?: Avhengigheter) => {
     return (
@@ -36,12 +42,12 @@ const useForeldelsePeriodeSkjema = (
         },
     });
 
-    const foreldelsesfrist = useFelt<string | ''>({
-        verdi: '',
+    const foreldelsesfrist = useFelt<Date | undefined>({
+        verdi: undefined,
         avhengigheter: { foreldelsesvurderingstype },
-        valideringsfunksjon: (felt: FeltState<string | ''>, avhengigheter?: Avhengigheter) => {
+        valideringsfunksjon: (felt: FeltState<Date | undefined>, avhengigheter?: Avhengigheter) => {
             if (!avhengigheterOppfyltForeldelsesfrist(avhengigheter)) return ok(felt);
-            return validerDatoFelt(felt);
+            return validerGyldigDato(felt);
         },
     });
 
@@ -58,7 +64,7 @@ const useForeldelsePeriodeSkjema = (
         {
             begrunnelse: string | '';
             foreldelsesvurderingstype: Foreldelsevurdering | '';
-            foreldelsesfrist: string | '';
+            foreldelsesfrist: Date | undefined;
             oppdagelsesdato: string | '';
         },
         string
@@ -84,7 +90,9 @@ const useForeldelsePeriodeSkjema = (
                 begrunnelse: skjema.felter.begrunnelse.verdi,
                 //@ts-ignore
                 foreldelsesvurderingstype: skjema.felter.foreldelsesvurderingstype.verdi,
-                foreldelsesfrist: skjema.felter.foreldelsesfrist.verdi,
+                foreldelsesfrist: dateTilIsoDatoStringEllerUndefined(
+                    skjema.felter.foreldelsesfrist.verdi
+                ),
                 oppdagelsesdato: skjema.felter.oppdagelsesdato.verdi,
             });
             nullstillSkjema();

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
@@ -83,8 +83,9 @@ const useForeldelsePeriodeSkjema = (
             oppdaterPeriode({
                 ...periode,
                 begrunnelse: skjema.felter.begrunnelse.verdi,
-                //@ts-ignore
-                foreldelsesvurderingstype: skjema.felter.foreldelsesvurderingstype.verdi,
+                foreldelsesvurderingstype: skjema.felter.foreldelsesvurderingstype.verdi
+                    ? skjema.felter.foreldelsesvurderingstype.verdi
+                    : undefined,
                 foreldelsesfrist: dateTilIsoDatoStringEllerUndefined(
                     skjema.felter.foreldelsesfrist.verdi
                 ),

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
@@ -8,12 +8,7 @@ import {
 } from '@navikt/familie-skjema';
 
 import { Foreldelsevurdering } from '../../../../kodeverk';
-import {
-    erFeltetEmpty,
-    validerDatoFelt,
-    validerGyldigDato,
-    validerTekstFeltMaksLengde,
-} from '../../../../utils';
+import { erFeltetEmpty, validerGyldigDato, validerTekstFeltMaksLengde } from '../../../../utils';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
 import { dateTilIsoDatoStringEllerUndefined } from '../../../../utils/dato';
 
@@ -51,12 +46,12 @@ const useForeldelsePeriodeSkjema = (
         },
     });
 
-    const oppdagelsesdato = useFelt<string | ''>({
-        verdi: '',
+    const oppdagelsesdato = useFelt<Date | undefined>({
+        verdi: undefined,
         avhengigheter: { foreldelsesvurderingstype },
-        valideringsfunksjon: (felt: FeltState<string | ''>, avhengigheter?: Avhengigheter) => {
+        valideringsfunksjon: (felt: FeltState<Date | undefined>, avhengigheter?: Avhengigheter) => {
             if (!avhengigheterOppfyltOppdagelsesdato(avhengigheter)) return ok(felt);
-            return validerDatoFelt(felt);
+            return validerGyldigDato(felt);
         },
     });
 
@@ -65,7 +60,7 @@ const useForeldelsePeriodeSkjema = (
             begrunnelse: string | '';
             foreldelsesvurderingstype: Foreldelsevurdering | '';
             foreldelsesfrist: Date | undefined;
-            oppdagelsesdato: string | '';
+            oppdagelsesdato: Date | undefined;
         },
         string
     >({
@@ -93,7 +88,9 @@ const useForeldelsePeriodeSkjema = (
                 foreldelsesfrist: dateTilIsoDatoStringEllerUndefined(
                     skjema.felter.foreldelsesfrist.verdi
                 ),
-                oppdagelsesdato: skjema.felter.oppdagelsesdato.verdi,
+                oppdagelsesdato: dateTilIsoDatoStringEllerUndefined(
+                    skjema.felter.oppdagelsesdato.verdi
+                ),
             });
             nullstillSkjema();
         }

--- a/src/frontend/komponenter/Fagsak/Foreldelse/typer/feilutbetalingForeldelse.ts
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/typer/feilutbetalingForeldelse.ts
@@ -1,9 +1,10 @@
 import { Foreldelsevurdering } from '../../../../kodeverk';
 import { IPeriodeSkjemaData } from '../../../../typer/periodeSkjemaData';
+import { IsoDatoString } from '../../../../utils/dato';
 
 export interface ForeldelsePeriodeSkjemeData extends IPeriodeSkjemaData {
     foreldelsesvurderingstype?: Foreldelsevurdering;
     begrunnelse?: string;
-    foreldelsesfrist?: string;
+    foreldelsesfrist?: IsoDatoString;
     oppdagelsesdato?: string;
 }

--- a/src/frontend/komponenter/Fagsak/Foreldelse/typer/feilutbetalingForeldelse.ts
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/typer/feilutbetalingForeldelse.ts
@@ -6,5 +6,5 @@ export interface ForeldelsePeriodeSkjemeData extends IPeriodeSkjemaData {
     foreldelsesvurderingstype?: Foreldelsevurdering;
     begrunnelse?: string;
     foreldelsesfrist?: IsoDatoString;
-    oppdagelsesdato?: string;
+    oppdagelsesdato?: IsoDatoString;
 }

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/GjennoptaBehandling/GjennoptaBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/GjennoptaBehandling/GjennoptaBehandling.tsx
@@ -16,14 +16,12 @@ const GjennoptaBehandling: React.FC<IProps> = ({ behandling, onListElementClick 
     const [visModal, settVisModal] = React.useState<boolean>(false);
 
     const { hentBehandlingMedBehandlingId } = useBehandling();
-    const { feilmelding, onOkTaAvVent, nullstillSkjema } = usePåVentBehandling(
-        (suksess: boolean) => {
-            settVisModal(false);
-            if (suksess) {
-                hentBehandlingMedBehandlingId(behandling.behandlingId);
-            }
+    const { feilmelding, onOkTaAvVent } = usePåVentBehandling((suksess: boolean) => {
+        settVisModal(false);
+        if (suksess) {
+            hentBehandlingMedBehandlingId(behandling.behandlingId);
         }
-    );
+    });
 
     return (
         <>
@@ -45,7 +43,6 @@ const GjennoptaBehandling: React.FC<IProps> = ({ behandling, onListElementClick 
                     portal={true}
                     width="small"
                     onClose={() => {
-                        nullstillSkjema();
                         settVisModal(false);
                     }}
                 >

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
@@ -5,7 +5,6 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { IBehandling, manuelleVenteÅrsaker, venteårsaker } from '../../../../../typer/behandling';
-import { datoformatNorsk } from '../../../../../utils';
 import {
     BehandlingsMenyButton,
     FTButton,
@@ -13,8 +12,9 @@ import {
     Spacer8,
 } from '../../../../Felleskomponenter/Flytelementer';
 import { usePåVentBehandling } from '../../../../Felleskomponenter/Modal/PåVent/PåVentContext';
-import { maxTidsfrist, minTidsfrist } from '../../../../Felleskomponenter/Modal/PåVent/PåVentModal';
-import { FixedDatovelger } from '../../../../Felleskomponenter/Skjemaelementer/';
+import { addDays, addMonths } from 'date-fns';
+import { dagensDato } from '../../../../../utils/dato';
+import Datovelger from '../../../../Felleskomponenter/Datovelger/Datovelger';
 
 interface IProps {
     behandling: IBehandling;
@@ -66,23 +66,12 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
                     }}
                 >
                     <Modal.Body>
-                        <FixedDatovelger
-                            {...skjema.felter.tidsfrist.hentNavBaseSkjemaProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            id={'frist'}
-                            label={'Frist'}
-                            onChange={(nyVerdi?: string) =>
-                                skjema.felter.tidsfrist.onChange(nyVerdi ? nyVerdi : '')
-                            }
-                            limitations={{ minDate: minTidsfrist(), maxDate: maxTidsfrist() }}
-                            placeholder={datoformatNorsk.DATO}
-                            value={skjema.felter.tidsfrist.verdi}
-                            feil={
-                                ugyldigDatoValgt
-                                    ? skjema.felter.tidsfrist.feilmelding?.toString()
-                                    : ''
-                            }
+                        <Datovelger
+                            felt={skjema.felter.tidsfrist}
+                            label="Frist"
+                            visFeilmeldinger={ugyldigDatoValgt}
+                            minDatoAvgrensning={addDays(dagensDato, 1)}
+                            maksDatoAvgrensning={addMonths(dagensDato, 3)}
                         />
                         <Spacer20 />
                         <Select

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
@@ -25,7 +25,7 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
     const [visModal, settVisModal] = React.useState<boolean>(false);
     const { hentBehandlingMedBehandlingId } = useBehandling();
 
-    const { skjema, onBekreft, nullstillSkjema, feilmelding } = usePåVentBehandling(
+    const { skjema, onBekreft, feilmelding, tilbakestillFelterTilDefault } = usePåVentBehandling(
         (suksess: boolean) => {
             settVisModal(false);
             if (suksess) {
@@ -38,6 +38,11 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
     const ugyldigDatoValgt =
         skjema.visFeilmeldinger &&
         skjema.felter.tidsfrist.valideringsstatus === Valideringsstatus.FEIL;
+
+    const lukkModal = () => {
+        tilbakestillFelterTilDefault();
+        settVisModal(false);
+    };
 
     return (
         <>
@@ -61,9 +66,7 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
                     }}
                     portal={true}
                     width="small"
-                    onClose={() => {
-                        settVisModal(false);
-                    }}
+                    onClose={lukkModal}
                 >
                     <Modal.Body>
                         <Datovelger
@@ -110,10 +113,7 @@ const SettBehandlingPåVent: React.FC<IProps> = ({ behandling, onListElementClic
                         <FTButton
                             variant="tertiary"
                             key={'avbryt'}
-                            onClick={() => {
-                                nullstillSkjema();
-                                settVisModal(false);
-                            }}
+                            onClick={lukkModal}
                             size="small"
                         >
                             Avbryt

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import { addDays, format, startOfDay, subDays } from 'date-fns';
+
+import { DatePicker, useDatepicker } from '@navikt/ds-react';
+import type { Felt } from '@navikt/familie-skjema';
+
+import { dagensDato, Datoformat } from '../../../utils/dato';
+
+interface IProps {
+    felt: Felt<Date | undefined>;
+    label: string;
+    description?: React.ReactNode;
+    visFeilmeldinger: boolean;
+    minDatoAvgrensning?: Date;
+    maksDatoAvgrensning?: Date;
+    kanKunVelgeFortid?: boolean;
+    kanKunVelgeFremtid?: boolean;
+    readOnly?: boolean;
+}
+
+export enum Feilmelding {
+    UGYLDIG_DATO = 'UGYLDIG_DATO',
+    FØR_MIN_DATO = 'FØR_MIN_DATO',
+    ETTER_MAKS_DATO = 'ETTER_MAKS_DATO',
+}
+
+const tidligsteRelevanteDato = startOfDay(new Date(1900, 0));
+
+const senesteRelevanteDato = startOfDay(new Date(2500, 0));
+
+const Datovelger = ({
+    felt,
+    label,
+    visFeilmeldinger,
+    minDatoAvgrensning,
+    maksDatoAvgrensning,
+    description,
+    kanKunVelgeFortid = false,
+    kanKunVelgeFremtid = false,
+    readOnly = false,
+}: IProps) => {
+    const [error, setError] = useState<Feilmelding | undefined>(undefined);
+
+    const hentToDate = () => {
+        if (maksDatoAvgrensning) return maksDatoAvgrensning;
+        if (kanKunVelgeFortid) return dagensDato;
+        return senesteRelevanteDato;
+    };
+
+    const hentFromDate = () => {
+        if (minDatoAvgrensning) return minDatoAvgrensning;
+        if (kanKunVelgeFremtid) return dagensDato;
+        return tidligsteRelevanteDato;
+    };
+
+    const nullstillOgSettFeilmelding = (feilmelding: Feilmelding) => {
+        if (error !== feilmelding) {
+            setError(feilmelding);
+            felt.nullstill();
+        }
+    };
+    const { datepickerProps, inputProps } = useDatepicker({
+        defaultSelected: felt.verdi,
+        onDateChange: (dato?: Date) => {
+            felt.validerOgSettFelt(dato);
+        },
+        fromDate: hentFromDate(),
+        toDate: hentToDate(),
+        onValidate: val => {
+            if (val.isBefore) {
+                nullstillOgSettFeilmelding(Feilmelding.FØR_MIN_DATO);
+            } else if (val.isAfter) {
+                nullstillOgSettFeilmelding(Feilmelding.ETTER_MAKS_DATO);
+            } else if (!val.isValidDate) {
+                nullstillOgSettFeilmelding(Feilmelding.UGYLDIG_DATO);
+            } else {
+                setError(undefined);
+            }
+        },
+    });
+
+    const feilmeldingForDatoFørMinDato = () => {
+        if (kanKunVelgeFremtid) {
+            return 'Du kan ikke sette en dato som er tilbake i tid';
+        }
+        const førsteUgyldigeDato = minDatoAvgrensning
+            ? format(subDays(minDatoAvgrensning, 1), Datoformat.DATO)
+            : '';
+        return `Du må velge en dato som er senere enn ${førsteUgyldigeDato}`;
+    };
+    const feilmeldingForDatoEtterMaksDato = () => {
+        if (kanKunVelgeFortid) {
+            return 'Du kan ikke sette en dato som er frem i tid';
+        }
+        const førsteUgyldigeDato = maksDatoAvgrensning
+            ? format(addDays(maksDatoAvgrensning, 1), Datoformat.DATO)
+            : '';
+        return `Du må velge en dato som er tidligere enn ${førsteUgyldigeDato}`;
+    };
+
+    const feilmeldinger: Record<Feilmelding, string> = {
+        UGYLDIG_DATO: 'Du må velge en gyldig dato',
+        FØR_MIN_DATO: feilmeldingForDatoFørMinDato(),
+        ETTER_MAKS_DATO: feilmeldingForDatoEtterMaksDato(),
+    };
+
+    return (
+        <DatePicker dropdownCaption {...datepickerProps}>
+            <DatePicker.Input
+                {...inputProps}
+                label={label}
+                description={description}
+                placeholder={'DD.MM.ÅÅÅÅ'}
+                readOnly={readOnly}
+                error={
+                    error && visFeilmeldinger
+                        ? feilmeldinger[error]
+                        : felt.hentNavBaseSkjemaProps(visFeilmeldinger).error
+                }
+            />
+        </DatePicker>
+    );
+};
+
+export default Datovelger;

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentContext.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentContext.tsx
@@ -47,11 +47,19 @@ export const usePåVentBehandling = (
 
     if (ventegrunn !== forrigeVentegrunn) {
         settForrigeVentegrunn(ventegrunn);
-        nullstillSkjema();
         skjema.felter.tidsfrist.validerOgSettFelt(
             ventegrunn?.tidsfrist ? isoStringTilDate(ventegrunn.tidsfrist) : undefined
         );
     }
+
+    const tilbakestillFelterTilDefault = () => {
+        console.log('nullstiller');
+        console.log(ventegrunn);
+        nullstillSkjema();
+        skjema.felter.tidsfrist.validerOgSettFelt(
+            ventegrunn?.tidsfrist ? isoStringTilDate(ventegrunn.tidsfrist) : undefined
+        );
+    };
 
     const onBekreft = (behandlingId: string) => {
         if (kanSendeSkjema() && skjema.felter.årsak.verdi && skjema.felter.tidsfrist.verdi) {
@@ -108,5 +116,6 @@ export const usePåVentBehandling = (
         nullstillSkjema,
         onBekreft,
         onOkTaAvVent,
+        tilbakestillFelterTilDefault,
     };
 };

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentContext.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentContext.tsx
@@ -53,8 +53,6 @@ export const usePåVentBehandling = (
     }
 
     const tilbakestillFelterTilDefault = () => {
-        console.log('nullstiller');
-        console.log(ventegrunn);
         nullstillSkjema();
         skjema.felter.tidsfrist.validerOgSettFelt(
             ventegrunn?.tidsfrist ? isoStringTilDate(ventegrunn.tidsfrist) : undefined

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
@@ -13,10 +13,12 @@ import {
     manuelleVenteÅrsaker,
     venteårsaker,
 } from '../../../../typer/behandling';
-import { dateBeforeToday, datoformatNorsk, finnDateRelativtTilNå } from '../../../../utils';
+import { dateBeforeToday } from '../../../../utils';
 import { FTButton, Spacer20 } from '../../Flytelementer';
-import { FixedDatovelger } from '../../Skjemaelementer';
 import { usePåVentBehandling } from './PåVentContext';
+import Datovelger from '../../Datovelger/Datovelger';
+import { addDays, addMonths } from 'date-fns';
+import { dagensDato } from '../../../../utils/dato';
 
 const FeilContainer = styled.div`
     margin-top: ${ASpacing8};
@@ -25,17 +27,6 @@ const FeilContainer = styled.div`
         color: ${ATextDanger};
     }
 `;
-
-export const minTidsfrist = (): string => {
-    const minDato = new Date();
-    minDato.setDate(minDato.getDate() + 1);
-    return minDato.toISOString();
-};
-
-export const maxTidsfrist = (): string => {
-    const dato = finnDateRelativtTilNå({ months: 3 });
-    return dato.toISOString();
-};
 
 interface IProps {
     behandling: IBehandling;
@@ -98,19 +89,13 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
                             </BodyLong>
                         </>
                     )}
-                    <FixedDatovelger
-                        id={'frist'}
-                        label={'Frist'}
-                        onChange={(nyVerdi?: string) =>
-                            skjema.felter.tidsfrist.onChange(nyVerdi ? nyVerdi : '')
-                        }
-                        limitations={{ minDate: minTidsfrist(), maxDate: maxTidsfrist() }}
-                        placeholder={datoformatNorsk.DATO}
-                        value={skjema.felter.tidsfrist.verdi}
-                        feil={
-                            ugyldigDatoValgt ? skjema.felter.tidsfrist.feilmelding?.toString() : ''
-                        }
-                        erLesesvisning={erVenterPåKravgrunnlag}
+                    <Datovelger
+                        felt={skjema.felter.tidsfrist}
+                        label="Frist"
+                        visFeilmeldinger={ugyldigDatoValgt}
+                        readOnly={erVenterPåKravgrunnlag}
+                        minDatoAvgrensning={addDays(dagensDato, 1)}
+                        maksDatoAvgrensning={addMonths(dagensDato, 3)}
                     />
                     <Spacer20 />
                     <Select

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
@@ -35,7 +35,7 @@ interface IProps {
 }
 
 const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => {
-    const { skjema, onBekreft, nullstillSkjema, feilmelding } = usePåVentBehandling(
+    const { skjema, onBekreft, tilbakestillFelterTilDefault, feilmelding } = usePåVentBehandling(
         onClose,
         ventegrunn
     );
@@ -135,7 +135,7 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
                     variant="tertiary"
                     key={'avbryt'}
                     onClick={() => {
-                        nullstillSkjema();
+                        tilbakestillFelterTilDefault();
                         onClose();
                     }}
                     size="small"

--- a/src/frontend/typer/api.ts
+++ b/src/frontend/typer/api.ts
@@ -6,9 +6,10 @@ import {
     Vilkårsresultat,
 } from '../kodeverk';
 import { Vergetype } from '../kodeverk/verge';
-import { Behandlingresultat, Behandlingssteg } from './behandling';
+import { Behandlingresultat, Behandlingssteg, Venteårsak } from './behandling';
 import { IBrevmottaker } from './Brevmottaker';
 import { Aktsomhetsvurdering, GodTro, Periode } from './feilutbetalingtyper';
+import { IsoDatoString } from '../utils/dato';
 
 export interface PeriodeFaktaStegPayload {
     periode: Periode;
@@ -125,4 +126,9 @@ export interface HenleggBehandlingPaylod {
     behandlingsresultatstype: Behandlingresultat;
     begrunnelse: string;
     fritekst: string;
+}
+
+export interface IRestSettPåVent {
+    venteårsak: Venteårsak;
+    tidsfrist: IsoDatoString;
 }

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -9,6 +9,23 @@ export enum Datoformat {
     ISO_DAG = 'yyyy-MM-dd',
 }
 
+interface DateTilFormatertStringProps {
+    date?: Date;
+    tilFormat: Datoformat;
+    defaultString?: string;
+}
+
+export const dateTilFormatertString = ({
+    date,
+    tilFormat,
+    defaultString = '',
+}: DateTilFormatertStringProps): string => {
+    return date && isValid(date) ? format(date, tilFormat) : defaultString;
+};
+
+export const dateTilIsoDatoString = (dato?: Date): IsoDatoString =>
+    dateTilFormatertString({ date: dato, tilFormat: Datoformat.ISO_DAG, defaultString: '' });
+
 export const dateTilIsoDatoStringEllerUndefined = (dato?: Date): IsoDatoString | undefined =>
     dato && isValid(dato) ? format(dato, Datoformat.ISO_DAG) : undefined;
 

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -1,0 +1,23 @@
+import { format, isValid, parseISO, startOfToday } from 'date-fns';
+
+export type IsoDatoString = string; // Format YYYY-MM-DD (ISO)
+
+export const dagensDato = startOfToday();
+
+export enum Datoformat {
+    DATO = 'dd.MM.yyyy',
+    ISO_DAG = 'yyyy-MM-dd',
+}
+
+export const dateTilIsoDatoStringEllerUndefined = (dato?: Date): IsoDatoString | undefined =>
+    dato && isValid(dato) ? format(dato, Datoformat.ISO_DAG) : undefined;
+
+export const isoStringTilDate = (isoDatoString: IsoDatoString): Date => {
+    const dato = parseISO(isoDatoString);
+
+    if (!isValid(dato)) {
+        throw new Error(`Dato '${isoDatoString}' er ugyldig`);
+    }
+
+    return dato;
+};

--- a/src/frontend/utils/validering.ts
+++ b/src/frontend/utils/validering.ts
@@ -123,10 +123,5 @@ export const validerDato = (dato?: string): ValideringsResultat => {
     return isValid(lestDato) ? undefined : 'Ugyldig dato';
 };
 
-export const validerDatoFelt = (felt: FeltState<string | ''>) => {
-    const feilmelding = validerDato(felt.verdi);
-    return !feilmelding ? ok(felt) : feil(felt, feilmelding);
-};
-
 export const validerGyldigDato = (felt: FeltState<Date | undefined>) =>
     felt.verdi && isValid(felt.verdi) ? ok(felt) : feil(felt, 'Du må velge en gyldig dato');

--- a/src/frontend/utils/validering.ts
+++ b/src/frontend/utils/validering.ts
@@ -127,3 +127,6 @@ export const validerDatoFelt = (felt: FeltState<string | ''>) => {
     const feilmelding = validerDato(felt.verdi);
     return !feilmelding ? ok(felt) : feil(felt, feilmelding);
 };
+
+export const validerGyldigDato = (felt: FeltState<Date | undefined>) =>
+    felt.verdi && isValid(felt.verdi) ? ok(felt) : feil(felt, 'Du må velge en gyldig dato');


### PR DESCRIPTION
Bytter til ny DatePicker fra Aksel for alle stedene hvor vi har datovelger for skjemafelter. Etter dette mangler det kun oppgradering ett sted, men dette stedet bruker ikke Felt fra familie-skjema, og må løses på en litt annen måte. Tar det derfor i egen PR.

Koden i `Datovelger.tsx` og `dato.ts` er kopiert fra ba-sak/ks-sak. Kommer også mer opprydning i dato-funksjoner på sikt, syns derfor det var ryddig å starte på en ny og clean dato-fil som ligner på hvordan det gjøres i ba-sak og ks-sak.

Legger ved skjermbilder i kommentarer