### PR TITLE
Chore: bytt ut nav-frontend-grid for Verge, Fakta og Foreldelse-steg

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
         "import/default": "error",
         "import/export": "error",
         "import/order": [
-            "error",
+            "off",
             {
                 "alphabetize": {
                     "order": "asc",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
         "import/default": "error",
         "import/export": "error",
         "import/order": [
-            "off",
+            "error",
             {
                 "alphabetize": {
                     "order": "asc",

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
@@ -19,7 +19,7 @@ interface IProps {
 
 const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
     return feilutbetalingFakta ? (
-        <>
+        <VStack>
             <Heading level="2" size="small">
                 Revurdering
             </Heading>
@@ -66,7 +66,7 @@ const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
                     </BodyShort>
                 )}
             </VStack>
-        </>
+        </VStack>
     ) : null;
 };
 

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
@@ -1,17 +1,10 @@
 import * as React from 'react';
 
-import { styled } from 'styled-components';
-
 import { BodyShort, Heading, HGrid, VStack } from '@navikt/ds-react';
-import { ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import { IFeilutbetalingFakta, tilbakekrevingsvalg } from '../../../typer/feilutbetalingtyper';
 import { formatterDatostring } from '../../../utils';
-import { DetailBold, Spacer20 } from '../../Felleskomponenter/Flytelementer';
-
-export const HGridMedMargin = styled(HGrid)`
-    margin-bottom: ${ASpacing4};
-`;
+import { DetailBold } from '../../Felleskomponenter/Flytelementer';
 
 interface IProps {
     feilutbetalingFakta: IFeilutbetalingFakta;
@@ -19,52 +12,53 @@ interface IProps {
 
 const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
     return feilutbetalingFakta ? (
-        <VStack>
+        <VStack gap="5">
             <Heading level="2" size="small">
                 Revurdering
             </Heading>
-            <Spacer20 />
-            <HGridMedMargin columns={2}>
-                <VStack>
-                    <DetailBold>Årsak(er) til revurdering</DetailBold>
-                    {feilutbetalingFakta.faktainfo?.revurderingsårsak && (
+            <VStack gap="4">
+                <HGrid columns={2}>
+                    <div>
+                        <DetailBold>Årsak(er) til revurdering</DetailBold>
+                        {feilutbetalingFakta.faktainfo?.revurderingsårsak && (
+                            <BodyShort size="small">
+                                {feilutbetalingFakta.faktainfo.revurderingsårsak}
+                            </BodyShort>
+                        )}
+                    </div>
+                    <div>
+                        <DetailBold>Dato for revurderingsvedtak</DetailBold>
                         <BodyShort size="small">
-                            {feilutbetalingFakta.faktainfo.revurderingsårsak}
+                            {formatterDatostring(feilutbetalingFakta.revurderingsvedtaksdato)}
+                        </BodyShort>
+                    </div>
+                </HGrid>
+                <HGrid columns={2}>
+                    <div>
+                        <DetailBold>Resultat</DetailBold>
+                        {feilutbetalingFakta.faktainfo?.revurderingsresultat && (
+                            <BodyShort size="small">
+                                {feilutbetalingFakta.faktainfo.revurderingsresultat}
+                            </BodyShort>
+                        )}
+                    </div>
+                    <div>
+                        <DetailBold>Konsekvens</DetailBold>
+                        {feilutbetalingFakta.faktainfo?.konsekvensForYtelser && (
+                            <BodyShort size="small">
+                                {feilutbetalingFakta.faktainfo.konsekvensForYtelser?.join(', ')}
+                            </BodyShort>
+                        )}
+                    </div>
+                </HGrid>
+                <div>
+                    <DetailBold>Tilbakekrevingsvalg</DetailBold>
+                    {feilutbetalingFakta.faktainfo?.tilbakekrevingsvalg && (
+                        <BodyShort size="small">
+                            {tilbakekrevingsvalg[feilutbetalingFakta.faktainfo.tilbakekrevingsvalg]}
                         </BodyShort>
                     )}
-                </VStack>
-                <VStack>
-                    <DetailBold>Dato for revurderingsvedtak</DetailBold>
-                    <BodyShort size="small">
-                        {formatterDatostring(feilutbetalingFakta.revurderingsvedtaksdato)}
-                    </BodyShort>
-                </VStack>
-            </HGridMedMargin>
-            <HGridMedMargin columns={2}>
-                <VStack>
-                    <DetailBold>Resultat</DetailBold>
-                    {feilutbetalingFakta.faktainfo?.revurderingsresultat && (
-                        <BodyShort size="small">
-                            {feilutbetalingFakta.faktainfo.revurderingsresultat}
-                        </BodyShort>
-                    )}
-                </VStack>
-                <VStack>
-                    <DetailBold>Konsekvens</DetailBold>
-                    {feilutbetalingFakta.faktainfo?.konsekvensForYtelser && (
-                        <BodyShort size="small">
-                            {feilutbetalingFakta.faktainfo.konsekvensForYtelser?.join(', ')}
-                        </BodyShort>
-                    )}
-                </VStack>
-            </HGridMedMargin>
-            <VStack>
-                <DetailBold>Tilbakekrevingsvalg</DetailBold>
-                {feilutbetalingFakta.faktainfo?.tilbakekrevingsvalg && (
-                    <BodyShort size="small">
-                        {tilbakekrevingsvalg[feilutbetalingFakta.faktainfo.tilbakekrevingsvalg]}
-                    </BodyShort>
-                )}
+                </div>
             </VStack>
         </VStack>
     ) : null;

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaRevurdering.tsx
@@ -2,16 +2,14 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Column, Row } from 'nav-frontend-grid';
-
-import { BodyShort, Heading } from '@navikt/ds-react';
+import { BodyShort, Heading, HGrid, VStack } from '@navikt/ds-react';
 import { ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import { IFeilutbetalingFakta, tilbakekrevingsvalg } from '../../../typer/feilutbetalingtyper';
 import { formatterDatostring } from '../../../utils';
 import { DetailBold, Spacer20 } from '../../Felleskomponenter/Flytelementer';
 
-export const RadMedMargin = styled(Row)`
+export const HGridMedMargin = styled(HGrid)`
     margin-bottom: ${ASpacing4};
 `;
 
@@ -22,58 +20,52 @@ interface IProps {
 const FaktaRevurdering: React.FC<IProps> = ({ feilutbetalingFakta }) => {
     return feilutbetalingFakta ? (
         <>
-            <Row>
-                <Column xs="12">
-                    <Heading level="2" size="small">
-                        Revurdering
-                    </Heading>
-                </Column>
-            </Row>
+            <Heading level="2" size="small">
+                Revurdering
+            </Heading>
             <Spacer20 />
-            <RadMedMargin>
-                <Column xs="6">
+            <HGridMedMargin columns={2}>
+                <VStack>
                     <DetailBold>Årsak(er) til revurdering</DetailBold>
                     {feilutbetalingFakta.faktainfo?.revurderingsårsak && (
                         <BodyShort size="small">
                             {feilutbetalingFakta.faktainfo.revurderingsårsak}
                         </BodyShort>
                     )}
-                </Column>
-                <Column xs="6">
+                </VStack>
+                <VStack>
                     <DetailBold>Dato for revurderingsvedtak</DetailBold>
                     <BodyShort size="small">
                         {formatterDatostring(feilutbetalingFakta.revurderingsvedtaksdato)}
                     </BodyShort>
-                </Column>
-            </RadMedMargin>
-            <RadMedMargin>
-                <Column xs="6">
+                </VStack>
+            </HGridMedMargin>
+            <HGridMedMargin columns={2}>
+                <VStack>
                     <DetailBold>Resultat</DetailBold>
                     {feilutbetalingFakta.faktainfo?.revurderingsresultat && (
                         <BodyShort size="small">
                             {feilutbetalingFakta.faktainfo.revurderingsresultat}
                         </BodyShort>
                     )}
-                </Column>
-                <Column xs="6">
+                </VStack>
+                <VStack>
                     <DetailBold>Konsekvens</DetailBold>
                     {feilutbetalingFakta.faktainfo?.konsekvensForYtelser && (
                         <BodyShort size="small">
                             {feilutbetalingFakta.faktainfo.konsekvensForYtelser?.join(', ')}
                         </BodyShort>
                     )}
-                </Column>
-            </RadMedMargin>
-            <Row>
-                <Column xs="6">
-                    <DetailBold>Tilbakekrevingsvalg</DetailBold>
-                    {feilutbetalingFakta.faktainfo?.tilbakekrevingsvalg && (
-                        <BodyShort size="small">
-                            {tilbakekrevingsvalg[feilutbetalingFakta.faktainfo.tilbakekrevingsvalg]}
-                        </BodyShort>
-                    )}
-                </Column>
-            </Row>
+                </VStack>
+            </HGridMedMargin>
+            <VStack>
+                <DetailBold>Tilbakekrevingsvalg</DetailBold>
+                {feilutbetalingFakta.faktainfo?.tilbakekrevingsvalg && (
+                    <BodyShort size="small">
+                        {tilbakekrevingsvalg[feilutbetalingFakta.faktainfo.tilbakekrevingsvalg]}
+                    </BodyShort>
+                )}
+            </VStack>
         </>
     ) : null;
 };

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -5,13 +5,7 @@ import { BodyShort, Checkbox, Heading, HGrid, Textarea, VStack } from '@navikt/d
 import { Ytelsetype } from '../../../kodeverk';
 import { IFeilutbetalingFakta } from '../../../typer/feilutbetalingtyper';
 import { formatterDatostring, formatCurrencyNoKr } from '../../../utils';
-import {
-    DetailBold,
-    FTButton,
-    Navigering,
-    Spacer20,
-    Spacer8,
-} from '../../Felleskomponenter/Flytelementer';
+import { DetailBold, FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 import FeilutbetalingFaktaPerioder from './FaktaPeriode/FeilutbetalingFaktaPerioder';
 import FaktaRevurdering from './FaktaRevurdering';
 import { useFeilutbetalingFakta } from './FeilutbetalingFaktaContext';
@@ -50,13 +44,12 @@ const FaktaSkjema: React.FC<IProps> = ({
 
     return (
         <HGrid columns={2} gap="10">
-            <VStack>
+            <VStack gap="5">
                 <Heading level="2" size="small">
                     Feilutbetaling
                 </Heading>
-                <Spacer20 />
-                <HGrid columns={3}>
-                    <VStack>
+                <HGrid columns={3} gap="1">
+                    <div>
                         <DetailBold>Periode med feilutbetaling</DetailBold>
                         <BodyShort size="small">
                             {`${formatterDatostring(
@@ -65,25 +58,24 @@ const FaktaSkjema: React.FC<IProps> = ({
                                 feilutbetalingFakta.totalFeilutbetaltPeriode.tom
                             )}`}
                         </BodyShort>
-                    </VStack>
-                    <VStack>
+                    </div>
+                    <div>
                         <DetailBold>Feilutbetalt beløp totalt</DetailBold>
                         <BodyShort size="small" className={'redText'}>
                             {`${formatCurrencyNoKr(feilutbetalingFakta.totaltFeilutbetaltBeløp)}`}
                         </BodyShort>
-                    </VStack>
-                    <VStack>
+                    </div>
+                    <div>
                         <DetailBold>Tidligere varslet beløp</DetailBold>
                         <BodyShort size="small">
                             {feilutbetalingFakta.varsletBeløp
                                 ? `${formatCurrencyNoKr(feilutbetalingFakta.varsletBeløp)}`
                                 : ''}
                         </BodyShort>
-                    </VStack>
+                    </div>
                 </HGrid>
-                <Spacer20 />
-                {!erLesevisning && (
-                    <>
+                <VStack gap="2">
+                    {!erLesevisning && (
                         <Checkbox
                             size="small"
                             disabled={erLesevisning}
@@ -92,19 +84,15 @@ const FaktaSkjema: React.FC<IProps> = ({
                         >
                             Behandle alle perioder samlet
                         </Checkbox>
-                        <Spacer8 />
-                    </>
-                )}
-                {skjemaData.perioder && (
-                    <FeilutbetalingFaktaPerioder
-                        ytelse={ytelse}
-                        erLesevisning={erLesevisning}
-                        perioder={skjemaData.perioder}
-                    />
-                )}
-
-                <Spacer20 />
-
+                    )}
+                    {skjemaData.perioder && (
+                        <FeilutbetalingFaktaPerioder
+                            ytelse={ytelse}
+                            erLesevisning={erLesevisning}
+                            perioder={skjemaData.perioder}
+                        />
+                    )}
+                </VStack>
                 <Textarea
                     name={'begrunnelse'}
                     label={'Forklar årsaken(e) til feilutbetalingen'}
@@ -119,25 +107,19 @@ const FaktaSkjema: React.FC<IProps> = ({
                     }
                 />
 
-                <Spacer20 />
-
                 <Navigering>
-                    <div>
-                        <FTButton
-                            variant="primary"
-                            onClick={sendInnSkjema}
-                            loading={senderInn}
-                            disabled={erLesevisning && !stegErBehandlet}
-                        >
-                            {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
-                        </FTButton>
-                    </div>
+                    <FTButton
+                        variant="primary"
+                        onClick={sendInnSkjema}
+                        loading={senderInn}
+                        disabled={erLesevisning && !stegErBehandlet}
+                    >
+                        {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
+                    </FTButton>
                     {behandling.harVerge && (
-                        <div>
-                            <FTButton variant="secondary" onClick={gåTilForrige}>
-                                Forrige
-                            </FTButton>
-                        </div>
+                        <FTButton variant="secondary" onClick={gåTilForrige}>
+                            Forrige
+                        </FTButton>
                     )}
                 </Navigering>
             </VStack>

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-import { Column, Row } from 'nav-frontend-grid';
-
-import { BodyShort, Checkbox, Heading, Textarea } from '@navikt/ds-react';
+import { BodyShort, Checkbox, Heading, HGrid, Textarea, VStack } from '@navikt/ds-react';
 
 import { Ytelsetype } from '../../../kodeverk';
 import { IFeilutbetalingFakta } from '../../../typer/feilutbetalingtyper';
@@ -51,124 +49,101 @@ const FaktaSkjema: React.FC<IProps> = ({
     };
 
     return (
-        <>
-            <Row>
-                <Column sm="12" md="6">
-                    <Row>
-                        <Column xs="12">
-                            <Heading level="2" size="small">
-                                Feilutbetaling
-                            </Heading>
-                        </Column>
-                    </Row>
-                    <Spacer20 />
-                    <Row>
-                        <Column xs="12" md="4">
-                            <DetailBold>Periode med feilutbetaling</DetailBold>
-                            <BodyShort size="small">
-                                {`${formatterDatostring(
-                                    feilutbetalingFakta.totalFeilutbetaltPeriode.fom
-                                )} - ${formatterDatostring(
-                                    feilutbetalingFakta.totalFeilutbetaltPeriode.tom
-                                )}`}
-                            </BodyShort>
-                        </Column>
-                        <Column xs="12" md="4">
-                            <DetailBold>Feilutbetalt beløp totalt</DetailBold>
-                            <BodyShort size="small" className={'redText'}>
-                                {`${formatCurrencyNoKr(
-                                    feilutbetalingFakta.totaltFeilutbetaltBeløp
-                                )}`}
-                            </BodyShort>
-                        </Column>
-                        <Column xs="12" md="4">
-                            <DetailBold>Tidligere varslet beløp</DetailBold>
-                            <BodyShort size="small">
-                                {feilutbetalingFakta.varsletBeløp
-                                    ? `${formatCurrencyNoKr(feilutbetalingFakta.varsletBeløp)}`
-                                    : ''}
-                            </BodyShort>
-                        </Column>
-                    </Row>
-                    <Spacer20 />
-                    {!erLesevisning && (
-                        <>
-                            <Row>
-                                <Column xs="11">
-                                    <Checkbox
-                                        size="small"
-                                        disabled={erLesevisning}
-                                        checked={behandlePerioderSamlet === true}
-                                        onChange={() =>
-                                            settBehandlePerioderSamlet(!behandlePerioderSamlet)
-                                        }
-                                    >
-                                        Behandle alle perioder samlet
-                                    </Checkbox>
-                                </Column>
-                            </Row>
-                            <Spacer8 />
-                        </>
-                    )}
-                    <Row>
-                        <Column xs="11">
-                            {skjemaData.perioder && (
-                                <FeilutbetalingFaktaPerioder
-                                    ytelse={ytelse}
-                                    erLesevisning={erLesevisning}
-                                    perioder={skjemaData.perioder}
-                                />
-                            )}
-                        </Column>
-                    </Row>
-                </Column>
-                <Column sm="12" md="6">
-                    <FaktaRevurdering feilutbetalingFakta={feilutbetalingFakta} />
-                </Column>
-            </Row>
-            <Spacer20 />
-            <Row>
-                <Column sm="12" md="6">
-                    <Textarea
-                        name={'begrunnelse'}
-                        label={'Forklar årsaken(e) til feilutbetalingen'}
-                        readOnly={erLesevisning}
-                        value={skjemaData.begrunnelse ? skjemaData.begrunnelse : ''}
-                        onChange={event => onChangeBegrunnelse(event)}
-                        maxLength={3000}
-                        className={erLesevisning ? 'lesevisning' : ''}
-                        error={
-                            visFeilmeldinger &&
-                            feilmeldinger?.find(meld => meld.gjelderBegrunnelse)?.melding
-                        }
+        <HGrid columns={2} gap="10">
+            <VStack>
+                <Heading level="2" size="small">
+                    Feilutbetaling
+                </Heading>
+                <Spacer20 />
+                <HGrid columns={3}>
+                    <VStack>
+                        <DetailBold>Periode med feilutbetaling</DetailBold>
+                        <BodyShort size="small">
+                            {`${formatterDatostring(
+                                feilutbetalingFakta.totalFeilutbetaltPeriode.fom
+                            )} - ${formatterDatostring(
+                                feilutbetalingFakta.totalFeilutbetaltPeriode.tom
+                            )}`}
+                        </BodyShort>
+                    </VStack>
+                    <VStack>
+                        <DetailBold>Feilutbetalt beløp totalt</DetailBold>
+                        <BodyShort size="small" className={'redText'}>
+                            {`${formatCurrencyNoKr(feilutbetalingFakta.totaltFeilutbetaltBeløp)}`}
+                        </BodyShort>
+                    </VStack>
+                    <VStack>
+                        <DetailBold>Tidligere varslet beløp</DetailBold>
+                        <BodyShort size="small">
+                            {feilutbetalingFakta.varsletBeløp
+                                ? `${formatCurrencyNoKr(feilutbetalingFakta.varsletBeløp)}`
+                                : ''}
+                        </BodyShort>
+                    </VStack>
+                </HGrid>
+                <Spacer20 />
+                {!erLesevisning && (
+                    <>
+                        <Checkbox
+                            size="small"
+                            disabled={erLesevisning}
+                            checked={behandlePerioderSamlet === true}
+                            onChange={() => settBehandlePerioderSamlet(!behandlePerioderSamlet)}
+                        >
+                            Behandle alle perioder samlet
+                        </Checkbox>
+                        <Spacer8 />
+                    </>
+                )}
+                {skjemaData.perioder && (
+                    <FeilutbetalingFaktaPerioder
+                        ytelse={ytelse}
+                        erLesevisning={erLesevisning}
+                        perioder={skjemaData.perioder}
                     />
-                </Column>
-            </Row>
-            <Spacer20 />
-            <Row>
-                <Column xs="12" md="6">
-                    <Navigering>
+                )}
+
+                <Spacer20 />
+
+                <Textarea
+                    name={'begrunnelse'}
+                    label={'Forklar årsaken(e) til feilutbetalingen'}
+                    readOnly={erLesevisning}
+                    value={skjemaData.begrunnelse ? skjemaData.begrunnelse : ''}
+                    onChange={event => onChangeBegrunnelse(event)}
+                    maxLength={3000}
+                    className={erLesevisning ? 'lesevisning' : ''}
+                    error={
+                        visFeilmeldinger &&
+                        feilmeldinger?.find(meld => meld.gjelderBegrunnelse)?.melding
+                    }
+                />
+
+                <Spacer20 />
+
+                <Navigering>
+                    <div>
+                        <FTButton
+                            variant="primary"
+                            onClick={sendInnSkjema}
+                            loading={senderInn}
+                            disabled={erLesevisning && !stegErBehandlet}
+                        >
+                            {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
+                        </FTButton>
+                    </div>
+                    {behandling.harVerge && (
                         <div>
-                            <FTButton
-                                variant="primary"
-                                onClick={sendInnSkjema}
-                                loading={senderInn}
-                                disabled={erLesevisning && !stegErBehandlet}
-                            >
-                                {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
+                            <FTButton variant="secondary" onClick={gåTilForrige}>
+                                Forrige
                             </FTButton>
                         </div>
-                        {behandling.harVerge && (
-                            <div>
-                                <FTButton variant="secondary" onClick={gåTilForrige}>
-                                    Forrige
-                                </FTButton>
-                            </div>
-                        )}
-                    </Navigering>
-                </Column>
-            </Row>
-        </>
+                    )}
+                </Navigering>
+            </VStack>
+
+            <FaktaRevurdering feilutbetalingFakta={feilutbetalingFakta} />
+        </HGrid>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -78,7 +78,6 @@ const FaktaSkjema: React.FC<IProps> = ({
                     {!erLesevisning && (
                         <Checkbox
                             size="small"
-                            disabled={erLesevisning}
                             checked={behandlePerioderSamlet === true}
                             onChange={() => settBehandlePerioderSamlet(!behandlePerioderSamlet)}
                         >

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
@@ -12,17 +12,18 @@ import { FTButton, Navigering, Spacer20 } from '../../Felleskomponenter/Flytelem
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
 import { useFeilutbetalingForeldelse } from './FeilutbetalingForeldelseContext';
 import FeilutbetalingForeldelsePerioder from './ForeldelsePeriode/FeilutbetalingForeldelsePerioder';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 export const getDate = (): string => {
     return finnDatoRelativtTilNå({ months: -30 });
 };
 
 const StyledForeldelse = styled.div`
-    padding: 10px;
+    padding: ${ASpacing3};
 `;
 
 const StyledAutomatiskForeldelse = styled.div`
-    padding: 10px;
+    padding: ${ASpacing3};
     min-width: 15rem;
     max-width: 30rem;
 `;

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Column, Row } from 'nav-frontend-grid';
-
 import { Alert, BodyLong, BodyShort, Heading, Loader } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
@@ -21,6 +19,12 @@ export const getDate = (): string => {
 
 const StyledForeldelse = styled.div`
     padding: 10px;
+`;
+
+const StyledAutomatiskForeldelse = styled.div`
+    padding: 10px;
+    min-width: 15rem;
+    max-width: 30rem;
 `;
 
 const HenterContainer = styled(StyledForeldelse)`
@@ -45,7 +49,7 @@ const ForeldelseContainer: React.FC<IProps> = ({ behandling }) => {
 
     if (erAutoutført) {
         return (
-            <StyledForeldelse>
+            <StyledAutomatiskForeldelse>
                 <Heading spacing size="small" level="2">
                     Foreldelse
                 </Heading>
@@ -55,23 +59,15 @@ const ForeldelseContainer: React.FC<IProps> = ({ behandling }) => {
                 <BodyLong size="small" spacing>
                     Automatisk vurdert
                 </BodyLong>
-                <Row>
-                    <Column xs="10" md="4">
-                        <Navigering>
-                            <div>
-                                <FTButton variant="primary" onClick={gåTilNeste}>
-                                    Neste
-                                </FTButton>
-                            </div>
-                            <div>
-                                <FTButton variant="secondary" onClick={gåTilForrige}>
-                                    Forrige
-                                </FTButton>
-                            </div>
-                        </Navigering>
-                    </Column>
-                </Row>
-            </StyledForeldelse>
+                <Navigering>
+                    <FTButton variant="primary" onClick={gåTilNeste}>
+                        Neste
+                    </FTButton>
+                    <FTButton variant="secondary" onClick={gåTilForrige}>
+                        Forrige
+                    </FTButton>
+                </Navigering>
+            </StyledAutomatiskForeldelse>
         );
     }
 
@@ -92,17 +88,13 @@ const ForeldelseContainer: React.FC<IProps> = ({ behandling }) => {
                             <Spacer20 />
                         </>
                     )}
-                    <Row>
-                        <Column xs="12">
-                            {skjemaData.length > 0 && (
-                                <FeilutbetalingForeldelsePerioder
-                                    behandling={behandling}
-                                    perioder={skjemaData}
-                                    erLesevisning={erLesevisning}
-                                />
-                            )}
-                        </Column>
-                    </Row>
+                    {skjemaData.length > 0 && (
+                        <FeilutbetalingForeldelsePerioder
+                            behandling={behandling}
+                            perioder={skjemaData}
+                            erLesevisning={erLesevisning}
+                        />
+                    )}
                 </StyledForeldelse>
             );
         case RessursStatus.HENTER:

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
 
-import { styled } from 'styled-components';
-
 import { Column, Row } from 'nav-frontend-grid';
 
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
-import { BodyLong, Heading, Link, Radio, RadioGroup, ReadMore, Textarea } from '@navikt/ds-react';
-import { ABorderStrong, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
+import {
+    BodyLong,
+    Box,
+    Heading,
+    HStack,
+    Link,
+    Radio,
+    RadioGroup,
+    ReadMore,
+    Textarea,
+    VStack,
+} from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import {
@@ -24,10 +32,15 @@ import { useForeldelsePeriodeSkjema } from './ForeldelsePeriodeSkjemaContext';
 import SplittPeriode from './SplittPeriode/SplittPeriode';
 import { isoStringTilDate } from '../../../../utils/dato';
 import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
+import { styled } from 'styled-components';
 
-const StyledContainer = styled.div`
-    border: 1px solid ${ABorderStrong};
-    padding: ${ASpacing3};
+const StyledVStack = styled(VStack)`
+    max-width: 30rem;
+    width: 100%;
+`;
+
+const StyledBox = styled(Box)`
+    min-width: 38rem;
 `;
 
 interface IProps {
@@ -121,38 +134,33 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
     };
 
     return (
-        <StyledContainer>
-            <Row>
-                <Column lg="4" md="7" sm="12">
-                    <Heading size="small" level="2">
-                        Detaljer for valgt periode
-                    </Heading>
-                </Column>
-                <Column lg="2" md="2" sm="6">
-                    {!erLesevisning && (
-                        <SplittPeriode
-                            behandling={behandling}
-                            periode={periode}
-                            onBekreft={onSplitPeriode}
-                        />
-                    )}
-                </Column>
-                <Column lg="6" md="3" sm="6">
-                    <PeriodeController
-                        nestePeriode={() => nestePeriode(periode)}
-                        forrigePeriode={() => forrigePeriode(periode)}
-                    />
-                </Column>
-            </Row>
-            <Row>
-                <Column lg="6" md="9" sm="12">
+        <StyledBox padding="4" borderColor="border-strong" borderWidth="1">
+            <HStack justify="space-between">
+                <StyledVStack>
+                    <HStack justify="space-between" align="center">
+                        <Heading size="small" level="2">
+                            Detaljer for valgt periode
+                        </Heading>
+
+                        {!erLesevisning && (
+                            <SplittPeriode
+                                behandling={behandling}
+                                periode={periode}
+                                onBekreft={onSplitPeriode}
+                            />
+                        )}
+                    </HStack>
                     <PeriodeOppsummering
                         fom={periode.periode.fom}
                         tom={periode.periode.tom}
                         beløp={periode.feilutbetaltBeløp}
                     />
-                </Column>
-            </Row>
+                </StyledVStack>
+                <PeriodeController
+                    nestePeriode={() => nestePeriode(periode)}
+                    forrigePeriode={() => forrigePeriode(periode)}
+                />
+            </HStack>
             <Spacer20 />
             <Row>
                 <Column md="8">
@@ -248,7 +256,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                     </Row>
                 </>
             )}
-        </StyledContainer>
+        </StyledBox>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -31,11 +31,24 @@ import { useForeldelsePeriodeSkjema } from './ForeldelsePeriodeSkjemaContext';
 import SplittPeriode from './SplittPeriode/SplittPeriode';
 import { isoStringTilDate } from '../../../../utils/dato';
 import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 
-const StyledVStack = styled(VStack)<{ $maxWidth: string }>`
-    max-width: ${props => props.$maxWidth};
+const StyledVStack = styled(VStack)`
+    max-width: 50rem;
     width: 100%;
+`;
+
+const stylingBredde30rem = css`
+    max-width: 30rem;
+    width: 100%;
+`;
+
+const StyledStack = styled(Stack)`
+    ${stylingBredde30rem}
+`;
+
+const DivMedMaksbredde = styled.div`
+    ${stylingBredde30rem}
 `;
 
 const StyledBox = styled(Box)`
@@ -135,117 +148,112 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
     return (
         <StyledBox padding="4" borderColor="border-strong" borderWidth="1">
             <HGrid columns={'1fr 4rem'}>
-                <VStack gap="5">
-                    <StyledVStack $maxWidth={'30rem'} gap="1">
-                        <Stack
-                            justify="space-between"
-                            align={{ md: 'start', lg: 'center' }}
-                            direction={{ md: 'column', lg: 'row' }}
-                        >
-                            <Heading size="small" level="2">
-                                Detaljer for valgt periode
-                            </Heading>
+                <StyledStack
+                    justify="space-between"
+                    align={{ md: 'start', lg: 'center' }}
+                    direction={{ md: 'column', lg: 'row' }}
+                >
+                    <Heading size="small" level="2">
+                        Detaljer for valgt periode
+                    </Heading>
 
-                            {!erLesevisning && (
-                                <SplittPeriode
-                                    behandling={behandling}
-                                    periode={periode}
-                                    onBekreft={onSplitPeriode}
-                                />
-                            )}
-                        </Stack>
-                        <PeriodeOppsummering
-                            fom={periode.periode.fom}
-                            tom={periode.periode.tom}
-                            beløp={periode.feilutbetaltBeløp}
+                    {!erLesevisning && (
+                        <SplittPeriode
+                            behandling={behandling}
+                            periode={periode}
+                            onBekreft={onSplitPeriode}
                         />
-                    </StyledVStack>
-                    <StyledVStack $maxWidth={'50rem'} gap="4">
-                        <Textarea
-                            {...skjema.felter.begrunnelse.hentNavInputProps(
-                                skjema.visFeilmeldinger
-                            )}
-                            id={'begrunnelse'}
-                            name="begrunnelse"
-                            label={'Vurdering'}
-                            maxLength={3000}
-                            readOnly={erLesevisning}
-                            value={skjema.felter.begrunnelse.verdi}
-                            onChange={event =>
-                                skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
-                            }
-                        />
-                        <HGrid columns={{ md: 1, lg: 2 }} gap="8">
-                            <RadioGroup
-                                id="foreldet"
-                                readOnly={erLesevisning}
-                                legend="Vurder om perioden er foreldet"
-                                value={skjema.felter.foreldelsesvurderingstype.verdi}
-                                error={
-                                    ugyldigVurderingValgt
-                                        ? skjema.felter.foreldelsesvurderingstype.feilmelding?.toString()
-                                        : ''
-                                }
-                                onChange={(val: Foreldelsevurdering) =>
-                                    skjema.felter.foreldelsesvurderingstype.validerOgSettFelt(val)
-                                }
-                            >
-                                {foreldelseVurderingTyper.map(type => (
-                                    <Radio key={type} name="foreldet" value={type}>
-                                        {foreldelsevurderinger[type]}
-                                    </Radio>
-                                ))}
-                            </RadioGroup>
-                            <VStack gap="5">
-                                {erMedTilleggsfrist && (
-                                    <Datovelger
-                                        felt={skjema.felter.oppdagelsesdato}
-                                        label="Dato for når feilutbetaling ble oppdaget"
-                                        description="Datoen kommer i vedtaksbrevet"
-                                        visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
-                                        readOnly={erLesevisning}
-                                        kanKunVelgeFortid
-                                    />
-                                )}
-                                {(erForeldet || erMedTilleggsfrist) && (
-                                    <VStack gap="2">
-                                        <Datovelger
-                                            felt={skjema.felter.foreldelsesfrist}
-                                            label="Foreldelsesfrist"
-                                            description={
-                                                !erMedTilleggsfrist &&
-                                                'Datoen kommer i vedtaksbrevet'
-                                            }
-                                            visFeilmeldinger={ugyldigForeldelsesfristValgt}
-                                            readOnly={erLesevisning}
-                                        />
-                                        {!erLesevisning && (
-                                            <ReadMore header="Hvordan sette foreldelsesfrist">
-                                                {lagForeldelsesfristHjelpetekst()}
-                                            </ReadMore>
-                                        )}
-                                    </VStack>
-                                )}
-                            </VStack>
-                        </HGrid>
-
-                        {!erLesevisning && (
-                            <Navigering>
-                                <FTButton variant="primary" onClick={() => onBekreft(periode)}>
-                                    Bekreft
-                                </FTButton>
-                                <FTButton variant="secondary" onClick={lukkValgtPeriode}>
-                                    Lukk
-                                </FTButton>
-                            </Navigering>
-                        )}
-                    </StyledVStack>
-                </VStack>
+                    )}
+                </StyledStack>
                 <PeriodeController
                     nestePeriode={() => nestePeriode(periode)}
                     forrigePeriode={() => forrigePeriode(periode)}
                 />
             </HGrid>
+            <StyledVStack gap="4">
+                <DivMedMaksbredde>
+                    <PeriodeOppsummering
+                        fom={periode.periode.fom}
+                        tom={periode.periode.tom}
+                        beløp={periode.feilutbetaltBeløp}
+                    />
+                </DivMedMaksbredde>
+                <Textarea
+                    {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
+                    id={'begrunnelse'}
+                    name="begrunnelse"
+                    label={'Vurdering'}
+                    maxLength={3000}
+                    readOnly={erLesevisning}
+                    value={skjema.felter.begrunnelse.verdi}
+                    onChange={event =>
+                        skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
+                    }
+                />
+                <HGrid columns={{ md: 1, lg: 2 }} gap="8">
+                    <RadioGroup
+                        id="foreldet"
+                        readOnly={erLesevisning}
+                        legend="Vurder om perioden er foreldet"
+                        value={skjema.felter.foreldelsesvurderingstype.verdi}
+                        error={
+                            ugyldigVurderingValgt
+                                ? skjema.felter.foreldelsesvurderingstype.feilmelding?.toString()
+                                : ''
+                        }
+                        onChange={(val: Foreldelsevurdering) =>
+                            skjema.felter.foreldelsesvurderingstype.validerOgSettFelt(val)
+                        }
+                    >
+                        {foreldelseVurderingTyper.map(type => (
+                            <Radio key={type} name="foreldet" value={type}>
+                                {foreldelsevurderinger[type]}
+                            </Radio>
+                        ))}
+                    </RadioGroup>
+                    <VStack gap="5">
+                        {erMedTilleggsfrist && (
+                            <Datovelger
+                                felt={skjema.felter.oppdagelsesdato}
+                                label="Dato for når feilutbetaling ble oppdaget"
+                                description="Datoen kommer i vedtaksbrevet"
+                                visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
+                                readOnly={erLesevisning}
+                                kanKunVelgeFortid
+                            />
+                        )}
+                        {(erForeldet || erMedTilleggsfrist) && (
+                            <VStack gap="2">
+                                <Datovelger
+                                    felt={skjema.felter.foreldelsesfrist}
+                                    label="Foreldelsesfrist"
+                                    description={
+                                        !erMedTilleggsfrist && 'Datoen kommer i vedtaksbrevet'
+                                    }
+                                    visFeilmeldinger={ugyldigForeldelsesfristValgt}
+                                    readOnly={erLesevisning}
+                                />
+                                {!erLesevisning && (
+                                    <ReadMore header="Hvordan sette foreldelsesfrist">
+                                        {lagForeldelsesfristHjelpetekst()}
+                                    </ReadMore>
+                                )}
+                            </VStack>
+                        )}
+                    </VStack>
+                </HGrid>
+
+                {!erLesevisning && (
+                    <Navigering>
+                        <FTButton variant="primary" onClick={() => onBekreft(periode)}>
+                            Bekreft
+                        </FTButton>
+                        <FTButton variant="secondary" onClick={lukkValgtPeriode}>
+                            Lukk
+                        </FTButton>
+                    </Navigering>
+                )}
+            </StyledVStack>
         </StyledBox>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -22,7 +22,7 @@ import {
     foreldelseVurderingTyper,
 } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
-import { FTButton, Navigering, Spacer20, Spacer8 } from '../../../Felleskomponenter/Flytelementer';
+import { FTButton, Navigering } from '../../../Felleskomponenter/Flytelementer';
 import PeriodeOppsummering from '../../../Felleskomponenter/Periodeinformasjon/PeriodeOppsummering';
 import PeriodeController from '../../../Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
@@ -39,7 +39,7 @@ const StyledVStack = styled(VStack)<{ $maxWidth: string }>`
 `;
 
 const StyledBox = styled(Box)`
-    min-width: 38rem;
+    min-width: 20rem;
 `;
 
 interface IProps {
@@ -134,115 +134,114 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
 
     return (
         <StyledBox padding="4" borderColor="border-strong" borderWidth="1">
-            <HStack justify="space-between">
-                <StyledVStack $maxWidth={'30rem'}>
-                    <HStack justify="space-between" align="center">
-                        <Heading size="small" level="2">
-                            Detaljer for valgt periode
-                        </Heading>
+            <HGrid columns={'1fr 4rem'}>
+                <VStack gap="5">
+                    <StyledVStack $maxWidth={'30rem'} gap="1">
+                        <HStack justify="space-between" align="center">
+                            <Heading size="small" level="2">
+                                Detaljer for valgt periode
+                            </Heading>
+
+                            {!erLesevisning && (
+                                <SplittPeriode
+                                    behandling={behandling}
+                                    periode={periode}
+                                    onBekreft={onSplitPeriode}
+                                />
+                            )}
+                        </HStack>
+                        <PeriodeOppsummering
+                            fom={periode.periode.fom}
+                            tom={periode.periode.tom}
+                            beløp={periode.feilutbetaltBeløp}
+                        />
+                    </StyledVStack>
+                    <StyledVStack $maxWidth={'50rem'} gap="4">
+                        <Textarea
+                            {...skjema.felter.begrunnelse.hentNavInputProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            id={'begrunnelse'}
+                            name="begrunnelse"
+                            label={'Vurdering'}
+                            maxLength={3000}
+                            readOnly={erLesevisning}
+                            value={skjema.felter.begrunnelse.verdi}
+                            onChange={event =>
+                                skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
+                            }
+                        />
+                        <HGrid columns={2} gap="8">
+                            <RadioGroup
+                                id="foreldet"
+                                readOnly={erLesevisning}
+                                legend="Vurder om perioden er foreldet"
+                                value={skjema.felter.foreldelsesvurderingstype.verdi}
+                                error={
+                                    ugyldigVurderingValgt
+                                        ? skjema.felter.foreldelsesvurderingstype.feilmelding?.toString()
+                                        : ''
+                                }
+                                onChange={(val: Foreldelsevurdering) =>
+                                    skjema.felter.foreldelsesvurderingstype.validerOgSettFelt(val)
+                                }
+                            >
+                                {foreldelseVurderingTyper.map(type => (
+                                    <Radio key={type} name="foreldet" value={type}>
+                                        {foreldelsevurderinger[type]}
+                                    </Radio>
+                                ))}
+                            </RadioGroup>
+                            <VStack gap="5">
+                                {erMedTilleggsfrist && (
+                                    <Datovelger
+                                        felt={skjema.felter.oppdagelsesdato}
+                                        label="Dato for når feilutbetaling ble oppdaget"
+                                        description="Datoen kommer i vedtaksbrevet"
+                                        visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
+                                        readOnly={erLesevisning}
+                                        kanKunVelgeFortid
+                                    />
+                                )}
+                                {(erForeldet || erMedTilleggsfrist) && (
+                                    <VStack gap="2">
+                                        <Datovelger
+                                            felt={skjema.felter.foreldelsesfrist}
+                                            label="Foreldelsesfrist"
+                                            description={
+                                                !erMedTilleggsfrist &&
+                                                'Datoen kommer i vedtaksbrevet'
+                                            }
+                                            visFeilmeldinger={ugyldigForeldelsesfristValgt}
+                                            readOnly={erLesevisning}
+                                        />
+                                        {!erLesevisning && (
+                                            <ReadMore header="Hvordan sette foreldelsesfrist">
+                                                {lagForeldelsesfristHjelpetekst()}
+                                            </ReadMore>
+                                        )}
+                                    </VStack>
+                                )}
+                            </VStack>
+                        </HGrid>
 
                         {!erLesevisning && (
-                            <SplittPeriode
-                                behandling={behandling}
-                                periode={periode}
-                                onBekreft={onSplitPeriode}
-                            />
+                            <Navigering>
+                                <FTButton variant="primary" onClick={() => onBekreft(periode)}>
+                                    Bekreft
+                                </FTButton>
+                                <FTButton variant="secondary" onClick={lukkValgtPeriode}>
+                                    Lukk
+                                </FTButton>
+                            </Navigering>
                         )}
-                    </HStack>
-                    <PeriodeOppsummering
-                        fom={periode.periode.fom}
-                        tom={periode.periode.tom}
-                        beløp={periode.feilutbetaltBeløp}
-                    />
-                </StyledVStack>
+                    </StyledVStack>
+                </VStack>
                 <PeriodeController
                     nestePeriode={() => nestePeriode(periode)}
                     forrigePeriode={() => forrigePeriode(periode)}
                 />
-            </HStack>
-            <Spacer20 />
-            <StyledVStack $maxWidth={'50rem'}>
-                <Textarea
-                    {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                    id={'begrunnelse'}
-                    name="begrunnelse"
-                    label={'Vurdering'}
-                    maxLength={3000}
-                    readOnly={erLesevisning}
-                    value={skjema.felter.begrunnelse.verdi}
-                    onChange={event =>
-                        skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
-                    }
-                />
-                <HGrid columns={2} gap="8">
-                    <RadioGroup
-                        id="foreldet"
-                        readOnly={erLesevisning}
-                        legend="Vurder om perioden er foreldet"
-                        value={skjema.felter.foreldelsesvurderingstype.verdi}
-                        error={
-                            ugyldigVurderingValgt
-                                ? skjema.felter.foreldelsesvurderingstype.feilmelding?.toString()
-                                : ''
-                        }
-                        onChange={(val: Foreldelsevurdering) =>
-                            skjema.felter.foreldelsesvurderingstype.validerOgSettFelt(val)
-                        }
-                    >
-                        {foreldelseVurderingTyper.map(type => (
-                            <Radio key={type} name="foreldet" value={type}>
-                                {foreldelsevurderinger[type]}
-                            </Radio>
-                        ))}
-                    </RadioGroup>
-                    <VStack>
-                        {erMedTilleggsfrist && (
-                            <>
-                                <Datovelger
-                                    felt={skjema.felter.oppdagelsesdato}
-                                    label="Dato for når feilutbetaling ble oppdaget"
-                                    description="Datoen kommer i vedtaksbrevet"
-                                    visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
-                                    readOnly={erLesevisning}
-                                    kanKunVelgeFortid
-                                />
-                                <Spacer20 />
-                            </>
-                        )}
-                        {(erForeldet || erMedTilleggsfrist) && (
-                            <>
-                                <Datovelger
-                                    felt={skjema.felter.foreldelsesfrist}
-                                    label="Foreldelsesfrist"
-                                    description={
-                                        !erMedTilleggsfrist && 'Datoen kommer i vedtaksbrevet'
-                                    }
-                                    visFeilmeldinger={ugyldigForeldelsesfristValgt}
-                                    readOnly={erLesevisning}
-                                />
-                                <Spacer8 />
-                                {!erLesevisning && (
-                                    <ReadMore header="Hvordan sette foreldelsesfrist">
-                                        {lagForeldelsesfristHjelpetekst()}
-                                    </ReadMore>
-                                )}
-                            </>
-                        )}
-                    </VStack>
-                </HGrid>
-
-                <Spacer20 />
-                {!erLesevisning && (
-                    <Navigering>
-                        <FTButton variant="primary" onClick={() => onBekreft(periode)}>
-                            Bekreft
-                        </FTButton>
-                        <FTButton variant="secondary" onClick={lukkValgtPeriode}>
-                            Lukk
-                        </FTButton>
-                    </Navigering>
-                )}
-            </StyledVStack>
+            </HGrid>
         </StyledBox>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -175,7 +175,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                                 skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
                             }
                         />
-                        <HGrid columns={2} gap="8">
+                        <HGrid columns={{ md: 1, lg: 2 }} gap="8">
                             <RadioGroup
                                 id="foreldet"
                                 readOnly={erLesevisning}

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -6,11 +6,11 @@ import {
     Box,
     Heading,
     HGrid,
-    HStack,
     Link,
     Radio,
     RadioGroup,
     ReadMore,
+    Stack,
     Textarea,
     VStack,
 } from '@navikt/ds-react';
@@ -137,7 +137,11 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
             <HGrid columns={'1fr 4rem'}>
                 <VStack gap="5">
                     <StyledVStack $maxWidth={'30rem'} gap="1">
-                        <HStack justify="space-between" align="center">
+                        <Stack
+                            justify="space-between"
+                            align={{ md: 'start', lg: 'center' }}
+                            direction={{ md: 'column', lg: 'row' }}
+                        >
                             <Heading size="small" level="2">
                                 Detaljer for valgt periode
                             </Heading>
@@ -149,7 +153,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                                     onBekreft={onSplitPeriode}
                                 />
                             )}
-                        </HStack>
+                        </Stack>
                         <PeriodeOppsummering
                             fom={periode.periode.fom}
                             tom={periode.periode.tom}

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-import { Column, Row } from 'nav-frontend-grid';
-
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import {
     BodyLong,
     Box,
     Heading,
+    HGrid,
     HStack,
     Link,
     Radio,
@@ -34,8 +33,8 @@ import { isoStringTilDate } from '../../../../utils/dato';
 import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
 import { styled } from 'styled-components';
 
-const StyledVStack = styled(VStack)`
-    max-width: 30rem;
+const StyledVStack = styled(VStack)<{ $maxWidth: string }>`
+    max-width: ${props => props.$maxWidth};
     width: 100%;
 `;
 
@@ -136,7 +135,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
     return (
         <StyledBox padding="4" borderColor="border-strong" borderWidth="1">
             <HStack justify="space-between">
-                <StyledVStack>
+                <StyledVStack $maxWidth={'30rem'}>
                     <HStack justify="space-between" align="center">
                         <Heading size="small" level="2">
                             Detaljer for valgt periode
@@ -162,25 +161,20 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                 />
             </HStack>
             <Spacer20 />
-            <Row>
-                <Column md="8">
-                    <Textarea
-                        {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
-                        id={'begrunnelse'}
-                        name="begrunnelse"
-                        label={'Vurdering'}
-                        maxLength={3000}
-                        readOnly={erLesevisning}
-                        value={skjema.felter.begrunnelse.verdi}
-                        onChange={event =>
-                            skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
-                        }
-                    />
-                </Column>
-            </Row>
-            <Spacer20 />
-            <Row>
-                <Column md="5">
+            <StyledVStack $maxWidth={'50rem'}>
+                <Textarea
+                    {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
+                    id={'begrunnelse'}
+                    name="begrunnelse"
+                    label={'Vurdering'}
+                    maxLength={3000}
+                    readOnly={erLesevisning}
+                    value={skjema.felter.begrunnelse.verdi}
+                    onChange={event =>
+                        skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
+                    }
+                />
+                <HGrid columns={2} gap="8">
                     <RadioGroup
                         id="foreldet"
                         readOnly={erLesevisning}
@@ -201,61 +195,54 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                             </Radio>
                         ))}
                     </RadioGroup>
-                </Column>
-                <Column md="5">
-                    {erMedTilleggsfrist && (
-                        <>
-                            <Datovelger
-                                felt={skjema.felter.oppdagelsesdato}
-                                label="Dato for når feilutbetaling ble oppdaget"
-                                description="Datoen kommer i vedtaksbrevet"
-                                visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
-                                readOnly={erLesevisning}
-                                kanKunVelgeFortid
-                            />
-                            <Spacer20 />
-                        </>
-                    )}
-                    {(erForeldet || erMedTilleggsfrist) && (
-                        <>
-                            <Datovelger
-                                felt={skjema.felter.foreldelsesfrist}
-                                label="Foreldelsesfrist"
-                                description={!erMedTilleggsfrist && 'Datoen kommer i vedtaksbrevet'}
-                                visFeilmeldinger={ugyldigForeldelsesfristValgt}
-                                readOnly={erLesevisning}
-                            />
-                            <Spacer8 />
-                            {!erLesevisning && (
-                                <ReadMore header="Hvordan sette foreldelsesfrist">
-                                    {lagForeldelsesfristHjelpetekst()}
-                                </ReadMore>
-                            )}
-                        </>
-                    )}
-                </Column>
-            </Row>
-            <Spacer20 />
-            {!erLesevisning && (
-                <>
-                    <Row>
-                        <Column md="8">
-                            <Navigering>
-                                <div>
-                                    <FTButton variant="primary" onClick={() => onBekreft(periode)}>
-                                        Bekreft
-                                    </FTButton>
-                                </div>
-                                <div>
-                                    <FTButton variant="secondary" onClick={lukkValgtPeriode}>
-                                        Lukk
-                                    </FTButton>
-                                </div>
-                            </Navigering>
-                        </Column>
-                    </Row>
-                </>
-            )}
+                    <VStack>
+                        {erMedTilleggsfrist && (
+                            <>
+                                <Datovelger
+                                    felt={skjema.felter.oppdagelsesdato}
+                                    label="Dato for når feilutbetaling ble oppdaget"
+                                    description="Datoen kommer i vedtaksbrevet"
+                                    visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
+                                    readOnly={erLesevisning}
+                                    kanKunVelgeFortid
+                                />
+                                <Spacer20 />
+                            </>
+                        )}
+                        {(erForeldet || erMedTilleggsfrist) && (
+                            <>
+                                <Datovelger
+                                    felt={skjema.felter.foreldelsesfrist}
+                                    label="Foreldelsesfrist"
+                                    description={
+                                        !erMedTilleggsfrist && 'Datoen kommer i vedtaksbrevet'
+                                    }
+                                    visFeilmeldinger={ugyldigForeldelsesfristValgt}
+                                    readOnly={erLesevisning}
+                                />
+                                <Spacer8 />
+                                {!erLesevisning && (
+                                    <ReadMore header="Hvordan sette foreldelsesfrist">
+                                        {lagForeldelsesfristHjelpetekst()}
+                                    </ReadMore>
+                                )}
+                            </>
+                        )}
+                    </VStack>
+                </HGrid>
+
+                <Spacer20 />
+                {!erLesevisning && (
+                    <Navigering>
+                        <FTButton variant="primary" onClick={() => onBekreft(periode)}>
+                            Bekreft
+                        </FTButton>
+                        <FTButton variant="secondary" onClick={lukkValgtPeriode}>
+                            Lukk
+                        </FTButton>
+                    </Navigering>
+                )}
+            </StyledVStack>
         </StyledBox>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -190,7 +190,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                         skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
                     }
                 />
-                <HGrid columns={{ md: 1, lg: 2 }} gap="8">
+                <HGrid columns={{ md: 1, lg: 2 }} gap="4">
                     <RadioGroup
                         id="foreldet"
                         readOnly={erLesevisning}

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 
+import { VStack } from '@navikt/ds-react';
 import { type Periode } from '@navikt/familie-tidslinje';
 
+import FeilutbetalingForeldelsePeriodeSkjema from './FeilutbetalingForeldelsePeriodeSkjema';
 import { Foreldelsevurdering } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
 import { ForeldelsePeriode } from '../../../../typer/feilutbetalingtyper';
@@ -11,8 +13,6 @@ import { FTButton, Navigering } from '../../../Felleskomponenter/Flytelementer';
 import TilbakeTidslinje from '../../../Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
-import FeilutbetalingForeldelsePeriodeSkjema from './FeilutbetalingForeldelsePeriodeSkjema';
-import { VStack } from '@navikt/ds-react';
 
 const finnClassNamePeriode = (periode: ForeldelsePeriode, aktivPeriode: boolean) => {
     const aktivPeriodeCss = aktivPeriode ? 'aktivPeriode' : '';

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
@@ -7,11 +7,12 @@ import { type Periode } from '@navikt/familie-tidslinje';
 import { Foreldelsevurdering } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
 import { ForeldelsePeriode } from '../../../../typer/feilutbetalingtyper';
-import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
+import { FTButton, Navigering } from '../../../Felleskomponenter/Flytelementer';
 import TilbakeTidslinje from '../../../Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
 import FeilutbetalingForeldelsePeriodeSkjema from './FeilutbetalingForeldelsePeriodeSkjema';
+import { VStack } from '@navikt/ds-react';
 
 const finnClassNamePeriode = (periode: ForeldelsePeriode, aktivPeriode: boolean) => {
     const aktivPeriodeCss = aktivPeriode ? 'aktivPeriode' : '';
@@ -97,21 +98,16 @@ const FeilutbetalingForeldelsePerioder: React.FC<IProps> = ({
     };
 
     return perioder && tidslinjeRader ? (
-        <>
+        <VStack gap="5">
             <TilbakeTidslinje rader={tidslinjeRader} onSelectPeriode={onSelectPeriode} />
 
             {!!valgtPeriode && (
-                <>
-                    <Spacer20 />
-
-                    <FeilutbetalingForeldelsePeriodeSkjema
-                        behandling={behandling}
-                        periode={valgtPeriode}
-                        erLesevisning={erLesevisning}
-                    />
-                </>
+                <FeilutbetalingForeldelsePeriodeSkjema
+                    behandling={behandling}
+                    periode={valgtPeriode}
+                    erLesevisning={erLesevisning}
+                />
             )}
-            <Spacer20 />
             <Navigering>
                 {erAutoutført || (stegErBehandlet && erLesevisning) ? (
                     <FTButton variant="primary" onClick={gåTilNeste}>
@@ -131,7 +127,7 @@ const FeilutbetalingForeldelsePerioder: React.FC<IProps> = ({
                     Forrige
                 </FTButton>
             </Navigering>
-        </>
+        </VStack>
     ) : null;
 };
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 
-import { Column, Row } from 'nav-frontend-grid';
-
 import { type Periode } from '@navikt/familie-tidslinje';
 
 import { Foreldelsevurdering } from '../../../../kodeverk';
@@ -100,53 +98,39 @@ const FeilutbetalingForeldelsePerioder: React.FC<IProps> = ({
 
     return perioder && tidslinjeRader ? (
         <>
-            <Row>
-                <Column xs="12">
-                    <TilbakeTidslinje rader={tidslinjeRader} onSelectPeriode={onSelectPeriode} />
-                </Column>
-            </Row>
+            <TilbakeTidslinje rader={tidslinjeRader} onSelectPeriode={onSelectPeriode} />
+
             {!!valgtPeriode && (
                 <>
                     <Spacer20 />
-                    <Row>
-                        <Column xs="12">
-                            <FeilutbetalingForeldelsePeriodeSkjema
-                                behandling={behandling}
-                                periode={valgtPeriode}
-                                erLesevisning={erLesevisning}
-                            />
-                        </Column>
-                    </Row>
+
+                    <FeilutbetalingForeldelsePeriodeSkjema
+                        behandling={behandling}
+                        periode={valgtPeriode}
+                        erLesevisning={erLesevisning}
+                    />
                 </>
             )}
             <Spacer20 />
-            <Row>
-                <Column md="12">
-                    <Navigering>
-                        <div>
-                            {erAutoutført || (stegErBehandlet && erLesevisning) ? (
-                                <FTButton variant="primary" onClick={gåTilNeste}>
-                                    Neste
-                                </FTButton>
-                            ) : (
-                                <FTButton
-                                    variant="primary"
-                                    onClick={sendInnSkjema}
-                                    loading={senderInn}
-                                    disabled={disableBekreft}
-                                >
-                                    {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
-                                </FTButton>
-                            )}
-                        </div>
-                        <div>
-                            <FTButton variant="secondary" onClick={gåTilForrige}>
-                                Forrige
-                            </FTButton>
-                        </div>
-                    </Navigering>
-                </Column>
-            </Row>
+            <Navigering>
+                {erAutoutført || (stegErBehandlet && erLesevisning) ? (
+                    <FTButton variant="primary" onClick={gåTilNeste}>
+                        Neste
+                    </FTButton>
+                ) : (
+                    <FTButton
+                        variant="primary"
+                        onClick={sendInnSkjema}
+                        loading={senderInn}
+                        disabled={disableBekreft}
+                    >
+                        {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
+                    </FTButton>
+                )}
+                <FTButton variant="secondary" onClick={gåTilForrige}>
+                    Forrige
+                </FTButton>
+            </Navigering>
         </>
     ) : null;
 };

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -89,7 +89,7 @@ const VergeContainer: React.FC = () => {
                             ))}
                     </Select>
                     {vergetypeValgt && (
-                        <HGrid columns={{ lg: 2, md: 1 }} gap="4">
+                        <HGrid columns={{ lg: 2, md: 1 }} gap="4" align="start">
                             <TextField
                                 {...skjema.felter.navn.hentNavInputProps(skjema.visFeilmeldinger)}
                                 label={'Navn'}

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -11,12 +11,13 @@ import {
     Select,
     Textarea,
     TextField,
+    VStack,
 } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Vergetype, vergetyper } from '../../../kodeverk/verge';
 import { hentFrontendFeilmelding } from '../../../utils';
-import { FTButton, Navigering, Spacer20, Spacer8 } from '../../Felleskomponenter/Flytelementer';
+import { FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
 import { useVerge } from './VergeContext';
 
@@ -24,7 +25,7 @@ const StyledVerge = styled.div`
     padding: 10px;
 `;
 
-const Container = styled.div`
+const StyledVStack = styled(VStack)`
     max-width: 30rem;
 `;
 
@@ -58,9 +59,9 @@ const VergeContainer: React.FC = () => {
                     />
                 </div>
             ) : (
-                <Container>
+                <StyledVStack gap="5">
                     {erAutoutført && (
-                        <BodyLong size="small" spacing>
+                        <BodyLong size="small">
                             Automatisk vurdert. Verge er kopiert fra fagsystemet.
                         </BodyLong>
                     )}
@@ -68,7 +69,6 @@ const VergeContainer: React.FC = () => {
                         behandletSteg={stegErBehandlet}
                         infotekst={'Fyll ut og kontroller vergeopplysninger'}
                     />
-                    <Spacer20 />
                     <Select
                         {...skjema.felter.vergetype.hentNavInputProps(skjema.visFeilmeldinger)}
                         id="vergeType"
@@ -89,53 +89,47 @@ const VergeContainer: React.FC = () => {
                             ))}
                     </Select>
                     {vergetypeValgt && (
-                        <>
-                            <Spacer8 />
-                            <HGrid columns={{ lg: 2, md: 1 }} gap="4">
+                        <HGrid columns={{ lg: 2, md: 1 }} gap="4">
+                            <TextField
+                                {...skjema.felter.navn.hentNavInputProps(skjema.visFeilmeldinger)}
+                                label={'Navn'}
+                                readOnly={erLesevisning}
+                                value={skjema.felter.navn.verdi}
+                                onChange={event =>
+                                    skjema.felter.navn.validerOgSettFelt(event.target.value)
+                                }
+                            />
+                            {skjema.felter.vergetype.verdi === Vergetype.ADVOKAT ? (
                                 <TextField
-                                    {...skjema.felter.navn.hentNavInputProps(
+                                    {...skjema.felter.organisasjonsnummer.hentNavInputProps(
                                         skjema.visFeilmeldinger
                                     )}
-                                    label={'Navn'}
+                                    label={'Organisasjonsnummer'}
                                     readOnly={erLesevisning}
-                                    value={skjema.felter.navn.verdi}
+                                    value={skjema.felter.organisasjonsnummer.verdi}
                                     onChange={event =>
-                                        skjema.felter.navn.validerOgSettFelt(event.target.value)
+                                        skjema.felter.organisasjonsnummer.validerOgSettFelt(
+                                            event.target.value
+                                        )
                                     }
                                 />
-                                {skjema.felter.vergetype.verdi === Vergetype.ADVOKAT ? (
-                                    <TextField
-                                        {...skjema.felter.organisasjonsnummer.hentNavInputProps(
-                                            skjema.visFeilmeldinger
-                                        )}
-                                        label={'Organisasjonsnummer'}
-                                        readOnly={erLesevisning}
-                                        value={skjema.felter.organisasjonsnummer.verdi}
-                                        onChange={event =>
-                                            skjema.felter.organisasjonsnummer.validerOgSettFelt(
-                                                event.target.value
-                                            )
-                                        }
-                                    />
-                                ) : (
-                                    <TextField
-                                        {...skjema.felter.fødselsnummer.hentNavInputProps(
-                                            skjema.visFeilmeldinger
-                                        )}
-                                        label={'Fødselsnummer'}
-                                        readOnly={erLesevisning}
-                                        value={skjema.felter.fødselsnummer.verdi}
-                                        onChange={event =>
-                                            skjema.felter.fødselsnummer.validerOgSettFelt(
-                                                event.target.value
-                                            )
-                                        }
-                                    />
-                                )}
-                            </HGrid>
-                        </>
+                            ) : (
+                                <TextField
+                                    {...skjema.felter.fødselsnummer.hentNavInputProps(
+                                        skjema.visFeilmeldinger
+                                    )}
+                                    label={'Fødselsnummer'}
+                                    readOnly={erLesevisning}
+                                    value={skjema.felter.fødselsnummer.verdi}
+                                    onChange={event =>
+                                        skjema.felter.fødselsnummer.validerOgSettFelt(
+                                            event.target.value
+                                        )
+                                    }
+                                />
+                            )}
+                        </HGrid>
                     )}
-                    <Spacer20 />
                     <Textarea
                         {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
                         label={'Begrunn endringene'}
@@ -146,27 +140,17 @@ const VergeContainer: React.FC = () => {
                         }
                         maxLength={400}
                     />
-                    {feilmelding && (
-                        <>
-                            <Spacer8 />
-                            <div className="skjemaelement__feilmelding">
-                                <ErrorMessage size="small">{feilmelding}</ErrorMessage>
-                            </div>
-                        </>
-                    )}
-                    <Spacer20 />
+                    {feilmelding && <ErrorMessage size="small">{feilmelding}</ErrorMessage>}
                     <Navigering>
-                        <div>
-                            <FTButton
-                                variant="primary"
-                                onClick={sendInn}
-                                disabled={erLesevisning && !stegErBehandlet}
-                            >
-                                {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
-                            </FTButton>
-                        </div>
+                        <FTButton
+                            variant="primary"
+                            onClick={sendInn}
+                            disabled={erLesevisning && !stegErBehandlet}
+                        >
+                            {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
+                        </FTButton>
                     </Navigering>
-                </Container>
+                </StyledVStack>
             )}
         </StyledVerge>
     );

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -20,9 +20,10 @@ import { hentFrontendFeilmelding } from '../../../utils';
 import { FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
 import { useVerge } from './VergeContext';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 const StyledVerge = styled.div`
-    padding: 10px;
+    padding: ${ASpacing3};
 `;
 
 const StyledVStack = styled(VStack)`

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Column, Row } from 'nav-frontend-grid';
-
 import {
     BodyLong,
     ErrorMessage,
     Heading,
+    HGrid,
     Loader,
     Select,
     Textarea,
@@ -23,6 +22,10 @@ import { useVerge } from './VergeContext';
 
 const StyledVerge = styled.div`
     padding: 10px;
+`;
+
+const Container = styled.div`
+    max-width: 30rem;
 `;
 
 const VergeContainer: React.FC = () => {
@@ -55,7 +58,7 @@ const VergeContainer: React.FC = () => {
                     />
                 </div>
             ) : (
-                <>
+                <Container>
                     {erAutoutført && (
                         <BodyLong size="small" spacing>
                             Automatisk vurdert. Verge er kopiert fra fagsystemet.
@@ -66,99 +69,83 @@ const VergeContainer: React.FC = () => {
                         infotekst={'Fyll ut og kontroller vergeopplysninger'}
                     />
                     <Spacer20 />
-                    <Row>
-                        <Column sm="12" md="6" lg="3">
-                            <Select
-                                {...skjema.felter.vergetype.hentNavInputProps(
-                                    skjema.visFeilmeldinger
-                                )}
-                                id="vergeType"
-                                label={'Vergetype'}
-                                readOnly={erLesevisning}
-                                value={skjema.felter.vergetype.verdi}
-                                onChange={event => onChangeVergeType(event)}
-                            >
-                                <option disabled={true} value={''}>
-                                    Velg vergetype
+                    <Select
+                        {...skjema.felter.vergetype.hentNavInputProps(skjema.visFeilmeldinger)}
+                        id="vergeType"
+                        label={'Vergetype'}
+                        readOnly={erLesevisning}
+                        value={skjema.felter.vergetype.verdi}
+                        onChange={event => onChangeVergeType(event)}
+                    >
+                        <option disabled={true} value={''}>
+                            Velg vergetype
+                        </option>
+                        {Object.values(Vergetype)
+                            .filter(type => type !== Vergetype.UDEFINERT)
+                            .map(opt => (
+                                <option key={opt} value={opt}>
+                                    {vergetyper[opt]}
                                 </option>
-                                {Object.values(Vergetype)
-                                    .filter(type => type !== Vergetype.UDEFINERT)
-                                    .map(opt => (
-                                        <option key={opt} value={opt}>
-                                            {vergetyper[opt]}
-                                        </option>
-                                    ))}
-                            </Select>
-                        </Column>
-                    </Row>
+                            ))}
+                    </Select>
                     {vergetypeValgt && (
                         <>
                             <Spacer8 />
-                            <Row>
-                                <Column sm="12" md="6" lg="3">
+                            <HGrid columns={{ lg: 2, md: 1 }} gap="4">
+                                <TextField
+                                    {...skjema.felter.navn.hentNavInputProps(
+                                        skjema.visFeilmeldinger
+                                    )}
+                                    label={'Navn'}
+                                    readOnly={erLesevisning}
+                                    value={skjema.felter.navn.verdi}
+                                    onChange={event =>
+                                        skjema.felter.navn.validerOgSettFelt(event.target.value)
+                                    }
+                                />
+                                {skjema.felter.vergetype.verdi === Vergetype.ADVOKAT ? (
                                     <TextField
-                                        {...skjema.felter.navn.hentNavInputProps(
+                                        {...skjema.felter.organisasjonsnummer.hentNavInputProps(
                                             skjema.visFeilmeldinger
                                         )}
-                                        label={'Navn'}
+                                        label={'Organisasjonsnummer'}
                                         readOnly={erLesevisning}
-                                        value={skjema.felter.navn.verdi}
+                                        value={skjema.felter.organisasjonsnummer.verdi}
                                         onChange={event =>
-                                            skjema.felter.navn.validerOgSettFelt(event.target.value)
+                                            skjema.felter.organisasjonsnummer.validerOgSettFelt(
+                                                event.target.value
+                                            )
                                         }
                                     />
-                                </Column>
-                                <Column sm="12" md="6" lg="3">
-                                    {skjema.felter.vergetype.verdi === Vergetype.ADVOKAT ? (
-                                        <TextField
-                                            {...skjema.felter.organisasjonsnummer.hentNavInputProps(
-                                                skjema.visFeilmeldinger
-                                            )}
-                                            label={'Organisasjonsnummer'}
-                                            readOnly={erLesevisning}
-                                            value={skjema.felter.organisasjonsnummer.verdi}
-                                            onChange={event =>
-                                                skjema.felter.organisasjonsnummer.validerOgSettFelt(
-                                                    event.target.value
-                                                )
-                                            }
-                                        />
-                                    ) : (
-                                        <TextField
-                                            {...skjema.felter.fødselsnummer.hentNavInputProps(
-                                                skjema.visFeilmeldinger
-                                            )}
-                                            label={'Fødselsnummer'}
-                                            readOnly={erLesevisning}
-                                            value={skjema.felter.fødselsnummer.verdi}
-                                            onChange={event =>
-                                                skjema.felter.fødselsnummer.validerOgSettFelt(
-                                                    event.target.value
-                                                )
-                                            }
-                                        />
-                                    )}
-                                </Column>
-                            </Row>
+                                ) : (
+                                    <TextField
+                                        {...skjema.felter.fødselsnummer.hentNavInputProps(
+                                            skjema.visFeilmeldinger
+                                        )}
+                                        label={'Fødselsnummer'}
+                                        readOnly={erLesevisning}
+                                        value={skjema.felter.fødselsnummer.verdi}
+                                        onChange={event =>
+                                            skjema.felter.fødselsnummer.validerOgSettFelt(
+                                                event.target.value
+                                            )
+                                        }
+                                    />
+                                )}
+                            </HGrid>
                         </>
                     )}
                     <Spacer20 />
-                    <Row>
-                        <Column md="12" lg="6">
-                            <Textarea
-                                {...skjema.felter.begrunnelse.hentNavInputProps(
-                                    skjema.visFeilmeldinger
-                                )}
-                                label={'Begrunn endringene'}
-                                value={skjema.felter.begrunnelse.verdi}
-                                readOnly={erLesevisning}
-                                onChange={event =>
-                                    skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
-                                }
-                                maxLength={400}
-                            />
-                        </Column>
-                    </Row>
+                    <Textarea
+                        {...skjema.felter.begrunnelse.hentNavInputProps(skjema.visFeilmeldinger)}
+                        label={'Begrunn endringene'}
+                        value={skjema.felter.begrunnelse.verdi}
+                        readOnly={erLesevisning}
+                        onChange={event =>
+                            skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
+                        }
+                        maxLength={400}
+                    />
                     {feilmelding && (
                         <>
                             <Spacer8 />
@@ -168,22 +155,18 @@ const VergeContainer: React.FC = () => {
                         </>
                     )}
                     <Spacer20 />
-                    <Row>
-                        <Column xs="12" md="6">
-                            <Navigering>
-                                <div>
-                                    <FTButton
-                                        variant="primary"
-                                        onClick={sendInn}
-                                        disabled={erLesevisning && !stegErBehandlet}
-                                    >
-                                        {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
-                                    </FTButton>
-                                </div>
-                            </Navigering>
-                        </Column>
-                    </Row>
-                </>
+                    <Navigering>
+                        <div>
+                            <FTButton
+                                variant="primary"
+                                onClick={sendInn}
+                                disabled={erLesevisning && !stegErBehandlet}
+                            >
+                                {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
+                            </FTButton>
+                        </div>
+                    </Navigering>
+                </Container>
             )}
         </StyledVerge>
     );

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
@@ -23,9 +23,10 @@ import {
     useFeilutbetalingVilkårsvurdering,
 } from './FeilutbetalingVilkårsvurderingContext';
 import VilkårsvurderingPerioder from './VilkårsvurderingPerioder';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 const StyledVilkårsvurdering = styled.div`
-    padding: 10px;
+    padding: ${ASpacing3};
 `;
 
 const HenterContainer = styled(StyledVilkårsvurdering)`

--- a/src/frontend/komponenter/Felleskomponenter/Periodeinformasjon/PeriodeOppsummering.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Periodeinformasjon/PeriodeOppsummering.tsx
@@ -3,9 +3,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { styled } from 'styled-components';
 
-import { Column, Row } from 'nav-frontend-grid';
-
-import { BodyShort, Label } from '@navikt/ds-react';
+import { BodyShort, HGrid, Label } from '@navikt/ds-react';
 import {
     AFontWeightBold,
     AOrange100,
@@ -26,7 +24,7 @@ const StyledContainer = styled.div`
     margin-top: ${ASpacing3};
 `;
 
-const SumRad = styled(Row)`
+const RadTotaltFeilutbetalt = styled(HGrid)`
     margin-top: ${ASpacing5};
 
     .redNumber {
@@ -46,29 +44,19 @@ interface IProps {
 const PeriodeOppsummering: React.FC<IProps> = ({ fom, tom, beløp, hendelsetype }) => {
     return (
         <StyledContainer>
-            <Row>
-                <Column xs="7">
-                    <Label size="small">{`${formatterDatostring(fom)} - ${formatterDatostring(
-                        tom
-                    )}`}</Label>
-                </Column>
-                <Column xs="5">
-                    <BodyShort size="small">{hentPeriodelengde(fom, tom)}</BodyShort>
-                </Column>
-            </Row>
-            <SumRad>
-                <Column xs="7">
-                    <BodyShort size="small">
-                        Feilutbetaling:
-                        <span className={classNames('redNumber')}>{formatCurrencyNoKr(beløp)}</span>
-                    </BodyShort>
-                </Column>
-                <Column xs="5">
-                    {hendelsetype && (
-                        <BodyShort size="small">{hendelsetyper[hendelsetype]}</BodyShort>
-                    )}
-                </Column>
-            </SumRad>
+            <HGrid columns={2} gap="4">
+                <Label size="small">{`${formatterDatostring(fom)} - ${formatterDatostring(
+                    tom
+                )}`}</Label>
+                <BodyShort size="small">{hentPeriodelengde(fom, tom)}</BodyShort>
+            </HGrid>
+            <RadTotaltFeilutbetalt columns={2} gap="4">
+                <BodyShort size="small">
+                    Feilutbetaling:
+                    <span className={classNames('redNumber')}>{formatCurrencyNoKr(beløp)}</span>
+                </BodyShort>
+                {hendelsetype && <BodyShort size="small">{hendelsetyper[hendelsetype]}</BodyShort>}
+            </RadTotaltFeilutbetalt>
         </StyledContainer>
     );
 };


### PR DESCRIPTION
Del 1 av denne oppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-18314

Skriver oss bort fra `nav-frontend-grid` komponenter på Verge, Fakta og Foreldelse-stegene. Tar resten i en egen PR, så det ikke blir alt for stort.

Noen steder kunne vi bare slette komponentene uten at det påvirket stylingen, mens andre steder har jeg måttet bytte det ut med primitiver fra Aksel. Syns selv koden ble mye mer lesbar!

Tror jeg ville ha lest alt i ett og ikke commit for commit. Ble litt mye endringer på en komponent, men det er total diff jeg tror er best å lese. Legger ved skjermbilder til hver fil. Noen steder ser det ut som flere endringer fordi jeg har flyttet litt på hvor ulike komponenter ligger, for at det skal bli riktig oppbygning med `HGrid`/`HStack`/`VStack` - resultatet visuelt skal være likt som før.