### PR TITLE
Vilkårsvurdering default se periode

### DIFF
--- a/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
@@ -42,6 +42,7 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
         const { gjerFeilutbetalingForeldelseKall, sendInnFeilutbetalingForeldelse } =
             useBehandlingApi();
         const navigate = useNavigate();
+        const behandlingUrl = `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`;
 
         React.useEffect(() => {
             if (visVenteModal === false) {
@@ -108,16 +109,12 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
                 });
         };
 
-        const gåTilNeste = () => {
-            navigate(
-                `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${sider.VILKÅRSVURDERING.href}`
-            );
+        const gåTilNesteSteg = () => {
+            navigate(`${behandlingUrl}/${sider.VILKÅRSVURDERING.href}`);
         };
 
-        const gåTilForrige = () => {
-            navigate(
-                `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${sider.FAKTA.href}`
-            );
+        const gåTilForrigeSteg = () => {
+            navigate(`${behandlingUrl}/${sider.FAKTA.href}`);
         };
 
         const oppdaterPeriode = (periode: ForeldelsePeriodeSkjemeData) => {
@@ -179,7 +176,7 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
 
         const sendInnSkjema = () => {
             if (stegErBehandlet && !harEndretOpplysninger()) {
-                gåTilNeste();
+                gåTilNesteSteg();
             } else {
                 settSenderInn(true);
                 const payload: ForeldelseStegPayload = {
@@ -210,10 +207,6 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
             }
         };
 
-        const lukkValgtPeriode = () => {
-            settValgtPeriode(undefined);
-        };
-
         return {
             feilutbetalingForeldelse,
             erAutoutført,
@@ -223,12 +216,11 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
             valgtPeriode,
             settValgtPeriode,
             allePerioderBehandlet,
-            gåTilNeste,
-            gåTilForrige,
+            gåTilNesteSteg,
+            gåTilForrigeSteg,
             senderInn,
             sendInnSkjema,
             onSplitPeriode,
-            lukkValgtPeriode,
             nestePeriode,
             forrigePeriode,
         };

--- a/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
@@ -30,7 +30,9 @@ const utledValgtPeriode = (
         periode => !periode.foreldelsesvurderingstype
     );
     const skalViseÅpentVurderingspanel =
-        skjemaPerioder.length > 0 && behandlingStatus === Behandlingstatus.FATTER_VEDTAK;
+        skjemaPerioder.length > 0 &&
+        (behandlingStatus === Behandlingstatus.FATTER_VEDTAK ||
+            behandlingStatus === Behandlingstatus.AVSLUTTET);
 
     if (førsteUbehandletPeriode) {
         return førsteUbehandletPeriode;

--- a/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
@@ -77,6 +77,8 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
                 );
                 if (førsteUbehandletPeriode) {
                     settValgtPeriode(førsteUbehandletPeriode);
+                } else if (skjemaPerioder.length > 0) {
+                    settValgtPeriode(skjemaPerioder[0]);
                 }
             }
         }, [feilutbetalingForeldelse]);

--- a/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
@@ -16,11 +16,29 @@ import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Foreldelsevurdering } from '../../../kodeverk';
 import { ForeldelseStegPayload, PeriodeForeldelseStegPayload } from '../../../typer/api';
-import { Behandlingssteg, IBehandling } from '../../../typer/behandling';
+import { Behandlingssteg, Behandlingstatus, IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { IFeilutbetalingForeldelse } from '../../../typer/feilutbetalingtyper';
 import { sorterFeilutbetaltePerioder } from '../../../utils';
 import { sider } from '../../Felleskomponenter/Venstremeny/sider';
+
+const utledValgtPeriode = (
+    skjemaPerioder: ForeldelsePeriodeSkjemeData[],
+    behandlingStatus: Behandlingstatus
+) => {
+    const førsteUbehandletPeriode = skjemaPerioder.find(
+        periode => !periode.foreldelsesvurderingstype
+    );
+    const skalViseÅpentVurderingspanel =
+        skjemaPerioder.length > 0 && behandlingStatus === Behandlingstatus.FATTER_VEDTAK;
+
+    if (førsteUbehandletPeriode) {
+        return førsteUbehandletPeriode;
+    } else if (skalViseÅpentVurderingspanel) {
+        return skjemaPerioder[0];
+    }
+    return undefined;
+};
 
 interface IProps {
     behandling: IBehandling;
@@ -71,15 +89,12 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
                     };
                     return skjemaPeriode;
                 });
