### PR TITLE
Besluter skal default til faktasteg

### DIFF
--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -24,7 +24,7 @@ import { Behandlingstatus, IBehandling } from '../../typer/behandling';
 import { IFagsak } from '../../typer/fagsak';
 import {
     erØnsketSideTilgjengelig,
-    finnSideAktivtSteg,
+    utledBehandlingSide,
 } from '../Felleskomponenter/Venstremeny/sider';
 import Venstremeny from '../Felleskomponenter/Venstremeny/Venstremeny';
 
@@ -58,31 +58,26 @@ interface IProps {
 }
 
 const BehandlingContainer: React.FC<IProps> = ({ fagsak, behandling }) => {
+    const { visVenteModal, harKravgrunnlag, aktivtSteg } = useBehandling();
     const navigate = useNavigate();
     const location = useLocation();
-    const ønsketSide = location.pathname.split('/')[7];
 
-    const { visVenteModal, harKravgrunnlag, aktivtSteg } = useBehandling();
+    const ønsketSide = location.pathname.split('/')[7];
+    const erØnsketSideLovlig = ønsketSide && erØnsketSideTilgjengelig(ønsketSide, behandling);
+    const behandlingUrl = `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`;
 
     React.useEffect(() => {
         if (visVenteModal === false) {
-            const ønsketSideLovlig = ønsketSide && erØnsketSideTilgjengelig(ønsketSide, behandling);
-            if (!ønsketSideLovlig && aktivtSteg) {
-                const aktivSide = finnSideAktivtSteg(aktivtSteg);
+            if (!erØnsketSideLovlig && aktivtSteg) {
+                const aktivSide = utledBehandlingSide(aktivtSteg.behandlingssteg);
                 if (aktivSide) {
-                    navigate(
-                        `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${aktivSide?.href}`
-                    );
+                    navigate(`${behandlingUrl}/${aktivSide?.href}`);
                 }
-            } else if (!ønsketSideLovlig) {
+            } else if (!erØnsketSideLovlig) {
                 if (behandling.status === Behandlingstatus.AVSLUTTET) {
-                    navigate(
-                        `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/vedtak`
-                    );
+                    navigate(`${behandlingUrl}/vedtak`);
                 } else {
-                    navigate(
-                        `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
-                    );
+                    navigate(`${behandlingUrl}`);
                 }
             }
         }

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -93,17 +93,16 @@ export const visSide = (side: ISide, åpenBehandling: IBehandling) => {
     return true;
 };
 
-export const finnSideAktivtSteg = (aktivtSteg: IBehandlingsstegstilstand): ISide | undefined => {
-    if (aktivtSteg.behandlingssteg === Behandlingssteg.FATTE_VEDTAK) {
-        return sider.FAKTA;
-    } else if (
-        aktivtSteg.behandlingssteg === Behandlingssteg.AVSLUTTET ||
-        aktivtSteg.behandlingssteg === Behandlingssteg.IVERKSETT_VEDTAK
-    ) {
-        return sider.VEDTAK;
+export const utledBehandlingSide = (steg: Behandlingssteg): ISide | undefined => {
+    switch (steg) {
+        case Behandlingssteg.FATTE_VEDTAK:
+            return sider.FAKTA;
+        case Behandlingssteg.AVSLUTTET:
+        case Behandlingssteg.IVERKSETT_VEDTAK:
+            return sider.VEDTAK;
+        default:
+            return finnSideForSteg(steg);
     }
-
-    return finnSideForSteg(aktivtSteg.behandlingssteg);
 };
 
 export const erØnsketSideTilgjengelig = (ønsketSide: string, behandling: IBehandling): boolean => {

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -94,9 +94,10 @@ export const visSide = (side: ISide, åpenBehandling: IBehandling) => {
 };
 
 export const finnSideAktivtSteg = (aktivtSteg: IBehandlingsstegstilstand): ISide | undefined => {
-    if (
+    if (aktivtSteg.behandlingssteg === Behandlingssteg.FATTE_VEDTAK) {
+        return sider.FAKTA;
+    } else if (
         aktivtSteg.behandlingssteg === Behandlingssteg.AVSLUTTET ||
-        aktivtSteg.behandlingssteg === Behandlingssteg.FATTE_VEDTAK ||
         aktivtSteg.behandlingssteg === Behandlingssteg.IVERKSETT_VEDTAK
     ) {
         return sider.VEDTAK;


### PR DESCRIPTION
Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20488

Det er meldt inn som et ønske fra saksbehandlere om at dersom behandlingen er i steget FATTE VEDTAK, så skal saksbehandler default navigeres til faktasteget. Dette er fordi saksbehandler uansett skal starte her, for så å se gjennom hele behandlingen før eventuel godkjennelse.

PRen er delt inn i to comits: 
- Den første løser selve problemet
- Den andre er en liten refaktorering for å forenkle kode

Endringen er testet lokalt ✅ 