### PR TITLE
Erstatt blanke sider med varsler om hva som mangler

### DIFF
--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -82,24 +82,25 @@ const FagsakContainer: React.FC = () => {
         case RessursStatus.SUKSESS: {
             switch (behandling?.status) {
                 case RessursStatus.SUKSESS:
-                    return !visVenteModal ? (
-                        <>
-                            <Personlinje bruker={fagsak.data.bruker} fagsak={fagsak.data} />
+                    return (
+                        !visVenteModal && (
+                            <>
+                                <Personlinje bruker={fagsak.data.bruker} fagsak={fagsak.data} />
 
-                            {ventegrunn && (
-                                <FTAlertStripe children={venteBeskjed(ventegrunn)} variant="info" />
-                            )}
-                            <FagsakContainerContent className={ventegrunn ? 'venter' : ''}>
-                                <BehandlingContainer
-                                    fagsak={fagsak.data}
-                                    behandling={behandling.data}
-                                />
-                            </FagsakContainerContent>
-                        </>
-                    ) : (
-                        <Alert variant="info">
-                            Data om behandlingen er innhentet, men saken er på vent.
-                        </Alert>
+                                {ventegrunn && (
+                                    <FTAlertStripe
+                                        children={venteBeskjed(ventegrunn)}
+                                        variant="info"
+                                    />
+                                )}
+                                <FagsakContainerContent className={ventegrunn ? 'venter' : ''}>
+                                    <BehandlingContainer
+                                        fagsak={fagsak.data}
+                                        behandling={behandling.data}
+                                    />
+                                </FagsakContainerContent>
+                            </>
+                        )
                     );
                 case RessursStatus.IKKE_TILGANG:
                     return (
@@ -112,7 +113,7 @@ const FagsakContainer: React.FC = () => {
                 case RessursStatus.FUNKSJONELL_FEIL:
                     return <Alert children={behandling.frontendFeilmelding} variant="error" />;
                 default:
-                    return <Alert variant="warning">Venter på data om behandlingen</Alert>;
+                    return <Alert variant="info">Venter på data om behandlingen</Alert>;
             }
         }
         case RessursStatus.IKKE_TILGANG:
@@ -123,7 +124,7 @@ const FagsakContainer: React.FC = () => {
         case RessursStatus.FUNKSJONELL_FEIL:
             return <Alert children={fagsak.frontendFeilmelding} variant="error" />;
         default:
-            return <Alert variant="warning">Venter på data om fagsaken</Alert>;
+            return <Alert variant="info">Venter på data om fagsaken</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/FagsakContainer.tsx
@@ -97,7 +97,9 @@ const FagsakContainer: React.FC = () => {
                             </FagsakContainerContent>
                         </>
                     ) : (
-                        <div />
+                        <Alert variant="info">
+                            Data om behandlingen er innhentet, men saken er på vent.
+                        </Alert>
                     );
                 case RessursStatus.IKKE_TILGANG:
                     return (
@@ -110,7 +112,7 @@ const FagsakContainer: React.FC = () => {
                 case RessursStatus.FUNKSJONELL_FEIL:
                     return <Alert children={behandling.frontendFeilmelding} variant="error" />;
                 default:
-                    return <div />;
+                    return <Alert variant="warning">Venter på data om behandlingen</Alert>;
             }
         }
         case RessursStatus.IKKE_TILGANG:
@@ -121,7 +123,7 @@ const FagsakContainer: React.FC = () => {
         case RessursStatus.FUNKSJONELL_FEIL:
             return <Alert children={fagsak.frontendFeilmelding} variant="error" />;
         default:
-            return <div />;
+            return <Alert variant="warning">Venter på data om fagsaken</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.tsx
@@ -75,7 +75,7 @@ const FaktaContainer: React.FC<IProps> = ({ ytelse }) => {
         case RessursStatus.FUNKSJONELL_FEIL:
             return <Alert children={feilutbetalingFakta.frontendFeilmelding} variant="error" />;
         default:
-            return <div />;
+            return <Alert variant="warning">Kunne ikke hente data om feilutbetalingen</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
@@ -116,7 +116,7 @@ const ForeldelseContainer: React.FC<IProps> = ({ behandling }) => {
                 <Alert variant="error" children={feilutbetalingForeldelse.frontendFeilmelding} />
             );
         default:
-            return <div />;
+            return <Alert variant="warning">Kunne ikke hente data om foreldelse</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentlisting.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Dokumentlisting/Dokumentlisting.tsx
@@ -44,7 +44,7 @@ const Dokumentlisting: React.FC = () => {
         case RessursStatus.FUNKSJONELL_FEIL:
             return <Alert children={journalposter.frontendFeilmelding} variant="error" />;
         default:
-            return <div />;
+            return <Alert variant="warning">Kunne ikke hente data om dokumenter</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/Historikk.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Historikk/Historikk.tsx
@@ -40,7 +40,7 @@ const Historikk: React.FC = () => {
         case RessursStatus.FUNKSJONELL_FEIL:
             return <Alert children={historikkInnslag.frontendFeilmelding} variant="error" />;
         default:
-            return <div />;
+            return <Alert variant="warning">Kunne ikke hente data om historikk</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
@@ -206,12 +206,7 @@ const VedtakContainer: React.FC<IProps> = ({ behandling, fagsak }) => {
             />
         );
     } else {
-        return (
-            <Alert variant="warning">
-                Kunne ikke hente data om vedtaksbrev. Venter på beregningsresultat og
-                vedtaksbrevavsnitt.
-            </Alert>
-        );
+        return <Alert variant="warning">Kunne ikke hente data om vedtaksbrev</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
@@ -206,7 +206,12 @@ const VedtakContainer: React.FC<IProps> = ({ behandling, fagsak }) => {
             />
         );
     } else {
-        return <div />;
+        return (
+            <Alert variant="warning">
+                Kunne ikke hente data om vedtaksbrev. Venter på beregningsresultat og
+                vedtaksbrevavsnitt.
+            </Alert>
+        );
     }
 };
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.tsx
@@ -106,7 +106,7 @@ const VilkårsvurderingContainer: React.FC<IProps> = ({ fagsak, behandling }) =>
                 />
             );
         default:
-            return <div />;
+            return <Alert variant="warning">Kunne ikke hente data om vilkårsvurdering</Alert>;
     }
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/PdfVisningModal/PdfVisningModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/PdfVisningModal/PdfVisningModal.tsx
@@ -79,7 +79,7 @@ const Dokument: React.FC<{ pdfdata: Ressurs<string> }> = ({ pdfdata }) => {
                 />
             );
         default:
-            return null;
+            <Alert variant="warning">Kunne ikke hente dokument</Alert>;
     }
 };
 


### PR DESCRIPTION
Fant en del tilfeller av at vi har switch med default-case `return <div />`. Dette fører i disse tilfellene til at vi viser blanke elementer eller helt blanke sider, uten noen forklaring til brukeren om hvilken tilstand applikasjonen er i.

Erstatter disse med varselbokser der jeg har forsøkt å utlede hvilken `RessursStatus` vi har kommet til. Ofte `IKKE_HENTET` og iblant det eller `IKKE_TILGANG`