+                const valgtForeldelsePeriode = utledValgtPeriode(skjemaPerioder, behandling.status);
+
                 settSkjemaData(skjemaPerioder);
 
-                const førsteUbehandletPeriode = skjemaPerioder.find(
-                    per => !per.foreldelsesvurderingstype
-                );
-                if (førsteUbehandletPeriode) {
-                    settValgtPeriode(førsteUbehandletPeriode);
-                } else if (skjemaPerioder.length > 0) {
-                    settValgtPeriode(skjemaPerioder[0]);
+                if (valgtForeldelsePeriode) {
+                    settValgtPeriode(valgtForeldelsePeriode);
                 }
             }
         }, [feilutbetalingForeldelse]);

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
@@ -224,13 +224,14 @@ describe('Tester: ForeldelseContainer', () => {
 
         await waitFor(async () => {
             expect(getByText('Foreldelse')).toBeTruthy();
-            expect(queryByText('Detaljer for valgt periode')).toBeFalsy();
+            expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
+            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
 
             expect(
                 getByRole('button', {
                     name: 'Neste',
                 })
-            ).toBeEnabled();
+            ).toBeDisabled();
         });
 
         await act(() =>
@@ -328,7 +329,8 @@ describe('Tester: ForeldelseContainer', () => {
 
         await waitFor(async () => {
             expect(getByText('Foreldelse')).toBeTruthy();
-            expect(queryByText('Detaljer for valgt periode')).toBeFalsy();
+            expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
+            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
 
             expect(
                 getByRole('button', {

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
@@ -11,7 +11,7 @@ import ForeldelseContainer from './ForeldelseContainer';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Foreldelsevurdering } from '../../../kodeverk';
-import { IBehandling } from '../../../typer/behandling';
+import { Behandlingstatus, IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
 import { ForeldelsePeriode, IFeilutbetalingForeldelse } from '../../../typer/feilutbetalingtyper';
 
@@ -224,14 +224,13 @@ describe('Tester: ForeldelseContainer', () => {
 
         await waitFor(async () => {
             expect(getByText('Foreldelse')).toBeTruthy();
-            expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
-            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
+            expect(queryByText('Detaljer for valgt periode')).toBeFalsy();
 
             expect(
                 getByRole('button', {
                     name: 'Neste',
                 })
-            ).toBeDisabled();
+            ).toBeEnabled();
         });
 
         await act(() =>
@@ -318,20 +317,58 @@ describe('Tester: ForeldelseContainer', () => {
                 },
             ],
         });
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ status: Behandlingstatus.FATTER_VEDTAK });
         const fagsak = mock<IFagsak>();
 
-        const { getByText, getByRole, queryByText, queryByRole, getByLabelText } = render(
+        const { getByText, getByRole, getByLabelText } = render(
             <FeilutbetalingForeldelseProvider behandling={behandling} fagsak={fagsak}>
                 <ForeldelseContainer behandling={behandling} />
             </FeilutbetalingForeldelseProvider>
         );
 
         await waitFor(async () => {
-            expect(getByText('Foreldelse')).toBeTruthy();
-            expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
-            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
+            // Tittel skal alltid være synlig
+            expect(getByText('Foreldelse', { selector: 'h2' })).toBeTruthy();
 
+            // Første periode sitt endringspanel skal være åpnet by default i lesevisning, sjekker at riktige verdier er satt
+            expect(getByText('Detaljer for valgt periode', { selector: 'h2' })).toBeTruthy();
+            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
+            expect(getByText('Begrunnelse 1')).toBeTruthy();
+            expect(
+                getByLabelText('Perioden er foreldet', {
+                    selector: 'input',
+                    exact: false,
+                })
+            ).toBeChecked();
+            expect(
+                getByLabelText(
+                    'Perioden er ikke foreldet, regel om tilleggsfrist (10 år) benyttes',
+                    {
+                        selector: 'input',
+                        exact: false,
+                    }
+                )
+            ).not.toBeChecked();
+            expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
+
+            // Alle tidslinje knappene skal alltid være synlige
+            expect(
+                getByRole('button', {
+                    name: 'suksess fra 01.01.2020 til og med 31.03.2020',
+                })
+            ).toBeTruthy();
+            expect(
+                getByRole('button', {
+                    name: 'suksess fra 01.05.2020 til og med 30.06.2020',
+                })
+            ).toBeTruthy();
+
+            // Knapper for navigering mellom faner skal alltid være synlige og enabled
+            expect(
+                getByRole('button', {
+                    name: 'Forrige',
+                })
+            ).toBeEnabled();
             expect(
                 getByRole('button', {
                     name: 'Neste',
@@ -342,55 +379,53 @@ describe('Tester: ForeldelseContainer', () => {
         await act(() =>
             user.click(
                 getByRole('button', {
-                    name: 'suksess fra 01.01.2020 til og med 31.03.2020',
-                })
-            )
-        );
-
-        expect(
-            queryByRole('button', {
-                name: 'Bekreft',
-            })
-        ).toBeFalsy();
-
-        expect(
-            getByRole('button', {
-                name: 'Neste',
-            })
-        ).toBeEnabled();
-
-        expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
-        expect(getByText('01.01.2020 - 31.03.2020')).toBeTruthy();
-
-        expect(getByText('Begrunnelse 1')).toBeTruthy();
-        expect(getByText('Perioden er foreldet')).toBeTruthy();
-        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
-
-        await act(() =>
-            user.click(
-                getByRole('button', {
                     name: 'suksess fra 01.05.2020 til og med 30.06.2020',
                 })
             )
         );
 
-        expect(getByText('01.05.2020 - 30.06.2020')).toBeTruthy();
+        // Tittel skal alltid være synlig
+        expect(getByText('Foreldelse', { selector: 'h2' })).toBeTruthy();
 
+        // Andre periode sitt endringspanel skal nå være åpnet, sjekker at riktige verdier er satt
+        expect(getByText('Detaljer for valgt periode', { selector: 'h2' })).toBeTruthy();
+        expect(getByText('01.05.2020 - 30.06.2020', { selector: 'label' })).toBeTruthy();
         expect(getByText('Begrunnelse 2')).toBeTruthy();
         expect(
-            getByText('Perioden er ikke foreldet, regel om tilleggsfrist (10 år) benyttes')
-        ).toBeTruthy();
-        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
+            getByLabelText('Perioden er foreldet', {
+                selector: 'input',
+                exact: false,
+            })
+        ).not.toBeChecked();
+        expect(
+            getByLabelText('Perioden er ikke foreldet, regel om tilleggsfrist (10 år) benyttes', {
+                selector: 'input',
+                exact: false,
+            })
+        ).toBeChecked();
         expect(getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
             '24.12.2020'
         );
+        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
 
+        // Alle tidslinje knappene skal alltid være synlige
         expect(
-            queryByRole('button', {
-                name: 'Lukk',
+            getByRole('button', {
+                name: 'suksess fra 01.01.2020 til og med 31.03.2020',
             })
-        ).toBeFalsy();
+        ).toBeTruthy();
+        expect(
+            getByRole('button', {
+                name: 'suksess fra 01.05.2020 til og med 30.06.2020',
+            })
+        ).toBeTruthy();
 
+        // Knapper for navigering mellom faner skal alltid være synlige og enabled
+        expect(
+            getByRole('button', {
+                name: 'Forrige',
+            })
+        ).toBeEnabled();
         expect(
             getByRole('button', {
                 name: 'Neste',

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.tsx
@@ -42,8 +42,8 @@ const ForeldelseContainer: React.FC<IProps> = ({ behandling }) => {
         skjemaData,
         stegErBehandlet,
         erAutoutført,
-        gåTilNeste,
-        gåTilForrige,
+        gåTilNesteSteg,
+        gåTilForrigeSteg,
     } = useFeilutbetalingForeldelse();
     const { behandlingILesemodus } = useBehandling();
     const erLesevisning = !!behandlingILesemodus || !!erAutoutført;
@@ -61,10 +61,10 @@ const ForeldelseContainer: React.FC<IProps> = ({ behandling }) => {
                     Automatisk vurdert
                 </BodyLong>
                 <Navigering>
-                    <FTButton variant="primary" onClick={gåTilNeste}>
+                    <FTButton variant="primary" onClick={gåTilNesteSteg}>
                         Neste
                     </FTButton>
-                    <FTButton variant="secondary" onClick={gåTilForrige}>
+                    <FTButton variant="secondary" onClick={gåTilForrigeSteg}>
                         Forrige
                     </FTButton>
                 </Navigering>

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -58,7 +58,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
     periode,
     erLesevisning,
 }) => {
-    const { oppdaterPeriode, onSplitPeriode, lukkValgtPeriode, nestePeriode, forrigePeriode } =
+    const { oppdaterPeriode, onSplitPeriode, nestePeriode, forrigePeriode, settValgtPeriode } =
         useFeilutbetalingForeldelse();
     const { skjema, onBekreft } = useForeldelsePeriodeSkjema(
         (oppdatertPeriode: ForeldelsePeriodeSkjemeData) => oppdaterPeriode(oppdatertPeriode)
@@ -238,7 +238,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                         <FTButton variant="primary" onClick={() => onBekreft(periode)}>
                             Bekreft
                         </FTButton>
-                        <FTButton variant="secondary" onClick={lukkValgtPeriode}>
+                        <FTButton variant="secondary" onClick={() => settValgtPeriode(undefined)}>
                             Lukk
                         </FTButton>
                     </Navigering>

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
@@ -69,8 +69,8 @@ const FeilutbetalingForeldelsePerioder: React.FC<IProps> = ({
         settValgtPeriode,
         stegErBehandlet,
         erAutoutført,
-        gåTilForrige,
-        gåTilNeste,
+        gåTilForrigeSteg,
+        gåTilNesteSteg,
         allePerioderBehandlet,
         sendInnSkjema,
         senderInn,
@@ -110,7 +110,7 @@ const FeilutbetalingForeldelsePerioder: React.FC<IProps> = ({
             )}
             <Navigering>
                 {erAutoutført || (stegErBehandlet && erLesevisning) ? (
-                    <FTButton variant="primary" onClick={gåTilNeste}>
+                    <FTButton variant="primary" onClick={gåTilNesteSteg}>
                         Neste
                     </FTButton>
                 ) : (
@@ -123,7 +123,7 @@ const FeilutbetalingForeldelsePerioder: React.FC<IProps> = ({
                         {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
                     </FTButton>
                 )}
-                <FTButton variant="secondary" onClick={gåTilForrige}>
+                <FTButton variant="secondary" onClick={gåTilForrigeSteg}>
                     Forrige
                 </FTButton>
             </Navigering>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
@@ -110,6 +110,8 @@ const [FeilutbetalingVilkårsvurderingProvider, useFeilutbetalingVilkårsvurderi
                 const førsteUbehandletPeriode = skjemaPerioder.find(per => !erBehandlet(per));
                 if (førsteUbehandletPeriode) {
                     settValgtPeriode(førsteUbehandletPeriode);
+                } else if (skjemaPerioder.length > 0) {
+                    settValgtPeriode(skjemaPerioder[0]);
                 }
             }
         }, [feilutbetalingVilkårsvurdering]);

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
@@ -84,6 +84,7 @@ const [FeilutbetalingVilkårsvurderingProvider, useFeilutbetalingVilkårsvurderi
         const kanIleggeRenter = ![Ytelsetype.BARNETRYGD, Ytelsetype.KONTANTSTØTTE].includes(
             fagsak.ytelsestype
         );
+        const behandlingUrl = `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`;
 
         React.useEffect(() => {
             if (visVenteModal === false) {
@@ -143,16 +144,12 @@ const [FeilutbetalingVilkårsvurderingProvider, useFeilutbetalingVilkårsvurderi
                 });
         };
 
-        const gåTilNeste = () => {
-            navigate(
-                `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${sider.VEDTAK.href}`
-            );
+        const gåTilNesteSteg = () => {
+            navigate(`${behandlingUrl}/${sider.VEDTAK.href}`);
         };
 
-        const gåTilForrige = () => {
-            navigate(
-                `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${sider.FORELDELSE.href}`
-            );
+        const gåTilForrigeSteg = () => {
+            navigate(`${behandlingUrl}/${sider.FORELDELSE.href}`);
         };
 
         const oppdaterPeriode = (periode: VilkårsvurderingPeriodeSkjemaData) => {
@@ -258,7 +255,7 @@ const [FeilutbetalingVilkårsvurderingProvider, useFeilutbetalingVilkårsvurderi
             if (validerPerioder()) {
                 const ikkeForeldetPerioder = skjemaData.filter(per => !per.foreldet);
                 if (stegErBehandlet && !harEndretOpplysninger(ikkeForeldetPerioder)) {
-                    gåTilNeste();
+                    gåTilNesteSteg();
                 } else {
                     settSenderInn(true);
                     const payload: VilkårdsvurderingStegPayload = {
@@ -288,11 +285,6 @@ const [FeilutbetalingVilkårsvurderingProvider, useFeilutbetalingVilkårsvurderi
             }
         };
 
-        const lukkValgtPeriode = () => {
-            settSenderInn(false);
-            settValgtPeriode(undefined);
-        };
-
         return {
             feilutbetalingVilkårsvurdering,
             stegErBehandlet,
@@ -304,14 +296,13 @@ const [FeilutbetalingVilkårsvurderingProvider, useFeilutbetalingVilkårsvurderi
             settValgtPeriode,
             behandletPerioder,
             allePerioderBehandlet,
-            gåTilNeste,
-            gåTilForrige,
+            gåTilNesteSteg,
+            gåTilForrigeSteg,
             senderInn,
             valideringsfeil,
             valideringsFeilmelding,
             sendInnSkjema,
             onSplitPeriode,
-            lukkValgtPeriode,
             nestePeriode,
             forrigePeriode,
         };

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/FeilutbetalingVilkårsvurderingContext.tsx
@@ -45,7 +45,9 @@ const utledValgtPeriode = (
 ): VilkårsvurderingPeriodeSkjemaData | undefined => {
     const førsteUbehandledePeriode = skjemaPerioder.find(periode => !erBehandlet(periode));
     const skalViseÅpentVurderingspanel =
-        skjemaPerioder.length > 0 && behandlingStatus === Behandlingstatus.FATTER_VEDTAK;
+        skjemaPerioder.length > 0 &&
+        (behandlingStatus === Behandlingstatus.FATTER_VEDTAK ||
+            behandlingStatus === Behandlingstatus.AVSLUTTET);
 
     if (førsteUbehandledePeriode) {
         return førsteUbehandledePeriode;

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.test.tsx
@@ -447,7 +447,8 @@ describe('Tester: VilkårsvurderingContainer', () => {
 
         await waitFor(async () => {
             expect(getByText('Tilbakekreving')).toBeTruthy();
-            expect(queryByText('Detaljer for valgt periode')).toBeFalsy();
+            expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
+            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
             expect(
                 getByRole('button', {
                     name: 'suksess fra 01.01.2020 til og med 31.03.2020',
@@ -471,11 +472,7 @@ describe('Tester: VilkårsvurderingContainer', () => {
             })
         ).toBeDisabled();
 
-        expect(
-            getByText('01.01.2020 - 31.03.2020', {
-                selector: 'label',
-            })
-        ).toBeTruthy();
+        expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
 
         expect(getByLabelText('Vilkårene for tilbakekreving')).toHaveValue('Begrunnelse vilkår 1');
         expect(
@@ -584,7 +581,8 @@ describe('Tester: VilkårsvurderingContainer', () => {
 
         await waitFor(async () => {
             expect(getByText('Tilbakekreving')).toBeTruthy();
-            expect(queryByText('Detaljer for valgt periode')).toBeFalsy();
+            expect(queryByText('Detaljer for valgt periode')).toBeTruthy();
+            expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
             expect(
                 getByRole('button', {
                     name: 'suksess fra 01.01.2020 til og med 31.03.2020',
@@ -608,11 +606,7 @@ describe('Tester: VilkårsvurderingContainer', () => {
             })
         ).toBeEnabled();
 
-        expect(
-            getByText('01.01.2020 - 31.03.2020', {
-                selector: 'label',
-            })
-        ).toBeTruthy();
+        expect(getByText('01.01.2020 - 31.03.2020', { selector: 'label' })).toBeTruthy();
 
         expect(getByText('Begrunnelse vilkår 1')).toBeTruthy();
         expect(

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -204,9 +204,9 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
         kanIlleggeRenter,
         oppdaterPeriode,
         onSplitPeriode,
-        lukkValgtPeriode,
         nestePeriode,
         forrigePeriode,
+        settValgtPeriode,
     } = useFeilutbetalingVilkårsvurdering();
     const { skjema, onBekreft } = useVilkårsvurderingPeriodeSkjema(
         (oppdatertPeriode: VilkårsvurderingPeriodeSkjemaData) => {
@@ -421,7 +421,7 @@ const VilkårsvurderingPeriodeSkjema: React.FC<IProps> = ({
                         Bekreft
                     </FTButton>
                 )}
-                <FTButton variant="secondary" onClick={lukkValgtPeriode}>
+                <FTButton variant="secondary" onClick={() => settValgtPeriode(undefined)}>
                     Lukk
                 </FTButton>
             </Navigering>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
@@ -96,8 +96,8 @@ const VilkårsvurderingPerioder: React.FC<IProps> = ({
         settValgtPeriode,
         stegErBehandlet,
         erAutoutført,
-        gåTilForrige,
-        gåTilNeste,
+        gåTilForrigeSteg,
+        gåTilNesteSteg,
         behandletPerioder,
         allePerioderBehandlet,
         sendInnSkjema,
@@ -147,7 +147,7 @@ const VilkårsvurderingPerioder: React.FC<IProps> = ({
             )}
             <Navigering>
                 {erAutoutført || (stegErBehandlet && erLesevisning) ? (
-                    <FTButton variant="primary" onClick={gåTilNeste}>
+                    <FTButton variant="primary" onClick={gåTilNesteSteg}>
                         Neste
                     </FTButton>
                 ) : (
@@ -160,7 +160,7 @@ const VilkårsvurderingPerioder: React.FC<IProps> = ({
                         {stegErBehandlet ? 'Neste' : 'Bekreft og fortsett'}
                     </FTButton>
                 )}
-                <FTButton variant="secondary" onClick={gåTilForrige}>
+                <FTButton variant="secondary" onClick={gåTilForrigeSteg}>
                     Forrige
                 </FTButton>
             </Navigering>


### PR DESCRIPTION
Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20486

Når en saksbehandler åpner Foreldelse- eller Vilkårsvurderingsbildet skal følgende skje:
1. Den første ubehandledde perioden skal åpnes by default
2. Dersom alle perioder er behandlet skal den første perioden kun åpnes by default - dersom behandlingen er til totrinnskontroll.
