### PR TITLE
Bugfix: legg på open-prop og onclose så modal rendres

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/PåVent/PåVentModal.tsx
@@ -60,8 +60,15 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
         ventegrunn.venteårsak === skjema.felter.årsak.verdi &&
         ventegrunn.tidsfrist === skjema.felter.tidsfrist.verdi;
 
+    const lukkModal = () => {
+        tilbakestillFelterTilDefault();
+        onClose();
+    };
+
     return (
         <Modal
+            open
+            onClose={lukkModal}
             header={{
                 heading: 'Behandling satt på vent',
                 size: 'medium',
@@ -130,15 +137,7 @@ const PåVentModal: React.FC<IProps> = ({ behandling, ventegrunn, onClose }) => 
                 >
                     Oppdater
                 </FTButton>
-                <FTButton
-                    variant="tertiary"
-                    key={'avbryt'}
-                    onClick={() => {
-                        tilbakestillFelterTilDefault();
-                        onClose();
-                    }}
-                    size="small"
-                >
+                <FTButton variant="tertiary" key={'avbryt'} onClick={lukkModal} size="small">
                     Lukk
                 </FTButton>
             </Modal.Footer>


### PR DESCRIPTION
Legger tilbake open-prop (og da også en onClose-funksjon som kreves for å bruke open-prop), slik at PåVentModal faktisk rendres. Er bug i prod hvor saksbehandler kun ser en hvit skjerm fordi modalen ikke dukker opp. Dette er verifisert at tester lokalt