### PR TITLE
Chore: skru på eslint-error ved feil import-order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
         "import/default": "error",
         "import/export": "error",
         "import/order": [
-            "off",
+            "error",
             {
                 "alphabetize": {
                     "order": "asc",
@@ -75,11 +75,6 @@
                         "pattern": "react",
                         "group": "external",
                         "position": "before"
-                    },
-                    {
-                        "pattern": "nav-**",
-                        "group": "external",
-                        "position": "after"
                     },
                     {
                         "pattern": "@navikt/**",

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -13,7 +13,6 @@ import webpackHotMiddleware from 'webpack-hot-middleware';
 import backend, { IApp, ensureAuthenticated, envVar } from '@navikt/familie-backend';
 import { logInfo } from '@navikt/familie-logging';
 
-import config from '../../src/webpack/webpack.dev';
 import { oboHistorikkConfig, oboTilbakeConfig, sessionConfig } from './config';
 import { prometheusTellere } from './metrikker';
 import {
@@ -25,6 +24,7 @@ import {
     doRedirectProxy,
 } from './proxy';
 import setupRouter from './router';
+import config from '../../src/webpack/webpack.dev';
 
 const port = 8000;
 

--- a/src/dev-server/mock-routes.ts
+++ b/src/dev-server/mock-routes.ts
@@ -4,24 +4,6 @@ import { Request, Response, Router } from 'express';
 
 import { byggFeiletRessurs, byggSuksessRessurs, RessursStatus } from '@navikt/familie-typer';
 
-import {
-    Aktsomhet,
-    Foreldelsevurdering,
-    HendelseType,
-    HendelseUndertype,
-    SærligeGrunner,
-    Vilkårsresultat,
-} from '../frontend/kodeverk';
-import {
-    FaktaPeriode,
-    ForeldelsePeriode,
-    IFeilutbetalingFakta,
-    IFeilutbetalingForeldelse,
-    IFeilutbetalingVilkårsvurdering,
-    Periode,
-    VilkårsresultatInfo,
-    VilkårsvurderingPeriode,
-} from '../frontend/typer/feilutbetalingtyper';
 import { fagsak_ba2, ba_behandling_4, ba_behandling_5 } from './mock/ba2/BA_fagsak_2';
 import {
     fagsak_ba3,
@@ -70,6 +52,24 @@ import {
     feilutbetalingVilkårsvurdering_ubehandlet_3,
     feilutbetalingVilkårsvurdering_ubehandlet_4,
 } from './mock/vilkårsvurdering/feilutbetalingVilkårsvurdering_ubehandlet';
+import {
+    Aktsomhet,
+    Foreldelsevurdering,
+    HendelseType,
+    HendelseUndertype,
+    SærligeGrunner,
+    Vilkårsresultat,
+} from '../frontend/kodeverk';
+import {
+    FaktaPeriode,
+    ForeldelsePeriode,
+    IFeilutbetalingFakta,
+    IFeilutbetalingForeldelse,
+    IFeilutbetalingVilkårsvurdering,
+    Periode,
+    VilkårsresultatInfo,
+    VilkårsvurderingPeriode,
+} from '../frontend/typer/feilutbetalingtyper';
 
 const behandleFaktaPerioder = (
     perioder: FaktaPeriode[],

--- a/src/dev-server/mock-server.ts
+++ b/src/dev-server/mock-server.ts
@@ -4,8 +4,8 @@ import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 
-import config from '../../src/webpack/webpack.dev';
 import { setupRouter } from './mock-routes';
+import config from '../../src/webpack/webpack.dev';
 
 const port = 8008;
 

--- a/src/frontend/context/BehandlingContext.tsx
+++ b/src/frontend/context/BehandlingContext.tsx
@@ -12,6 +12,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { useFagsak } from './FagsakContext';
 import {
     Behandlingssteg,
     Behandlingsstegstatus,
@@ -20,7 +21,6 @@ import {
     IBehandlingsstegstilstand,
 } from '../typer/behandling';
 import { IFagsak } from '../typer/fagsak';
-import { useFagsak } from './FagsakContext';
 
 const erStegUtført = (status: Behandlingsstegstatus) => {
     return status === Behandlingsstegstatus.UTFØRT || status === Behandlingsstegstatus.AUTOUTFØRT;

--- a/src/frontend/komponenter/App.tsx
+++ b/src/frontend/komponenter/App.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import '@navikt/ds-css';
 import { type ISaksbehandler } from '@navikt/familie-typer';
 
-import { hentInnloggetBruker } from '../api/saksbehandler';
-import { AppProvider } from '../context/AppContext';
 import Container from './Container';
 import ErrorBoundary from './Felleskomponenter/ErrorBoundary/ErrorBoundary';
+import { hentInnloggetBruker } from '../api/saksbehandler';
+import { AppProvider } from '../context/AppContext';
 
 const App: React.FC = () => {
     const [autentisertSaksbehandler, settAutentisertSaksbehandler] = React.useState<

--- a/src/frontend/komponenter/Container.tsx
+++ b/src/frontend/komponenter/Container.tsx
@@ -2,15 +2,15 @@ import * as React from 'react';
 
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
-import { useApp } from '../context/AppContext';
-import { BehandlingProvider } from '../context/BehandlingContext';
-import { FagsakProvider } from '../context/FagsakContext';
 import FagsakContainer from './Fagsak/FagsakContainer';
 import Dashboard from './Felleskomponenter/Dashboard';
 import Feilmelding from './Felleskomponenter/Feilmelding';
 import FTHeader from './Felleskomponenter/FTHeader/FTHeader';
 import UgyldigSesjon from './Felleskomponenter/Modal/SesjonUtløpt';
 import Toasts from './Felleskomponenter/Toast/Toasts';
+import { useApp } from '../context/AppContext';
+import { BehandlingProvider } from '../context/BehandlingContext';
+import { FagsakProvider } from '../context/FagsakContext';
 
 const Container: React.FC = () => {
     const { autentisert, innloggetSaksbehandler } = useApp();

--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -6,14 +6,6 @@ import { styled } from 'styled-components';
 import { BodyShort } from '@navikt/ds-react';
 import { ABorderDefault, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
-import { useBehandling } from '../../context/BehandlingContext';
-import { Behandlingstatus, IBehandling } from '../../typer/behandling';
-import { IFagsak } from '../../typer/fagsak';
-import {
-    erØnsketSideTilgjengelig,
-    finnSideAktivtSteg,
-} from '../Felleskomponenter/Venstremeny/sider';
-import Venstremeny from '../Felleskomponenter/Venstremeny/Venstremeny';
 import BrevmottakerContainer from './Brevmottaker/BrevmottakerContainer';
 import { BrevmottakerProvider } from './Brevmottaker/BrevmottakerContext';
 import FaktaContainer from './Fakta/FaktaContainer';
@@ -27,6 +19,14 @@ import VergeContainer from './Verge/VergeContainer';
 import { VergeProvider } from './Verge/VergeContext';
 import { FeilutbetalingVilkårsvurderingProvider } from './Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext';
 import VilkårsvurderingContainer from './Vilkårsvurdering/VilkårsvurderingContainer';
+import { useBehandling } from '../../context/BehandlingContext';
+import { Behandlingstatus, IBehandling } from '../../typer/behandling';
+import { IFagsak } from '../../typer/fagsak';
+import {
+    erØnsketSideTilgjengelig,
+    finnSideAktivtSteg,
+} from '../Felleskomponenter/Venstremeny/sider';
+import Venstremeny from '../Felleskomponenter/Venstremeny/Venstremeny';
 
 const BEHANDLING_KONTEKST_PATH = '/behandling/:behandlingId';
 

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/Brevmottaker.tsx
@@ -7,9 +7,9 @@ import { Button, Heading } from '@navikt/ds-react';
 import { AFontWeightBold } from '@navikt/ds-tokens/dist/tokens';
 import CountryData from '@navikt/land-verktoy';
 
+import { useBrevmottaker } from './BrevmottakerContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { IBrevmottaker, MottakerType, mottakerTypeVisningsnavn } from '../../../typer/Brevmottaker';
-import { useBrevmottaker } from './BrevmottakerContext';
 
 const FlexDiv = styled.div`
     display: flex;

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerContainer.tsx
@@ -5,11 +5,11 @@ import { styled } from 'styled-components';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, Heading } from '@navikt/ds-react';
 
-import { useBehandling } from '../../../context/BehandlingContext';
-import { MottakerType } from '../../../typer/Brevmottaker';
 import Brevmottaker from './Brevmottaker';
 import { useBrevmottaker } from './BrevmottakerContext';
 import { LeggTilEndreBrevmottakerModal } from './LeggTilEndreBrevmottakerModal';
+import { useBehandling } from '../../../context/BehandlingContext';
+import { MottakerType } from '../../../typer/Brevmottaker';
 
 const StyledBrevmottaker = styled.div`
     padding: 2.5rem;

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -7,8 +7,8 @@ import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import CountrySelect from '@navikt/landvelger';
 
-import { MottakerType } from '../../../typer/Brevmottaker';
 import { useBrevmottaker } from './BrevmottakerContext';
+import { MottakerType } from '../../../typer/Brevmottaker';
 
 const PostnummerOgStedContainer = styled.div`
     display: grid;

--- a/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/LeggTilEndreBrevmottakerModal.tsx
@@ -6,6 +6,8 @@ import { Button, Fieldset, Modal, Radio, RadioGroup, Select, TextField } from '@
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { useBrevmottaker } from './BrevmottakerContext';
+import BrevmottakerSkjema from './BrevmottakerSkjema';
 import { useBehandling } from '../../../context/BehandlingContext';
 import {
     AdresseKilde,
@@ -14,8 +16,6 @@ import {
     mottakerTypeVisningsnavn,
 } from '../../../typer/Brevmottaker';
 import { hentFrontendFeilmelding } from '../../../utils';
-import { useBrevmottaker } from './BrevmottakerContext';
-import BrevmottakerSkjema from './BrevmottakerSkjema';
 
 const FlexContainer = styled.div`
     display: flex;

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -6,6 +6,8 @@ import { styled } from 'styled-components';
 import { Alert } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import BehandlingContainer from './BehandlingContainer';
+import Personlinje from './Personlinje/Personlinje';
 import { useBehandling } from '../../context/BehandlingContext';
 import { useFagsak } from '../../context/FagsakContext';
 import { Fagsystem } from '../../kodeverk';
@@ -14,8 +16,6 @@ import { formatterDatostring } from '../../utils';
 import { FTAlertStripe } from '../Felleskomponenter/Flytelementer';
 import HenterBehandling from '../Felleskomponenter/Modal/HenterBehandling';
 import PåVentModal from '../Felleskomponenter/Modal/PåVent/PåVentModal';
-import BehandlingContainer from './BehandlingContainer';
-import Personlinje from './Personlinje/Personlinje';
 
 const FagsakContainerContent = styled.div`
     display: flex;

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.test.tsx
@@ -6,6 +6,8 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import FaktaContainer from './FaktaContainer';
+import { FeilutbetalingFaktaProvider } from './FeilutbetalingFaktaContext';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { HendelseType, HendelseUndertype, Ytelsetype } from '../../../kodeverk';
@@ -16,8 +18,6 @@ import {
     IFeilutbetalingFakta,
     Tilbakekrevingsvalg,
 } from '../../../typer/feilutbetalingtyper';
-import FaktaContainer from './FaktaContainer';
-import { FeilutbetalingFaktaProvider } from './FeilutbetalingFaktaContext';
 
 jest.mock('../../../context/BehandlingContext', () => ({
     useBehandling: jest.fn(),

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.tsx
@@ -6,12 +6,12 @@ import { Alert, BodyLong, Heading, Loader } from '@navikt/ds-react';
 import { AFontWeightBold, ATextDanger, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import FaktaSkjema from './FaktaSkjema';
+import { useFeilutbetalingFakta } from './FeilutbetalingFaktaContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Ytelsetype } from '../../../kodeverk';
 import { Spacer20 } from '../../Felleskomponenter/Flytelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
-import FaktaSkjema from './FaktaSkjema';
-import { useFeilutbetalingFakta } from './FeilutbetalingFaktaContext';
 
 const StyledFeilutbetalingFakta = styled.div`
     padding: ${ASpacing3};

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaPeriode/FeilutbetalingFaktaPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaPeriode/FeilutbetalingFaktaPeriodeSkjema.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
 import classNames from 'classnames';
+import { styled } from 'styled-components';
 
 import { BodyShort, Select, Table, VStack } from '@navikt/ds-react';
+import { ASpacing1 } from '@navikt/ds-tokens/dist/tokens';
 
 import {
     hendelsetyper,
@@ -14,8 +16,6 @@ import {
 import { formatterDatostring, formatCurrencyNoKr } from '../../../../utils';
 import { useFeilutbetalingFakta } from '../FeilutbetalingFaktaContext';
 import { FaktaPeriodeSkjemaData } from '../typer/feilutbetalingFakta';
-import { styled } from 'styled-components';
-import { ASpacing1 } from '@navikt/ds-tokens/dist/tokens';
 
 const StyledVStack = styled(VStack)`
     margin-top: ${ASpacing1};

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaPeriode/FeilutbetalingFaktaPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaPeriode/FeilutbetalingFaktaPerioder.tsx
@@ -4,10 +4,10 @@ import { styled } from 'styled-components';
 
 import { Table } from '@navikt/ds-react';
 
+import FeilutbetalingFaktaPeriode from './FeilutbetalingFaktaPeriodeSkjema';
 import { HendelseType, hentHendelseTyper, Ytelsetype } from '../../../../kodeverk';
 import { useFeilutbetalingFakta } from '../FeilutbetalingFaktaContext';
 import { FaktaPeriodeSkjemaData } from '../typer/feilutbetalingFakta';
-import FeilutbetalingFaktaPeriode from './FeilutbetalingFaktaPeriodeSkjema';
 
 const StyledPeriodeTable = styled(Table)`
     td {

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 
 import { BodyShort, Checkbox, Heading, HGrid, Textarea, VStack } from '@navikt/ds-react';
 
-import { Ytelsetype } from '../../../kodeverk';
-import { IFeilutbetalingFakta } from '../../../typer/feilutbetalingtyper';
-import { formatterDatostring, formatCurrencyNoKr } from '../../../utils';
-import { DetailBold, FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 import FeilutbetalingFaktaPerioder from './FaktaPeriode/FeilutbetalingFaktaPerioder';
 import FaktaRevurdering from './FaktaRevurdering';
 import { useFeilutbetalingFakta } from './FeilutbetalingFaktaContext';
 import { FaktaSkjemaData } from './typer/feilutbetalingFakta';
+import { Ytelsetype } from '../../../kodeverk';
+import { IFeilutbetalingFakta } from '../../../typer/feilutbetalingtyper';
+import { formatterDatostring, formatCurrencyNoKr } from '../../../utils';
+import { DetailBold, FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 
 interface IProps {
     ytelse: Ytelsetype;

--- a/src/frontend/komponenter/Fagsak/Fakta/FeilutbetalingFaktaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FeilutbetalingFaktaContext.tsx
@@ -11,6 +11,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { FaktaPeriodeSkjemaData, FaktaSkjemaData, Feilmelding } from './typer/feilutbetalingFakta';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { HendelseType, HendelseUndertype } from '../../../kodeverk';
@@ -25,7 +26,6 @@ import {
     validerTekstMaksLengde,
 } from '../../../utils';
 import { sider } from '../../Felleskomponenter/Venstremeny/sider';
-import { FaktaPeriodeSkjemaData, FaktaSkjemaData, Feilmelding } from './typer/feilutbetalingFakta';
 
 const _validerTekst3000 = validerTekstMaksLengde(3000);
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
@@ -11,6 +11,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { ForeldelsePeriodeSkjemeData } from './typer/feilutbetalingForeldelse';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Foreldelsevurdering } from '../../../kodeverk';
@@ -20,7 +21,6 @@ import { IFagsak } from '../../../typer/fagsak';
 import { IFeilutbetalingForeldelse } from '../../../typer/feilutbetalingtyper';
 import { sorterFeilutbetaltePerioder } from '../../../utils';
 import { sider } from '../../Felleskomponenter/Venstremeny/sider';
-import { ForeldelsePeriodeSkjemeData } from './typer/feilutbetalingForeldelse';
 
 interface IProps {
     behandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
@@ -6,14 +6,14 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import { FeilutbetalingForeldelseProvider } from './FeilutbetalingForeldelseContext';
+import ForeldelseContainer from './ForeldelseContainer';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Foreldelsevurdering } from '../../../kodeverk';
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { ForeldelsePeriode, IFeilutbetalingForeldelse } from '../../../typer/feilutbetalingtyper';
-import { FeilutbetalingForeldelseProvider } from './FeilutbetalingForeldelseContext';
-import ForeldelseContainer from './ForeldelseContainer';
 
 jest.setTimeout(10000);
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
@@ -3,16 +3,16 @@ import * as React from 'react';
 import { styled } from 'styled-components';
 
 import { Alert, BodyLong, BodyShort, Heading, Loader } from '@navikt/ds-react';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { useFeilutbetalingForeldelse } from './FeilutbetalingForeldelseContext';
+import FeilutbetalingForeldelsePerioder from './ForeldelsePeriode/FeilutbetalingForeldelsePerioder';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { IBehandling } from '../../../typer/behandling';
 import { finnDatoRelativtTilNå } from '../../../utils';
 import { FTButton, Navigering, Spacer20 } from '../../Felleskomponenter/Flytelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
-import { useFeilutbetalingForeldelse } from './FeilutbetalingForeldelseContext';
-import FeilutbetalingForeldelsePerioder from './ForeldelsePeriode/FeilutbetalingForeldelsePerioder';
-import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 export const getDate = (): string => {
     return finnDatoRelativtTilNå({ months: -30 });

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.test.tsx
@@ -4,10 +4,10 @@ import { render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { mock } from 'jest-mock-extended';
 
+import FeilutbetalingForeldelsePeriodeSkjema from './FeilutbetalingForeldelsePeriodeSkjema';
 import { Foreldelsevurdering } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
-import FeilutbetalingForeldelsePeriodeSkjema from './FeilutbetalingForeldelsePeriodeSkjema';
 
 jest.mock('@navikt/familie-http', () => {
     return {

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { styled } from 'styled-components';
+
 import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import {
     BodyLong,
@@ -16,22 +18,21 @@ import {
 } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
+import { useForeldelsePeriodeSkjema } from './ForeldelsePeriodeSkjemaContext';
+import SplittPeriode from './SplittPeriode/SplittPeriode';
 import {
     Foreldelsevurdering,
     foreldelsevurderinger,
     foreldelseVurderingTyper,
 } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
+import { isoStringTilDate } from '../../../../utils/dato';
+import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
 import { FTButton, Navigering } from '../../../Felleskomponenter/Flytelementer';
 import PeriodeOppsummering from '../../../Felleskomponenter/Periodeinformasjon/PeriodeOppsummering';
 import PeriodeController from '../../../Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
 import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
-import { useForeldelsePeriodeSkjema } from './ForeldelsePeriodeSkjemaContext';
-import SplittPeriode from './SplittPeriode/SplittPeriode';
-import { isoStringTilDate } from '../../../../utils/dato';
-import Datovelger from '../../../Felleskomponenter/Datovelger/Datovelger';
-import { styled } from 'styled-components';
 
 const StyledVStack = styled(VStack)`
     max-width: 50rem;

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/ForeldelsePeriodeSkjemaContext.tsx
@@ -9,8 +9,8 @@ import {
 
 import { Foreldelsevurdering } from '../../../../kodeverk';
 import { erFeltetEmpty, validerGyldigDato, validerTekstFeltMaksLengde } from '../../../../utils';
-import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
 import { dateTilIsoDatoStringEllerUndefined } from '../../../../utils/dato';
+import { ForeldelsePeriodeSkjemeData } from '../typer/feilutbetalingForeldelse';
 
 const avhengigheterOppfyltForeldelsesfrist = (avhengigheter?: Avhengigheter) => {
     return (

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/SplittPeriode/SplittPeriode.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/SplittPeriode/SplittPeriode.test.tsx
@@ -6,9 +6,9 @@ import { mock } from 'jest-mock-extended';
 
 import { HttpProvider } from '@navikt/familie-http';
 
+import SplittPeriode from './SplittPeriode';
 import { IBehandling } from '../../../../../typer/behandling';
 import { ForeldelsePeriodeSkjemeData } from '../../typer/feilutbetalingForeldelse';
-import SplittPeriode from './SplittPeriode';
 
 describe('Tester: SplittPeriode - Foreldelse', () => {
     test('Tester åpning av modal', async () => {

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentlisting.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentlisting.tsx
@@ -5,9 +5,9 @@ import { styled } from 'styled-components';
 import { Alert, BodyLong, Loader } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { hentDatoRegistrertSendt } from '../../../../utils';
 import { useDokumentlisting } from './DokumentlistingContext';
 import JournalpostVisning from './Journalpostvisning';
+import { hentDatoRegistrertSendt } from '../../../../utils';
 
 const StyledContainer = styled.div`
     margin-top: 10px;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/HentDokument.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/HentDokument.tsx
@@ -12,9 +12,9 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { useDokumentlisting } from './DokumentlistingContext';
 import { base64ToArrayBuffer } from '../../../../utils';
 import PdfVisningModal from '../../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
-import { useDokumentlisting } from './DokumentlistingContext';
 
 interface IProps {
     journalpost: IJournalpost;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Journalpostvisning.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Journalpostvisning.tsx
@@ -6,9 +6,9 @@ import { Detail } from '@navikt/ds-react';
 import { AGray400, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { type IJournalpost, Journalposttype } from '@navikt/familie-typer';
 
+import Dokumentvisning from './Dokumentvisning';
 import { formatterDatoOgTid, hentDatoRegistrertSendt } from '../../../../utils';
 import { DokumentIkon } from '../../../Felleskomponenter/Ikoner';
-import Dokumentvisning from './Dokumentvisning';
 
 const Journalpost = styled.div`
     display: flex;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HentDokument.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HentDokument.tsx
@@ -10,10 +10,10 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { useHistorikk } from './HistorikkContext';
 import { IHistorikkInnslag } from '../../../../typer/historikk';
 import { base64ToArrayBuffer } from '../../../../utils';
 import PdfVisningModal from '../../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
-import { useHistorikk } from './HistorikkContext';
 
 interface IProps {
     innslag: IHistorikkInnslag;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/HistorikkInnslag.tsx
@@ -6,6 +6,8 @@ import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { BodyLong, BodyShort, Detail, Label, Link } from '@navikt/ds-react';
 import { AGray400, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 
+import HentDokument from './HentDokument';
+import { useHistorikk } from './HistorikkContext';
 import { Behandlingssteg } from '../../../../typer/behandling';
 import {
     Aktør,
@@ -17,8 +19,6 @@ import {
 import { formatterDatoOgTidstring } from '../../../../utils';
 import { BeslutterIkon, SaksbehandlerIkon, SystemIkon } from '../../../Felleskomponenter/Ikoner/';
 import { finnSideForSteg } from '../../../Felleskomponenter/Venstremeny/sider';
-import HentDokument from './HentDokument';
-import { useHistorikk } from './HistorikkContext';
 
 const Innslag = styled.div`
     display: flex;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Høyremeny.tsx
@@ -13,11 +13,11 @@ import {
 import { Button, Tabs } from '@navikt/ds-react';
 import { AFontSizeMedium, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
+import Behandlingskort from './Behandlingskort/Behandlingskort';
+import Menykontainer, { Menysider } from './Menykontainer';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
-import Behandlingskort from './Behandlingskort/Behandlingskort';
-import Menykontainer, { Menysider } from './Menykontainer';
 
 const StyledContainer = styled.div<{ $værtPåFatteVedtakSteget: boolean }>`
     width: ${({ $værtPåFatteVedtakSteget }) => ($værtPåFatteVedtakSteget ? '28rem' : '22rem')};

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Menykontainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Menykontainer.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { IBehandling } from '../../../typer/behandling';
-import { IFagsak } from '../../../typer/fagsak';
 import Dokumentlisting from './Dokumentlisting/Dokumentlisting';
 import { DokumentlistingProvider } from './Dokumentlisting/DokumentlistingContext';
 import Historikk from './Historikk/Historikk';
@@ -10,6 +8,8 @@ import SendMelding from './SendMelding/SendMelding';
 import { SendMeldingProvider } from './SendMelding/SendMeldingContext';
 import Totrinnskontroll from './Totrinnskontroll/Totrinnskontroll';
 import { TotrinnskontrollProvider } from './Totrinnskontroll/TotrinnskontrollContext';
+import { IBehandling } from '../../../typer/behandling';
+import { IFagsak } from '../../../typer/fagsak';
 
 export enum Menysider {
     TOTRINN = `TOTRINN`,

--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/ForhåndsvisBrev/ForhåndsvisBrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/ForhåndsvisBrev/ForhåndsvisBrev.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
+import { useForhåndsvisBrev } from './useForhåndsvisBrev';
 import { FTButton } from '../../../../Felleskomponenter/Flytelementer';
 import PdfVisningModal from '../../../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
 import { useSendMelding } from '../SendMeldingContext';
-import { useForhåndsvisBrev } from './useForhåndsvisBrev';
 
 interface IProps {
     test?: boolean;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.test.tsx
@@ -6,13 +6,13 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import SendMelding from './SendMelding';
+import { SendMeldingProvider } from './SendMeldingContext';
 import { useDokumentApi } from '../../../../api/dokument';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { DokumentMal } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
 import { IFagsak, Målform } from '../../../../typer/fagsak';
-import SendMelding from './SendMelding';
-import { SendMeldingProvider } from './SendMeldingContext';
 
 jest.mock('@navikt/familie-http', () => {
     return {

--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { BodyShort, Heading, Select, Textarea } from '@navikt/ds-react';
 
+import ForhåndsvisBrev from './ForhåndsvisBrev/ForhåndsvisBrev';
+import { useSendMelding } from './SendMeldingContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { DokumentMal, dokumentMaler } from '../../../../kodeverk';
 import { IBehandling } from '../../../../typer/behandling';
@@ -9,8 +11,6 @@ import { IFagsak, målform } from '../../../../typer/fagsak';
 import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
 import BrevmottakerListe from '../../../Felleskomponenter/Hendelsesoversikt/BrevModul/BrevmottakerListe';
 import { LabelMedSpråk } from '../../../Felleskomponenter/Skjemaelementer';
-import ForhåndsvisBrev from './ForhåndsvisBrev/ForhåndsvisBrev';
-import { useSendMelding } from './SendMeldingContext';
 
 const tekstfeltLabel = (mal: DokumentMal) => {
     return mal === DokumentMal.INNHENT_DOKUMENTASJON

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.test.tsx
@@ -6,13 +6,13 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import Totrinnskontroll from './Totrinnskontroll';
+import { TotrinnskontrollProvider } from './TotrinnskontrollContext';
 import { useBehandlingApi } from '../../../../api/behandling';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { Behandlingssteg, IBehandling } from '../../../../typer/behandling';
 import { IFagsak } from '../../../../typer/fagsak';
 import { ITotrinnkontroll } from '../../../../typer/totrinnTyper';
-import Totrinnskontroll from './Totrinnskontroll';
-import { TotrinnskontrollProvider } from './TotrinnskontrollContext';
 
 jest.mock('../../../../context/BehandlingContext', () => ({
     useBehandling: jest.fn(),

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.tsx
@@ -5,12 +5,6 @@ import { styled } from 'styled-components';
 import { Alert, BodyShort, Label, Link, Radio, Textarea } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { behandlingssteg } from '../../../../typer/behandling';
-import ArrowBox from '../../../Felleskomponenter/ArrowBox/ArrowBox';
-import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
-import { HorisontalRadioGroup } from '../../../Felleskomponenter/Skjemaelementer';
-import Steginformasjon from '../../../Felleskomponenter/Steginformasjon/StegInformasjon';
-import { finnSideForSteg, ISide } from '../../../Felleskomponenter/Venstremeny/sider';
 import { useTotrinnskontroll } from './TotrinnskontrollContext';
 import {
     OptionGodkjent,
@@ -18,6 +12,12 @@ import {
     TotrinnGodkjenningOption,
     totrinnGodkjenningOptions,
 } from './typer/totrinnSkjemaTyper';
+import { behandlingssteg } from '../../../../typer/behandling';
+import ArrowBox from '../../../Felleskomponenter/ArrowBox/ArrowBox';
+import { FTButton, Navigering, Spacer20 } from '../../../Felleskomponenter/Flytelementer';
+import { HorisontalRadioGroup } from '../../../Felleskomponenter/Skjemaelementer';
+import Steginformasjon from '../../../Felleskomponenter/Steginformasjon/StegInformasjon';
+import { finnSideForSteg, ISide } from '../../../Felleskomponenter/Venstremeny/sider';
 
 const StyledContainer = styled.div`
     margin-top: 10px;

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/TotrinnskontrollContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/TotrinnskontrollContext.tsx
@@ -11,6 +11,12 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import {
+    OptionIkkeGodkjent,
+    TotrinnGodkjenningOption,
+    totrinnGodkjenningOptions,
+    TotrinnStegSkjemaData,
+} from './typer/totrinnSkjemaTyper';
 import { useBehandlingApi } from '../../../../api/behandling';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { FatteVedtakStegPayload, TotrinnsStegVurdering } from '../../../../typer/api';
@@ -19,12 +25,6 @@ import { IFagsak } from '../../../../typer/fagsak';
 import { ITotrinnkontroll } from '../../../../typer/totrinnTyper';
 import { validerTekstMaksLengde } from '../../../../utils';
 import { ISide } from '../../../Felleskomponenter/Venstremeny/sider';
-import {
-    OptionIkkeGodkjent,
-    TotrinnGodkjenningOption,
-    totrinnGodkjenningOptions,
-    TotrinnStegSkjemaData,
-} from './typer/totrinnSkjemaTyper';
 
 const finnTotrinnGodkjenningOption = (verdi?: boolean): TotrinnGodkjenningOption | '' => {
     const option = totrinnGodkjenningOptions.find(opt => opt.verdi === verdi);

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -7,20 +7,20 @@ import { Button, Popover } from '@navikt/ds-react';
 import { AFontSizeXlarge, AFontWeightBold } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useBehandling } from '../../../../context/BehandlingContext';
-import { Fagsystem } from '../../../../kodeverk';
-import { Behandlingssteg, Behandlingstatus } from '../../../../typer/behandling';
-import { IFagsak } from '../../../../typer/fagsak';
 import EndreBehandlendeEnhet from './EndreBehandlendeEnhet/EndreBehandlendeEnhet';
 import GjennoptaBehandling from './GjennoptaBehandling/GjennoptaBehandling';
 import HenleggBehandling from './HenleggBehandling/HenleggBehandling';
+import HentOppdatertKravgrunnlag from './hentOppdatertKravgrunnlag/HentOppdatertKravgrunnlag';
 import LeggTilFjernBrevmottakere from './LeggTilFjernBrevmottakere/LeggTilFjernBrevmottakere';
 import OpprettBehandling from './OpprettBehandling/OpprettBehandling';
 import OpprettFjernVerge from './OpprettFjernVerge/OpprettFjernVerge';
 import SettBehandlingPåVent from './SettBehandlingPåVent/SettBehandlingPåVent';
-import { useApp } from '../../../../context/AppContext';
-import HentOppdatertKravgrunnlag from './hentOppdatertKravgrunnlag/HentOppdatertKravgrunnlag';
 import SettBehandlingTilbakeTilFakta from './SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta';
+import { useApp } from '../../../../context/AppContext';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { Fagsystem } from '../../../../kodeverk';
+import { Behandlingssteg, Behandlingstatus } from '../../../../typer/behandling';
+import { IFagsak } from '../../../../typer/fagsak';
 
 const StyledList = styled.ul`
     list-style-type: none;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhet.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { ErrorMessage, Modal, Select, Textarea } from '@navikt/ds-react';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { useEndreBehandlendeEnhet } from './EndreBehandlendeEnhetContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { Ytelsetype } from '../../../../../kodeverk';
 import { IBehandling } from '../../../../../typer/behandling';
@@ -13,7 +14,6 @@ import {
     FTButton,
     Spacer8,
 } from '../../../../Felleskomponenter/Flytelementer';
-import { useEndreBehandlendeEnhet } from './EndreBehandlendeEnhetContext';
 
 interface IProps {
     ytelse: Ytelsetype;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev.tsx
@@ -6,10 +6,10 @@ import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { Detail, Link } from '@navikt/ds-react';
 import { type ISkjema } from '@navikt/familie-skjema';
 
+import { useForhåndsvisHenleggelsesbrev } from './useForhåndsvisHenleggelsesbrev';
 import { IBehandling } from '../../../../../../typer/behandling';
 import PdfVisningModal from '../../../../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
 import { HenleggelseSkjemaDefinisjon } from '../HenleggBehandlingModal/HenleggBehandlingModalContext';
-import { useForhåndsvisHenleggelsesbrev } from './useForhåndsvisHenleggelsesbrev';
 
 const StyledContainer = styled.div`
     margin-top: -5px;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandling.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
+import HenleggBehandlingModal from './HenleggBehandlingModal/HenleggBehandlingModal';
 import { Behandlingresultat, Behandlingstype, IBehandling } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
 import { BehandlingsMenyButton } from '../../../../Felleskomponenter/Flytelementer';
-import HenleggBehandlingModal from './HenleggBehandlingModal/HenleggBehandlingModal';
 
 const getÅrsaker = (behandling: IBehandling) => {
     if (behandling.type === Behandlingstype.TILBAKEKREVING) {

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.test.tsx
@@ -6,6 +6,7 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import HenleggBehandlingModal from './HenleggBehandlingModal';
 import { useBehandlingApi } from '../../../../../../api/behandling';
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import {
@@ -14,7 +15,6 @@ import {
     IBehandling,
 } from '../../../../../../typer/behandling';
 import { IFagsak, Målform } from '../../../../../../typer/fagsak';
-import HenleggBehandlingModal from './HenleggBehandlingModal';
 
 jest.mock('@navikt/familie-http', () => {
     return {

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import { Modal, Select, Textarea } from '@navikt/ds-react';
+
+import { useHenleggBehandlingSkjema } from './HenleggBehandlingModalContext';
 import {
     Behandlingresultat,
     behandlingsresultater,
@@ -7,10 +10,8 @@ import {
 } from '../../../../../../typer/behandling';
 import { IFagsak, målform } from '../../../../../../typer/fagsak';
 import { FTButton, Spacer20 } from '../../../../../Felleskomponenter/Flytelementer';
-import { Modal, Select, Textarea } from '@navikt/ds-react';
 import { LabelMedSpråk } from '../../../../../Felleskomponenter/Skjemaelementer';
 import ForhåndsvisHenleggelsesBrev from '../ForhåndsvisHenleggelsesbrev/ForhåndsvisHenleggelsesbrev';
-import { useHenleggBehandlingSkjema } from './HenleggBehandlingModalContext';
 
 interface IProps {
     behandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandling.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ErrorMessage, Modal, Select } from '@navikt/ds-react';
 
+import { useOpprettBehandlingSkjema } from './OpprettBehandlingSkjemaContext';
 import {
     Behandlingstype,
     behandlingstyper,
@@ -17,7 +18,6 @@ import {
     Spacer20,
     Spacer8,
 } from '../../../../Felleskomponenter/Flytelementer';
-import { useOpprettBehandlingSkjema } from './OpprettBehandlingSkjemaContext';
 
 interface IProps {
     behandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingPåVent/SettBehandlingPåVent.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
 
+import { addDays, addMonths } from 'date-fns';
+
 import { ErrorMessage, Modal, Select } from '@navikt/ds-react';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { IBehandling, manuelleVenteÅrsaker, venteårsaker } from '../../../../../typer/behandling';
+import { dagensDato } from '../../../../../utils/dato';
+import Datovelger from '../../../../Felleskomponenter/Datovelger/Datovelger';
 import {
     BehandlingsMenyButton,
     FTButton,
@@ -12,9 +16,6 @@ import {
     Spacer8,
 } from '../../../../Felleskomponenter/Flytelementer';
 import { usePåVentBehandling } from '../../../../Felleskomponenter/Modal/PåVent/PåVentContext';
-import { addDays, addMonths } from 'date-fns';
-import { dagensDato } from '../../../../../utils/dato';
-import Datovelger from '../../../../Felleskomponenter/Datovelger/Datovelger';
 
 interface IProps {
     behandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
@@ -4,10 +4,10 @@ import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
+import { useBehandling } from '../../../../../context/BehandlingContext';
 import { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingsMenyButton } from '../../../../Felleskomponenter/Flytelementer';
 import { AlertType, ToastTyper } from '../../../../Felleskomponenter/Toast/typer';
-import { useBehandling } from '../../../../../context/BehandlingContext';
 
 interface IProps {
     behandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/hentOppdatertKravgrunnlag/HentOppdatertKravgrunnlag.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/hentOppdatertKravgrunnlag/HentOppdatertKravgrunnlag.tsx
@@ -4,10 +4,10 @@ import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
+import { useBehandling } from '../../../../../context/BehandlingContext';
 import { IBehandling } from '../../../../../typer/behandling';
 import { BehandlingsMenyButton } from '../../../../Felleskomponenter/Flytelementer';
 import { AlertType, ToastTyper } from '../../../../Felleskomponenter/Toast/typer';
-import { useBehandling } from '../../../../../context/BehandlingContext';
 
 interface IProps {
     behandling: IBehandling;

--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -16,12 +16,12 @@ import {
 import { RessursStatus } from '@navikt/familie-typer';
 import { Visittkort } from '@navikt/familie-visittkort';
 
+import Behandlingsmeny from './Behandlingsmeny/Behandlingsmeny';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { useFagsak } from '../../../context/FagsakContext';
 import { IFagsak } from '../../../typer/fagsak';
 import { IPerson } from '../../../typer/person';
 import { formatterDatostring, hentAlder } from '../../../utils';
-import Behandlingsmeny from './Behandlingsmeny/Behandlingsmeny';
 
 const PlaceholderDiv = styled.div`
     flex: 1;

--- a/src/frontend/komponenter/Fagsak/Vedtak/AvsnittSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/AvsnittSkjema.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 
-import { BodyLong, ExpansionCard, Heading } from '@navikt/ds-react';
+import { css, styled } from 'styled-components';
 
-import { Avsnittstype, Underavsnittstype } from '../../../kodeverk';
-import { Spacer8 } from '../../Felleskomponenter/Flytelementer';
+import { BodyLong, ExpansionCard, Heading } from '@navikt/ds-react';
+import { ABorderWarning, ASpacing2 } from '@navikt/ds-tokens/dist/tokens';
+
 import { AvsnittSkjemaData } from './typer/feilutbetalingVedtak';
 import VedtakFritekstSkjema from './VedtakFritekstSkjema';
-import { css, styled } from 'styled-components';
-import { ABorderWarning, ASpacing2 } from '@navikt/ds-tokens/dist/tokens';
+import { Avsnittstype, Underavsnittstype } from '../../../kodeverk';
+import { Spacer8 } from '../../Felleskomponenter/Flytelementer';
 
 const StyledExpansionCard = styled(ExpansionCard)`
     margin-bottom: ${ASpacing2};

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetalingVedtakContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetalingVedtakContext.tsx
@@ -11,6 +11,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { AvsnittSkjemaData, UnderavsnittSkjemaData } from './typer/feilutbetalingVedtak';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useDokumentApi } from '../../../api/dokument';
 import { useBehandling } from '../../../context/BehandlingContext';
@@ -26,7 +27,6 @@ import { IFagsak } from '../../../typer/fagsak';
 import { IBeregningsresultat, VedtaksbrevAvsnitt } from '../../../typer/vedtakTyper';
 import { isEmpty, validerTekstMaksLengde } from '../../../utils';
 import { sider } from '../../Felleskomponenter/Venstremeny/sider';
-import { AvsnittSkjemaData, UnderavsnittSkjemaData } from './typer/feilutbetalingVedtak';
 
 const hentPerioderMedTekst = (skjemaData: AvsnittSkjemaData[]): PeriodeMedTekst[] => {
     // @ts-ignore - klager på periode men er trygt p.g.s. filtreringen

--- a/src/frontend/komponenter/Fagsak/Vedtak/ForhåndsvisVedtaksbrev/ForhåndsvisVedtaksbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/ForhåndsvisVedtaksbrev/ForhåndsvisVedtaksbrev.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
+import { useForhåndsvisVedtaksbrev } from './useForhåndsvisVedtaksbrev';
 import { FTButton } from '../../../Felleskomponenter/Flytelementer';
 import PdfVisningModal from '../../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
-import { useForhåndsvisVedtaksbrev } from './useForhåndsvisVedtaksbrev';
 
 interface IProps {
     test?: boolean;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.test.tsx
@@ -6,6 +6,8 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import { FeilutbetalingVedtakProvider } from './FeilutbetalingVedtakContext';
+import VedtakContainer from './VedtakContainer';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Avsnittstype, Underavsnittstype, Vedtaksresultat, Vurdering } from '../../../kodeverk';
@@ -16,8 +18,6 @@ import {
     IBeregningsresultat,
     VedtaksbrevAvsnitt,
 } from '../../../typer/vedtakTyper';
-import { FeilutbetalingVedtakProvider } from './FeilutbetalingVedtakContext';
-import VedtakContainer from './VedtakContainer';
 
 jest.mock('@navikt/familie-http', () => {
     return {

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
@@ -6,6 +6,11 @@ import { Alert, BodyLong, BodyShort, Heading, Loader } from '@navikt/ds-react';
 import { AFontWeightBold, ASpacing1, ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import { BrevmottakereAlert } from './BrevmottakereAlert';
+import { useFeilutbetalingVedtak } from './FeilutbetalingVedtakContext';
+import ForhåndsvisVedtaksbrev from './ForhåndsvisVedtaksbrev/ForhåndsvisVedtaksbrev';
+import VedtakPerioder from './VedtakPerioder';
+import VedtakSkjema from './VedtakSkjema';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { vedtaksresultater } from '../../../kodeverk';
 import {
@@ -17,11 +22,6 @@ import {
 import { IFagsak } from '../../../typer/fagsak';
 import { DetailBold, FTButton, Navigering, Spacer20 } from '../../Felleskomponenter/Flytelementer';
 import { sider } from '../../Felleskomponenter/Venstremeny/sider';
-import { BrevmottakereAlert } from './BrevmottakereAlert';
-import { useFeilutbetalingVedtak } from './FeilutbetalingVedtakContext';
-import ForhåndsvisVedtaksbrev from './ForhåndsvisVedtaksbrev/ForhåndsvisVedtaksbrev';
-import VedtakPerioder from './VedtakPerioder';
-import VedtakSkjema from './VedtakSkjema';
 
 const StyledVedtak = styled.div`
     padding: ${ASpacing3};

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
@@ -5,10 +5,10 @@ import { styled } from 'styled-components';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyShort, Link, Textarea } from '@navikt/ds-react';
 
-import { isEmpty, validerTekstMaksLengde } from '../../../utils';
-import { Spacer8 } from '../../Felleskomponenter/Flytelementer';
 import { useFeilutbetalingVedtak } from './FeilutbetalingVedtakContext';
 import { UnderavsnittSkjemaData } from './typer/feilutbetalingVedtak';
+import { isEmpty, validerTekstMaksLengde } from '../../../utils';
+import { Spacer8 } from '../../Felleskomponenter/Flytelementer';
 
 const StyledUndertekst = styled(BodyShort)`
     display: inline-block;

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.test.tsx
@@ -6,14 +6,14 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import VergeContainer from './VergeContainer';
+import { VergeProvider } from './VergeContext';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Vergetype } from '../../../kodeverk/verge';
 import { VergeDto } from '../../../typer/api';
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
-import VergeContainer from './VergeContainer';
-import { VergeProvider } from './VergeContext';
 
 jest.mock('@navikt/familie-http', () => {
     return {

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -13,14 +13,14 @@ import {
     TextField,
     VStack,
 } from '@navikt/ds-react';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
+import { useVerge } from './VergeContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Vergetype, vergetyper } from '../../../kodeverk/verge';
 import { hentFrontendFeilmelding } from '../../../utils';
 import { FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
-import { useVerge } from './VergeContext';
-import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 const StyledVerge = styled.div`
     padding: ${ASpacing3};

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
@@ -12,6 +12,7 @@ import {
     RessursStatus,
 } from '@navikt/familie-typer';
 
+import { VilkårsvurderingPeriodeSkjemaData } from './typer/feilutbetalingVilkårsvurdering';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Aktsomhet, Vilkårsresultat, Ytelsetype } from '../../../kodeverk';
@@ -29,7 +30,6 @@ import {
 } from '../../../typer/feilutbetalingtyper';
 import { sorterFeilutbetaltePerioder } from '../../../utils';
 import { sider } from '../../Felleskomponenter/Venstremeny/sider';
-import { VilkårsvurderingPeriodeSkjemaData } from './typer/feilutbetalingVilkårsvurdering';
 
 const erBehandlet = (periode: VilkårsvurderingPeriodeSkjemaData) => {
     return (

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.test.tsx
@@ -6,6 +6,8 @@ import { mock } from 'jest-mock-extended';
 
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import { FeilutbetalingVilkårsvurderingProvider } from './FeilutbetalingVilkårsvurderingContext';
+import VilkårsvurderingContainer from './VilkårsvurderingContainer';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Aktsomhet, HendelseType, Vilkårsresultat, Ytelsetype } from '../../../kodeverk';
@@ -15,8 +17,6 @@ import {
     IFeilutbetalingVilkårsvurdering,
     VilkårsvurderingPeriode,
 } from '../../../typer/feilutbetalingtyper';
-import { FeilutbetalingVilkårsvurderingProvider } from './FeilutbetalingVilkårsvurderingContext';
-import VilkårsvurderingContainer from './VilkårsvurderingContainer';
 
 jest.setTimeout(25000);
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
@@ -3,8 +3,14 @@ import * as React from 'react';
 import { styled } from 'styled-components';
 
 import { Alert, BodyLong, Heading, Loader, VStack } from '@navikt/ds-react';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
+import {
+    erTotalbeløpUnder4Rettsgebyr,
+    useFeilutbetalingVilkårsvurdering,
+} from './FeilutbetalingVilkårsvurderingContext';
+import VilkårsvurderingPerioder from './VilkårsvurderingPerioder';
 import { useBehandling } from '../../../context/BehandlingContext';
 import {
     Ytelsetype,
@@ -15,12 +21,6 @@ import {
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import Steginformasjon from '../../Felleskomponenter/Steginformasjon/StegInformasjon';
-import {
-    erTotalbeløpUnder4Rettsgebyr,
-    useFeilutbetalingVilkårsvurdering,
-} from './FeilutbetalingVilkårsvurderingContext';
-import VilkårsvurderingPerioder from './VilkårsvurderingPerioder';
-import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 const StyledVilkårsvurdering = styled.div`
     padding: ${ASpacing3};

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/AktsomhetsvurderingSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/AktsomhetsvurderingSkjema.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import { Radio, VStack } from '@navikt/ds-react';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
+import GradForsettSkjema from './GradForsettSkjema';
+import GradUaktsomhetSkjema from './GradUaktsomhetSkjema';
 import {
     Aktsomhet,
     aktsomheter,
@@ -15,8 +17,6 @@ import {
     OptionNEI,
     VilkårsvurderingSkjemaDefinisjon,
 } from '../VilkårsvurderingPeriodeSkjemaContext';
-import GradForsettSkjema from './GradForsettSkjema';
-import GradUaktsomhetSkjema from './GradUaktsomhetSkjema';
 
 interface IProps {
     skjema: ISkjema<VilkårsvurderingSkjemaDefinisjon, string>;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/GradForsettSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/GradForsettSkjema.tsx
@@ -5,11 +5,11 @@ import { styled } from 'styled-components';
 import { BodyShort, HGrid, Label } from '@navikt/ds-react';
 import { type ISkjema } from '@navikt/familie-skjema';
 
+import TilleggesRenterRadioGroup from './TilleggesRenterRadioGroup';
 import { Vilkårsresultat } from '../../../../../kodeverk';
 import ArrowBox from '../../../../Felleskomponenter/ArrowBox/ArrowBox';
 import { useFeilutbetalingVilkårsvurdering } from '../../FeilutbetalingVilkårsvurderingContext';
 import { VilkårsvurderingSkjemaDefinisjon } from '../VilkårsvurderingPeriodeSkjemaContext';
-import TilleggesRenterRadioGroup from './TilleggesRenterRadioGroup';
 
 const StyledNormaltekst = styled(BodyShort)`
     padding-top: 15px;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/GradUaktsomhetSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/GradUaktsomhetSkjema.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Radio } from '@navikt/ds-react';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
+import SærligeGrunnerSkjema from './SærligeGrunnerSkjema';
 import { Aktsomhet, Vilkårsresultat } from '../../../../../kodeverk';
 import ArrowBox from '../../../../Felleskomponenter/ArrowBox/ArrowBox';
 import { HorisontalRadioGroup } from '../../../../Felleskomponenter/Skjemaelementer';
@@ -13,7 +14,6 @@ import {
     OptionNEI,
     VilkårsvurderingSkjemaDefinisjon,
 } from '../VilkårsvurderingPeriodeSkjemaContext';
-import SærligeGrunnerSkjema from './SærligeGrunnerSkjema';
 
 interface IProps {
     skjema: ISkjema<VilkårsvurderingSkjemaDefinisjon, string>;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/ReduksjonAvBeløpSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/ReduksjonAvBeløpSkjema.tsx
@@ -14,6 +14,7 @@ import {
 } from '@navikt/ds-react';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
+import TilleggesRenterRadioGroup from './TilleggesRenterRadioGroup';
 import { Aktsomhet, Vilkårsresultat } from '../../../../../kodeverk';
 import { formatCurrencyNoKr, isEmpty } from '../../../../../utils';
 import ArrowBox from '../../../../Felleskomponenter/ArrowBox/ArrowBox';
@@ -28,7 +29,6 @@ import {
     OptionNEI,
     VilkårsvurderingSkjemaDefinisjon,
 } from '../VilkårsvurderingPeriodeSkjemaContext';
-import TilleggesRenterRadioGroup from './TilleggesRenterRadioGroup';
 
 const StyledNormaltekst = styled(BodyShort)`
     padding-top: 15px;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/SærligeGrunnerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/SærligeGrunnerSkjema.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { Checkbox, CheckboxGroup, Detail, Textarea, VStack } from '@navikt/ds-react';
 import { type ISkjema } from '@navikt/familie-skjema';
 
+import ReduksjonAvBeløpSkjema from './ReduksjonAvBeløpSkjema';
 import { SærligeGrunner, særligegrunner, særligeGrunnerTyper } from '../../../../../kodeverk';
 import { VilkårsvurderingSkjemaDefinisjon } from '../VilkårsvurderingPeriodeSkjemaContext';
-import ReduksjonAvBeløpSkjema from './ReduksjonAvBeløpSkjema';
 
 interface IProps {
     skjema: ISkjema<VilkårsvurderingSkjemaDefinisjon, string>;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/TilleggesRenterRadioGroup.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/Aktsomhetsvurdering/TilleggesRenterRadioGroup.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+
 import { BodyShort, Label, Radio } from '@navikt/ds-react';
-import { HorisontalRadioGroup } from '../../../../Felleskomponenter/Skjemaelementer';
-import { JaNeiOption, jaNeiOptions } from '../VilkårsvurderingPeriodeSkjemaContext';
 import type { Felt } from '@navikt/familie-skjema';
 import { Valideringsstatus } from '@navikt/familie-skjema';
+
+import { HorisontalRadioGroup } from '../../../../Felleskomponenter/Skjemaelementer';
+import { JaNeiOption, jaNeiOptions } from '../VilkårsvurderingPeriodeSkjemaContext';
 
 interface IProps {
     erLesevisning: boolean;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/GodTroSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/GodTroSkjema.tsx
@@ -5,14 +5,14 @@ import { styled } from 'styled-components';
 import { BodyShort, Radio, TextField, VStack } from '@navikt/ds-react';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
-import ArrowBox from '../../../Felleskomponenter/ArrowBox/ArrowBox';
-import { HorisontalRadioGroup } from '../../../Felleskomponenter/Skjemaelementer';
 import {
     JaNeiOption,
     jaNeiOptions,
     OptionJA,
     VilkårsvurderingSkjemaDefinisjon,
 } from './VilkårsvurderingPeriodeSkjemaContext';
+import ArrowBox from '../../../Felleskomponenter/ArrowBox/ArrowBox';
+import { HorisontalRadioGroup } from '../../../Felleskomponenter/Skjemaelementer';
 
 const ArrowBoxContainer = styled.div`
     width: 300px;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.test.tsx
@@ -6,10 +6,10 @@ import { mock } from 'jest-mock-extended';
 
 import { HttpProvider } from '@navikt/familie-http';
 
+import SplittPeriode from './SplittPeriode';
 import { HendelseType } from '../../../../../kodeverk';
 import { IBehandling } from '../../../../../typer/behandling';
 import { VilkårsvurderingPeriodeSkjemaData } from '../../typer/feilutbetalingVilkårsvurdering';
-import SplittPeriode from './SplittPeriode';
 
 describe('Tester: SplittPeriode - Vilkårsvurdering', () => {
     test('Tester åpning av modal', async () => {

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -18,6 +18,18 @@ import {
 } from '@navikt/ds-react';
 import { type ISkjema, Valideringsstatus } from '@navikt/familie-skjema';
 
+import AktsomhetsvurderingSkjema from './Aktsomhetsvurdering/AktsomhetsvurderingSkjema';
+import GodTroSkjema from './GodTroSkjema';
+import SplittPeriode from './SplittPeriode/SplittPeriode';
+import TilbakekrevingAktivitetTabell from './TilbakekrevingAktivitetTabell';
+import {
+    ANDELER,
+    EGENDEFINERT,
+    finnJaNeiOption,
+    OptionNEI,
+    useVilkårsvurderingPeriodeSkjema,
+    VilkårsvurderingSkjemaDefinisjon,
+} from './VilkårsvurderingPeriodeSkjemaContext';
 import {
     Aktsomhet,
     SærligeGrunner,
@@ -37,18 +49,6 @@ import PeriodeOppsummering from '../../../Felleskomponenter/Periodeinformasjon/P
 import PeriodeController from '../../../Felleskomponenter/TilbakeTidslinje/PeriodeController/PeriodeController';
 import { useFeilutbetalingVilkårsvurdering } from '../FeilutbetalingVilkårsvurderingContext';
 import { VilkårsvurderingPeriodeSkjemaData } from '../typer/feilutbetalingVilkårsvurdering';
-import AktsomhetsvurderingSkjema from './Aktsomhetsvurdering/AktsomhetsvurderingSkjema';
-import GodTroSkjema from './GodTroSkjema';
-import SplittPeriode from './SplittPeriode/SplittPeriode';
-import TilbakekrevingAktivitetTabell from './TilbakekrevingAktivitetTabell';
-import {
-    ANDELER,
-    EGENDEFINERT,
-    finnJaNeiOption,
-    OptionNEI,
-    useVilkårsvurderingPeriodeSkjema,
-    VilkårsvurderingSkjemaDefinisjon,
-} from './VilkårsvurderingPeriodeSkjemaContext';
 
 const StyledBox = styled(Box)`
     min-width: 20rem;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaBA.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaBA.test.tsx
@@ -4,6 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { mock } from 'jest-mock-extended';
 
+import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriodeSkjema';
 import {
     Aktsomhet,
     HendelseType,
@@ -14,7 +15,6 @@ import {
 import { IBehandling } from '../../../../typer/behandling';
 import { IFagsak } from '../../../../typer/fagsak';
 import { VilkårsvurderingPeriodeSkjemaData } from '../typer/feilutbetalingVilkårsvurdering';
-import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriodeSkjema';
 
 jest.setTimeout(10000);
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaOS.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaOS.test.tsx
@@ -4,6 +4,7 @@ import { render, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { mock } from 'jest-mock-extended';
 
+import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriodeSkjema';
 import {
     Aktsomhet,
     HendelseType,
@@ -14,7 +15,6 @@ import {
 import { IBehandling } from '../../../../typer/behandling';
 import { IFagsak } from '../../../../typer/fagsak';
 import { VilkårsvurderingPeriodeSkjemaData } from '../typer/feilutbetalingVilkårsvurdering';
-import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriodeSkjema';
 
 jest.setTimeout(10000);
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
@@ -7,14 +7,14 @@ import { BodyShort, VStack } from '@navikt/ds-react';
 import { AFontWeightBold } from '@navikt/ds-tokens/dist/tokens';
 import { type Periode } from '@navikt/familie-tidslinje';
 
+import { useFeilutbetalingVilkårsvurdering } from './FeilutbetalingVilkårsvurderingContext';
+import { VilkårsvurderingPeriodeSkjemaData } from './typer/feilutbetalingVilkårsvurdering';
+import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema';
 import { Aktsomhet, Vilkårsresultat } from '../../../kodeverk';
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { FTAlertStripe, FTButton, Navigering } from '../../Felleskomponenter/Flytelementer';
 import TilbakeTidslinje from '../../Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje';
-import { useFeilutbetalingVilkårsvurdering } from './FeilutbetalingVilkårsvurderingContext';
-import { VilkårsvurderingPeriodeSkjemaData } from './typer/feilutbetalingVilkårsvurdering';
-import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema';
 
 const ValideringsFeilmelding = styled(BodyShort)`
     font-weight: ${AFontWeightBold};

--- a/src/frontend/komponenter/Felleskomponenter/FTHeader/FTHeader.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/FTHeader/FTHeader.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
-import { styled } from 'styled-components';
 import { Link } from 'react-router-dom';
+import { styled } from 'styled-components';
+
 import { Dropdown, InternalHeader } from '@navikt/ds-react';
 import {
     AFontLineHeightHeadingMedium,

--- a/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriode.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriode.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { endOfMonth } from 'date-fns';
 import { styled } from 'styled-components';
 
 import { BodyShort, Label, Modal, MonthPicker, useMonthpicker } from '@navikt/ds-react';
@@ -8,9 +9,8 @@ import { type Periode as TidslinjePeriode, Tidslinje } from '@navikt/familie-tid
 
 import { IPeriodeSkjemaData } from '../../../../typer/periodeSkjemaData';
 import { formatterDatostring } from '../../../../utils';
-import { FTButton } from '../../Flytelementer';
 import { dateTilIsoDatoString, isoStringTilDate } from '../../../../utils/dato';
-import { endOfMonth } from 'date-fns';
+import { FTButton } from '../../Flytelementer';
 
 const TidslinjeContainer = styled.div`
     border: 1px solid ${ABorderStrong};

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentContext.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentContext.tsx
@@ -4,9 +4,9 @@ import { useHttp } from '@navikt/familie-http';
 import { useSkjema, useFelt, type FeltState, feil, ok } from '@navikt/familie-skjema';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import { IRestSettPåVent } from '../../../../typer/api';
 import { IBehandlingsstegstilstand, Venteårsak } from '../../../../typer/behandling';
 import { isEmpty, validerGyldigDato } from '../../../../utils';
-import { IRestSettPåVent } from '../../../../typer/api';
 import { dateTilIsoDatoString, isoStringTilDate } from '../../../../utils/dato';
 
 export const usePåVentBehandling = (

--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
+import { addDays, addMonths } from 'date-fns';
 import { styled } from 'styled-components';
 
 import { BodyLong, Heading, Modal, Select } from '@navikt/ds-react';
 import { ATextDanger, ASpacing8 } from '@navikt/ds-tokens/dist/tokens';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 
+import { usePåVentBehandling } from './PåVentContext';
 import {
     Behandlingssteg,
     IBehandling,
@@ -14,11 +16,9 @@ import {
     venteårsaker,
 } from '../../../../typer/behandling';
 import { dateBeforeToday } from '../../../../utils';
-import { FTButton, Spacer20 } from '../../Flytelementer';
-import { usePåVentBehandling } from './PåVentContext';
-import Datovelger from '../../Datovelger/Datovelger';
-import { addDays, addMonths } from 'date-fns';
 import { dagensDato } from '../../../../utils/dato';
+import Datovelger from '../../Datovelger/Datovelger';
+import { FTButton, Spacer20 } from '../../Flytelementer';
 
 const FeilContainer = styled.div`
     margin-top: ${ASpacing8};

--- a/src/frontend/komponenter/Felleskomponenter/Periodeinformasjon/PeriodeOppsummering.test.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Periodeinformasjon/PeriodeOppsummering.test.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 import { render } from '@testing-library/react';
 
-import { HendelseType } from '../../../kodeverk';
 import PeriodeOppsummering from './PeriodeOppsummering';
+import { HendelseType } from '../../../kodeverk';
 
 describe('Tester: PeriodeOppsummering', () => {
     test('- uten hendelsetype', () => {

--- a/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/index.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Skjemaelementer/index.ts
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
-import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 import { RadioGroup } from '@navikt/ds-react';
+import { ASpacing3 } from '@navikt/ds-tokens/dist/tokens';
 
 export * from './LabelMedSpråk';
 

--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toast.tsx
@@ -4,8 +4,8 @@ import { styled } from 'styled-components';
 
 import { Alert } from '@navikt/ds-react';
 
-import { useApp } from '../../../context/AppContext';
 import type { IToast } from './typer';
+import { useApp } from '../../../context/AppContext';
 
 const Container = styled.div`
     grid-column: 3;

--- a/src/frontend/komponenter/Felleskomponenter/Toast/Toasts.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Toast/Toasts.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { useApp } from '../../../context/AppContext';
 import Toast from './Toast';
+import { useApp } from '../../../context/AppContext';
 
 const Container = styled.div`
     position: fixed;

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/Venstremeny.tsx
@@ -14,10 +14,10 @@ import {
 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
 
-import { useBehandling } from '../../../context/BehandlingContext';
-import { IFagsak } from '../../../typer/fagsak';
 import Link from './Link';
 import { erSidenAktiv, sider, visSide } from './sider';
+import { useBehandling } from '../../../context/BehandlingContext';
+import { IFagsak } from '../../../typer/fagsak';
 
 const StyledNav = styled.nav`
     display: flex;

--- a/src/frontend/typer/api.ts
+++ b/src/frontend/typer/api.ts
@@ -1,3 +1,6 @@
+import { Behandlingresultat, Behandlingssteg, Venteårsak } from './behandling';
+import { IBrevmottaker } from './Brevmottaker';
+import { Aktsomhetsvurdering, GodTro, Periode } from './feilutbetalingtyper';
 import {
     DokumentMal,
     Foreldelsevurdering,
@@ -6,9 +9,6 @@ import {
     Vilkårsresultat,
 } from '../kodeverk';
 import { Vergetype } from '../kodeverk/verge';
-import { Behandlingresultat, Behandlingssteg, Venteårsak } from './behandling';
-import { IBrevmottaker } from './Brevmottaker';
-import { Aktsomhetsvurdering, GodTro, Periode } from './feilutbetalingtyper';
 import { IsoDatoString } from '../utils/dato';
 
 export interface PeriodeFaktaStegPayload {

--- a/src/frontend/typer/fagsak.ts
+++ b/src/frontend/typer/fagsak.ts
@@ -1,6 +1,6 @@
-import { Fagsystem, Ytelsetype } from '../kodeverk';
 import { Behandlingstatus, Behandlingstype } from './behandling';
 import { IPerson } from './person';
+import { Fagsystem, Ytelsetype } from '../kodeverk';
 
 export enum Målform {
     NB = 'NB',

--- a/src/frontend/typer/vedtakTyper.ts
+++ b/src/frontend/typer/vedtakTyper.ts
@@ -1,5 +1,5 @@
-import { Avsnittstype, Underavsnittstype, Vedtaksresultat, Vurdering } from '../kodeverk/';
 import { FeilutbetalingPeriode } from './feilutbetalingtyper';
+import { Avsnittstype, Underavsnittstype, Vedtaksresultat, Vurdering } from '../kodeverk/';
 
 export type BeregningsresultatPeriode = {
     vurdering: Vurdering;

--- a/src/frontend/utils/dateUtils.ts
+++ b/src/frontend/utils/dateUtils.ts
@@ -11,8 +11,8 @@ import {
 
 import { type IJournalpostRelevantDato, JournalpostDatotype } from '@navikt/familie-typer';
 
-import { FeilutbetalingPeriode } from '../typer/feilutbetalingtyper';
 import { isEmpty } from './validering';
+import { FeilutbetalingPeriode } from '../typer/feilutbetalingtyper';
 
 const datoformat: Intl.DateTimeFormatOptions = {
     day: '2-digit',

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -1,6 +1,7 @@
-import type { IPerson } from '../typer/person';
 import { differenceInMilliseconds } from 'date-fns';
+
 import { dagensDato, isoStringTilDate } from './dato';
+import type { IPerson } from '../typer/person';
 
 export const millisekunderIEttÅr = 3.15576e10;
 


### PR DESCRIPTION
Endrer eslint-config slik at eslint gir error ved feil import order. Dette er sånn vi har det i andre repoer, og syns det er ryddig at også dette repoet har "riktig" import order.