### PR TITLE
preutfylt begrunnelse for tilbakekreving skal fylles direkte inn i be…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaContainer.test.tsx
@@ -108,9 +108,7 @@ describe('Tester: FaktaContainer', () => {
     test('- vis og fyll ut skjema', async () => {
         const user = userEvent.setup();
         setupMock(false, false, feilutbetalingFakta);
-        const behandling = mock<IBehandling>({
-            begrunnelseForTilbakekreving: 'Begrunnelse for tilbakekreving',
-        });
+        const behandling = mock<IBehandling>();
 
         const { getByText, getByRole, getAllByRole, getByTestId, queryAllByText } = render(
             <FeilutbetalingFaktaProvider behandling={behandling} fagsak={fagsak}>
@@ -164,7 +162,7 @@ describe('Tester: FaktaContainer', () => {
             )
         );
 
-        expect(getAllByRole('textbox')).toHaveLength(2);
+        expect(getAllByRole('textbox')).toHaveLength(1);
 
         expect(getAllByRole('combobox')).toHaveLength(6);
 

--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -37,11 +37,6 @@ const FaktaSkjema: React.FC<IProps> = ({
         gåTilForrige,
     } = useFeilutbetalingFakta();
 
-    const onChangeBegrunnelse = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        const nyVerdi = e.target.value;
-        oppdaterBegrunnelse(nyVerdi);
-    };
-
     return (
         <HGrid columns={2} gap="10">
             <VStack gap="5">
@@ -92,21 +87,12 @@ const FaktaSkjema: React.FC<IProps> = ({
                         />
                     )}
                 </VStack>
-                {behandling.begrunnelseForTilbakekreving && (
-                    <Textarea
-                        name={'begrunnelse for tilbakekreving'}
-                        label={'Begrunnelse for tilbakekreving fra fagsystem'}
-                        readOnly={true}
-                        value={behandling.begrunnelseForTilbakekreving}
-                        className={'lesevisning'}
-                    />
-                )}
                 <Textarea
                     name={'begrunnelse'}
                     label={'Forklar årsaken(e) til feilutbetalingen'}
                     readOnly={erLesevisning}
                     value={skjemaData.begrunnelse ? skjemaData.begrunnelse : ''}
-                    onChange={event => onChangeBegrunnelse(event)}
+                    onChange={e => oppdaterBegrunnelse(e.target.value)}
                     maxLength={3000}
                     className={erLesevisning ? 'lesevisning' : ''}
                     error={


### PR DESCRIPTION
…grunnelsesfeltet på faktasiden
Etter ønske fra Mirja og forespurte saksbehandlere, så skal begrunnelse for tilbakekreving preutfylles direkte inn i tekstfeltet på faktasiden.

<img width="599" alt="Skjermbilde 2024-05-02 kl  11 24 04" src="https://github.com/navikt/familie-tilbake-frontend/assets/32769446/0899db4f-4708-4c24-8427-6d97eecb5c88">
