### PR TITLE
Ferdigstill ulagret datamodal

### DIFF
--- a/src/frontend/context/BehandlingContext.tsx
+++ b/src/frontend/context/BehandlingContext.tsx
@@ -53,12 +53,6 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         settIkkePersisterteKomponenter(new Set(ikkePersisterteKomponenter).add(komponentId));
     };
 
-    const nullstillIkkePersistertKomponent = (komponentId: string) => {
-        const kopi = new Set(ikkePersisterteKomponenter);
-        kopi.delete(komponentId);
-        settIkkePersisterteKomponenter(kopi);
-    };
-
     const nullstillIkkePersisterteKomponenter = () => {
         if (ikkePersisterteKomponenter.size > 0) {
             settIkkePersisterteKomponenter(new Set());
@@ -210,7 +204,6 @@ const [BehandlingProvider, useBehandling] = createUseContext(() => {
         visBrevmottakerModal,
         settVisBrevmottakerModal,
         settIkkePersistertKomponent,
-        nullstillIkkePersistertKomponent,
         nullstillIkkePersisterteKomponenter,
     };
 });

--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -70,6 +70,7 @@ const BehandlingContainer: React.FC<IProps> = ({ fagsak, behandling }) => {
         if (visVenteModal === false) {
             if (!erØnsketSideLovlig && aktivtSteg) {
                 const aktivSide = utledBehandlingSide(aktivtSteg.behandlingssteg);
+                console.log('utledet side', aktivSide);
                 if (aktivSide) {
                     navigate(`${behandlingUrl}/${aktivSide?.href}`);
                 }

--- a/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/FeilutbetalingForeldelseContext.tsx
@@ -14,6 +14,7 @@ import {
 import { ForeldelsePeriodeSkjemeData } from './typer/feilutbetalingForeldelse';
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../hooks/useRedirectEtterLagring';
 import { Foreldelsevurdering } from '../../../kodeverk';
 import { ForeldelseStegPayload, PeriodeForeldelseStegPayload } from '../../../typer/api';
 import { Behandlingssteg, Behandlingstatus, IBehandling } from '../../../typer/behandling';
@@ -57,8 +58,14 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
         const [valgtPeriode, settValgtPeriode] = React.useState<ForeldelsePeriodeSkjemeData>();
         const [allePerioderBehandlet, settAllePerioderBehandlet] = React.useState<boolean>(false);
         const [senderInn, settSenderInn] = React.useState<boolean>(false);
-        const { erStegBehandlet, erStegAutoutført, visVenteModal, hentBehandlingMedBehandlingId } =
-            useBehandling();
+        const {
+            erStegBehandlet,
+            erStegAutoutført,
+            visVenteModal,
+            hentBehandlingMedBehandlingId,
+            nullstillIkkePersisterteKomponenter,
+        } = useBehandling();
+        const { utførRedirect } = useRedirectEtterLagring();
         const { gjerFeilutbetalingForeldelseKall, sendInnFeilutbetalingForeldelse } =
             useBehandlingApi();
         const navigate = useNavigate();
@@ -192,8 +199,9 @@ const [FeilutbetalingForeldelseProvider, useFeilutbetalingForeldelse] = createUs
         };
 
         const sendInnSkjema = () => {
+            nullstillIkkePersisterteKomponenter();
             if (stegErBehandlet && !harEndretOpplysninger()) {
-                gåTilNesteSteg();
+                utførRedirect(`${behandlingUrl}/${sider.VILKÅRSVURDERING.href}`);
             } else {
                 settSenderInn(true);
                 const payload: ForeldelseStegPayload = {

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelseContainer.test.tsx
@@ -100,6 +100,8 @@ describe('Tester: ForeldelseContainer', () => {
             visVenteModal: false,
             behandlingILesemodus: lesevisning,
             hentBehandlingMedBehandlingId: () => Promise.resolve(),
+            settIkkePersistertKomponent: jest.fn(),
+            nullstillIkkePersisterteKomponenter: jest.fn(),
         }));
     };
 

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.test.tsx
@@ -26,6 +26,15 @@ jest.mock('../FeilutbetalingForeldelseContext', () => {
     };
 });
 
+jest.mock('../../../../context/BehandlingContext', () => {
+    return {
+        useBehandling: () => ({
+            settIkkePersistertKomponent: jest.fn(),
+            nullstillIkkePersistertKomponent: jest.fn(),
+        }),
+    };
+});
+
 describe('Tester: FeilutbetalingForeldelsePeriodeSkjema', () => {
     const behandling = mock<IBehandling>();
     const periode: ForeldelsePeriodeSkjemeData = {

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -20,6 +20,7 @@ import { Valideringsstatus } from '@navikt/familie-skjema';
 
 import { useForeldelsePeriodeSkjema } from './ForeldelsePeriodeSkjemaContext';
 import SplittPeriode from './SplittPeriode/SplittPeriode';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import {
     Foreldelsevurdering,
     foreldelsevurderinger,
@@ -63,6 +64,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
     const { skjema, onBekreft } = useForeldelsePeriodeSkjema(
         (oppdatertPeriode: ForeldelsePeriodeSkjemeData) => oppdaterPeriode(oppdatertPeriode)
     );
+    const { settIkkePersistertKomponent } = useBehandling();
 
     React.useEffect(() => {
         skjema.felter.begrunnelse.onChange(periode?.begrunnelse || '');
@@ -176,9 +178,10 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                     maxLength={3000}
                     readOnly={erLesevisning}
                     value={skjema.felter.begrunnelse.verdi}
-                    onChange={event =>
-                        skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
-                    }
+                    onChange={event => {
+                        skjema.felter.begrunnelse.validerOgSettFelt(event.target.value);
+                        settIkkePersistertKomponent('foreldelse');
+                    }}
                 />
                 <HGrid columns={{ md: 1, lg: 2 }} gap="4">
                     <RadioGroup
@@ -191,9 +194,10 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                                 ? skjema.felter.foreldelsesvurderingstype.feilmelding?.toString()
                                 : ''
                         }
-                        onChange={(val: Foreldelsevurdering) =>
-                            skjema.felter.foreldelsesvurderingstype.validerOgSettFelt(val)
-                        }
+                        onChange={(val: Foreldelsevurdering) => {
+                            skjema.felter.foreldelsesvurderingstype.validerOgSettFelt(val);
+                            settIkkePersistertKomponent('foreldelse');
+                        }}
                     >
                         {foreldelseVurderingTyper.map(type => (
                             <Radio key={type} name="foreldet" value={type}>
@@ -210,6 +214,9 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                                 visFeilmeldinger={ugyldigOppdagelsesdatoValgt}
                                 readOnly={erLesevisning}
                                 kanKunVelgeFortid
+                                settIkkePersistertKomponent={() =>
+                                    settIkkePersistertKomponent('foreldelse')
+                                }
                             />
                         )}
                         {(erForeldet || erMedTilleggsfrist) && (
@@ -222,6 +229,9 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                                     }
                                     visFeilmeldinger={ugyldigForeldelsesfristValgt}
                                     readOnly={erLesevisning}
+                                    settIkkePersistertKomponent={() =>
+                                        settIkkePersistertKomponent('foreldelse')
+                                    }
                                 />
                                 {!erLesevisning && (
                                     <ReadMore header="Hvordan sette foreldelsesfrist">

--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.test.tsx
@@ -52,6 +52,8 @@ describe('Tester: SendMelding', () => {
         useBehandling.mockImplementation(() => ({
             behandlingILesemodus: false,
             hentBehandlingMedBehandlingId: () => Promise.resolve(),
+            settIkkePersistertKomponent: jest.fn(),
+            nullstillIkkePersisterteKomponenter: jest.fn(),
         }));
         const behandling = mock<IBehandling>({
             varselSendt: false,

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.test.tsx
@@ -52,6 +52,8 @@ describe('Tester: Totrinnskontroll', () => {
             visVenteModal: false,
             erBehandlingReturnertFraBeslutter: () => returnertFraBeslutter,
             hentBehandlingMedBehandlingId: () => Promise.resolve(),
+            settIkkePersistertKomponent: jest.fn(),
+            nullstillIkkePersisterteKomponenter: jest.fn(),
         }));
     };
 

--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/Totrinnskontroll.test.tsx
@@ -22,6 +22,11 @@ jest.mock('../../../../api/behandling', () => ({
     useBehandlingApi: jest.fn(),
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => jest.fn(),
+}));
+
 describe('Tester: Totrinnskontroll', () => {
     const setupMock = (returnertFraBeslutter: boolean, totrinnkontroll: ITotrinnkontroll) => {
         // @ts-ignore
@@ -46,7 +51,7 @@ describe('Tester: Totrinnskontroll', () => {
             erStegBehandlet: () => false,
             visVenteModal: false,
             erBehandlingReturnertFraBeslutter: () => returnertFraBeslutter,
-            hentBehandlingMedBehandlingId: jest.fn(),
+            hentBehandlingMedBehandlingId: () => Promise.resolve(),
         }));
     };
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/Behandlingsmeny.tsx
@@ -161,6 +161,13 @@ const Behandlingsmeny: React.FC<IProps> = ({ fagsak }) => {
                                             />
                                         </li>
                                     )}
+                                    <li>
+                                        <OpprettFjernVerge
+                                            behandling={behandling.data}
+                                            fagsak={fagsak}
+                                            onListElementClick={() => settVisMeny(false)}
+                                        />
+                                    </li>
                                 </>
                             )}
                     </StyledList>

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/EndreBehandlendeEnhet/EndreBehandlendeEnhetContext.tsx
@@ -5,7 +5,7 @@ import { useBehandling } from '../../../../../context/BehandlingContext';
 import { erFeltetEmpty, validerTekstFeltMaksLengde } from '../../../../../utils';
 
 const useEndreBehandlendeEnhet = (behandlingId: string, lukkModal: (_vis: boolean) => void) => {
-    const { hentBehandlingMedBehandlingId } = useBehandling();
+    const { hentBehandlingMedBehandlingId, nullstillIkkePersisterteKomponenter } = useBehandling();
 
     const { skjema, kanSendeSkjema, onSubmit, nullstillSkjema } = useSkjema<
         {
@@ -33,6 +33,7 @@ const useEndreBehandlendeEnhet = (behandlingId: string, lukkModal: (_vis: boolea
 
     const sendInn = () => {
         if (kanSendeSkjema()) {
+            nullstillIkkePersisterteKomponenter();
             onSubmit(
                 {
                     method: 'PUT',

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.test.tsx
@@ -47,6 +47,8 @@ describe('Tester: HenleggBehandlingModal', () => {
         // @ts-ignore
         useBehandling.mockImplementation(() => ({
             hentBehandlingMedBehandlingId: () => Promise.resolve(),
+            settIkkePersistertKomponent: jest.fn(),
+            nullstillIkkePersisterteKomponenter: jest.fn(),
         }));
     });
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModal.test.tsx
@@ -46,7 +46,7 @@ describe('Tester: HenleggBehandlingModal', () => {
         }));
         // @ts-ignore
         useBehandling.mockImplementation(() => ({
-            hentBehandlingMedBehandlingId: jest.fn(),
+            hentBehandlingMedBehandlingId: () => Promise.resolve(),
         }));
     });
 

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModalContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HenleggBehandling/HenleggBehandlingModal/HenleggBehandlingModalContext.tsx
@@ -39,6 +39,7 @@ interface IProps {
 export const useHenleggBehandlingSkjema = ({ behandling, settVisModal }: IProps) => {
     const { hentBehandlingMedBehandlingId } = useBehandling();
     const { henleggBehandling } = useBehandlingApi();
+    const { nullstillIkkePersisterteKomponenter } = useBehandling();
 
     const årsakkode = useFelt<Behandlingresultat | ''>({
         verdi: '',
@@ -81,6 +82,7 @@ export const useHenleggBehandlingSkjema = ({ behandling, settVisModal }: IProps)
     const onBekreft = () => {
         validerAlleSynligeFelter();
         if (kanSendeSkjema()) {
+            nullstillIkkePersisterteKomponenter();
             const payload: HenleggBehandlingPaylod = {
                 //@ts-ignore
                 behandlingsresultatstype: skjema.felter.årsakkode.verdi,

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilFjernBrevmottakere/LeggTilFjernBrevmottakere.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/LeggTilFjernBrevmottakere/LeggTilFjernBrevmottakere.tsx
@@ -9,6 +9,7 @@ import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../../../hooks/useRedirectEtterLagring';
 import {
     Behandlingssteg,
     Behandlingsstegstatus,
@@ -33,8 +34,13 @@ const LeggTilFjernBrevmottakere: React.FC<IProps> = ({
     const [visFjernModal, settVisFjernModal] = React.useState<boolean>(false);
     const [senderInn, settSenderInn] = React.useState<boolean>(false);
     const [feilmelding, settFeilmelding] = React.useState<string>();
-    const { hentBehandlingMedBehandlingId, behandlingILesemodus, settVisBrevmottakerModal } =
-        useBehandling();
+    const {
+        hentBehandlingMedBehandlingId,
+        behandlingILesemodus,
+        settVisBrevmottakerModal,
+        nullstillIkkePersisterteKomponenter,
+    } = useBehandling();
+    const { utførRedirect } = useRedirectEtterLagring();
     const { request } = useHttp();
     const { settToast } = useApp();
     const navigate = useNavigate();
@@ -48,6 +54,7 @@ const LeggTilFjernBrevmottakere: React.FC<IProps> = ({
         );
 
     const opprettBrevmottakerSteg = () => {
+        nullstillIkkePersisterteKomponenter();
         settSenderInn(true);
         request<void, string>({
             method: 'POST',
@@ -72,6 +79,7 @@ const LeggTilFjernBrevmottakere: React.FC<IProps> = ({
     };
 
     const fjernBrevmottakerSteg = () => {
+        nullstillIkkePersisterteKomponenter();
         settSenderInn(true);
         request<void, string>({
             method: 'PUT',
@@ -81,7 +89,7 @@ const LeggTilFjernBrevmottakere: React.FC<IProps> = ({
             if (respons.status === RessursStatus.SUKSESS) {
                 settVisFjernModal(false);
                 hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
-                    navigate(
+                    utførRedirect(
                         `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
                     );
                 });

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingSkjemaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettBehandling/OpprettBehandlingSkjemaContext.tsx
@@ -1,6 +1,8 @@
 import { useFelt, useSkjema } from '@navikt/familie-skjema';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
+import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../../../hooks/useRedirectEtterLagring';
 import { Behandlingstype, Behandlingårsak } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
 import { erFeltetEmpty } from '../../../../../utils';
@@ -10,6 +12,8 @@ const useOpprettBehandlingSkjema = (
     behandlingId: string,
     lukkModal: (_vis: boolean) => void
 ) => {
+    const { nullstillIkkePersisterteKomponenter } = useBehandling();
+    const { utførRedirect } = useRedirectEtterLagring();
     const { skjema, kanSendeSkjema, onSubmit, nullstillSkjema } = useSkjema<
         {
             behandlingstype: Behandlingstype;
@@ -32,6 +36,7 @@ const useOpprettBehandlingSkjema = (
 
     const sendInn = () => {
         if (kanSendeSkjema()) {
+            nullstillIkkePersisterteKomponenter();
             onSubmit(
                 {
                     method: 'POST',
@@ -45,7 +50,9 @@ const useOpprettBehandlingSkjema = (
                 (response: Ressurs<string>) => {
                     if (response.status === RessursStatus.SUKSESS) {
                         lukkModal(false);
-                        window.location.href = `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${response.data}`;
+                        utførRedirect(
+                            `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${response.data}`
+                        );
                     }
                 }
             );

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettFjernVerge/OpprettFjernVerge.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/OpprettFjernVerge/OpprettFjernVerge.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { ErrorMessage, Modal } from '@navikt/ds-react';
 import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../../../hooks/useRedirectEtterLagring';
 import { Behandlingssteg, IBehandling } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
 import { BehandlingsMenyButton, FTButton } from '../../../../Felleskomponenter/Flytelementer';
@@ -21,14 +20,20 @@ const OpprettFjernVerge: React.FC<IProps> = ({ behandling, fagsak, onListElement
     const [visModal, settVisModal] = React.useState<boolean>(false);
     const [senderInn, settSenderInn] = React.useState<boolean>(false);
     const [feilmelding, settFeilmelding] = React.useState<string>();
-    const { hentBehandlingMedBehandlingId, aktivtSteg, behandlingILesemodus } = useBehandling();
+    const {
+        hentBehandlingMedBehandlingId,
+        aktivtSteg,
+        behandlingILesemodus,
+        nullstillIkkePersisterteKomponenter,
+    } = useBehandling();
     const { request } = useHttp();
-    const navigate = useNavigate();
+    const { utførRedirect } = useRedirectEtterLagring();
 
     const kanFjerneVerge =
         behandling.harVerge || aktivtSteg?.behandlingssteg === Behandlingssteg.VERGE;
 
     const opprettVerge = () => {
+        nullstillIkkePersisterteKomponenter();
         request<void, string>({
             method: 'POST',
             url: `/familie-tilbake/api/behandling/v1/${behandling.behandlingId}/verge`,
@@ -37,7 +42,7 @@ const OpprettFjernVerge: React.FC<IProps> = ({ behandling, fagsak, onListElement
                 settSenderInn(false);
                 settVisModal(false);
                 hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
-                    navigate(
+                    utførRedirect(
                         `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
                     );
                 });
@@ -52,6 +57,7 @@ const OpprettFjernVerge: React.FC<IProps> = ({ behandling, fagsak, onListElement
     };
 
     const fjernVerge = () => {
+        nullstillIkkePersisterteKomponenter();
         request<void, string>({
             method: 'PUT',
             url: `/familie-tilbake/api/behandling/v1/${behandling.behandlingId}/verge`,
@@ -60,7 +66,7 @@ const OpprettFjernVerge: React.FC<IProps> = ({ behandling, fagsak, onListElement
                 settSenderInn(false);
                 settVisModal(false);
                 hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
-                    navigate(
+                    utførRedirect(
                         `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
                     );
                 });

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../../../hooks/useRedirectEtterLagring';
 import { IBehandling } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
 import { BehandlingsMenyButton } from '../../../../Felleskomponenter/Flytelementer';
@@ -25,10 +24,11 @@ const SettBehandlingTilbakeTilFakta: React.FC<IProps> = ({
 }) => {
     const { request } = useHttp();
     const { settToast } = useApp();
-    const { hentBehandlingMedBehandlingId } = useBehandling();
-    const navigate = useNavigate();
+    const { hentBehandlingMedBehandlingId, nullstillIkkePersisterteKomponenter } = useBehandling();
+    const { utførRedirect } = useRedirectEtterLagring();
 
     const settBehandlingTilbakeTilFakta = () => {
+        nullstillIkkePersisterteKomponenter();
         request<void, string>({
             method: 'PUT',
             url: `/familie-tilbake/api/forvaltning/behandling/${behandling.behandlingId}/flytt-behandling/v1`,
@@ -39,7 +39,7 @@ const SettBehandlingTilbakeTilFakta: React.FC<IProps> = ({
                     tekst: 'Flyttet behandling tilbake til fakta',
                 });
                 hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
-                    navigate(
+                    utførRedirect(
                         `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
                     );
                 });

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/hentOppdatertKravgrunnlag/HentOppdatertKravgrunnlag.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/hentOppdatertKravgrunnlag/HentOppdatertKravgrunnlag.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { useHttp } from '@navikt/familie-http';
 import { type Ressurs, RessursStatus } from '@navikt/familie-typer';
 
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../../../hooks/useRedirectEtterLagring';
 import { IBehandling } from '../../../../../typer/behandling';
 import { IFagsak } from '../../../../../typer/fagsak';
 import { BehandlingsMenyButton } from '../../../../Felleskomponenter/Flytelementer';
@@ -25,10 +24,11 @@ const HentOppdatertKravgrunnlag: React.FC<IProps> = ({
 }) => {
     const { request } = useHttp();
     const { settToast } = useApp();
-    const { hentBehandlingMedBehandlingId } = useBehandling();
-    const navigate = useNavigate();
+    const { hentBehandlingMedBehandlingId, nullstillIkkePersisterteKomponenter } = useBehandling();
+    const { utførRedirect } = useRedirectEtterLagring();
 
     const hentKorrigertKravgrunnlag = () => {
+        nullstillIkkePersisterteKomponenter();
         request<void, string>({
             method: 'PUT',
             url: `/familie-tilbake/api/forvaltning/behandling/${behandling.behandlingId}/kravgrunnlag/v1`,
@@ -39,7 +39,7 @@ const HentOppdatertKravgrunnlag: React.FC<IProps> = ({
                     tekst: 'Hentet korrigert kravgrunnlag',
                 });
                 hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
-                    navigate(
+                    utførRedirect(
                         `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
                     );
                 });

--- a/src/frontend/komponenter/Fagsak/Vedtak/AvsnittSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/AvsnittSkjema.tsx
@@ -76,18 +76,18 @@ const AvsnittSkjema: React.FC<IProps> = ({
     erLesevisning,
     erRevurderingBortfaltBeløp,
 }) => {
-    const [åpen, settÅpen] = React.useState<boolean>(false);
+    const [erEkspandert, settErEkspandert] = React.useState<boolean>(false);
 
     const harPåkrevetFritekstMenIkkeUtfylt = skalVisesÅpen(avsnitt);
 
     React.useEffect(() => {
-        settÅpen(åpen || harPåkrevetFritekstMenIkkeUtfylt);
+        settErEkspandert(erEkspandert || harPåkrevetFritekstMenIkkeUtfylt);
     }, [avsnitt]);
 
     return (
         <StyledExpansionCard
-            open={åpen}
-            onToggle={() => settÅpen(!åpen)}
+            open={erEkspandert}
+            onToggle={() => settErEkspandert(prevState => !prevState)}
             aria-label={avsnitt.overskrift ?? 'ekspanderbart panel'}
             size="small"
         >

--- a/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetalingVedtakContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/FeilutbetalingVedtakContext.tsx
@@ -94,7 +94,11 @@ const [FeilutbetalingVedtakProvider, useFeilutbetalingVedtak] = createUseContext
         const [nonUsedKey, settNonUsedKey] = React.useState<string>(Date.now().toString());
         const [senderInn, settSenderInn] = React.useState<boolean>(false);
         const [foreslåVedtakRespons, settForeslåVedtakRespons] = React.useState<Ressurs<string>>();
-        const { visVenteModal, hentBehandlingMedBehandlingId } = useBehandling();
+        const {
+            visVenteModal,
+            hentBehandlingMedBehandlingId,
+            nullstillIkkePersisterteKomponenter,
+        } = useBehandling();
         const { gjerVedtaksbrevteksterKall, gjerBeregningsresultatKall, sendInnForeslåVedtak } =
             useBehandlingApi();
         const { lagreUtkastVedtaksbrev } = useDokumentApi();
@@ -256,6 +260,7 @@ const [FeilutbetalingVedtakProvider, useFeilutbetalingVedtak] = createUseContext
             if (!harPåkrevetFritekstMenIkkeUtfylt && validerAlleAvsnittOk(true)) {
                 settSenderInn(true);
                 settForeslåVedtakRespons(undefined);
+                nullstillIkkePersisterteKomponenter();
                 const payload: ForeslåVedtakStegPayload = {
                     '@type': 'FORESLÅ_VEDTAK',
                     fritekstavsnitt: lagFritekstavsnitt(),
@@ -290,6 +295,7 @@ const [FeilutbetalingVedtakProvider, useFeilutbetalingVedtak] = createUseContext
             if (validerAlleAvsnittOk(false)) {
                 settSenderInn(true);
                 settForeslåVedtakRespons(undefined);
+                nullstillIkkePersisterteKomponenter();
                 lagreUtkastVedtaksbrev(behandling.behandlingId, lagFritekstavsnitt())
                     .then((respons: Ressurs<string>) => {
                         settSenderInn(false);

--- a/src/frontend/komponenter/Fagsak/Vedtak/ForhåndsvisVedtaksbrev/ForhåndsvisVedtaksbrev.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/ForhåndsvisVedtaksbrev/ForhåndsvisVedtaksbrev.tsx
@@ -4,11 +4,7 @@ import { useForhåndsvisVedtaksbrev } from './useForhåndsvisVedtaksbrev';
 import { FTButton } from '../../../Felleskomponenter/Flytelementer';
 import PdfVisningModal from '../../../Felleskomponenter/PdfVisningModal/PdfVisningModal';
 
-interface IProps {
-    test?: boolean;
-}
-
-const ForhåndsvisVedtaksbrev: React.FC<IProps> = () => {
+const ForhåndsvisVedtaksbrev: React.FC = () => {
     const {
         hentetForhåndsvisning,
         hentVedtaksbrev,

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.test.tsx
@@ -35,6 +35,13 @@ jest.mock('../../../api/behandling', () => ({
     useBehandlingApi: jest.fn(),
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => jest.fn(),
+}));
+
+const mockedSettIkkePersistertKomponent = jest.fn();
+
 describe('Tester: VedtakContainer', () => {
     const perioder: BeregningsresultatPeriode[] = [
         {
@@ -121,7 +128,9 @@ describe('Tester: VedtakContainer', () => {
         useBehandling.mockImplementation(() => ({
             visVenteModal: false,
             behandlingILesemodus: lesevisning,
-            hentBehandlingMedBehandlingId: jest.fn(),
+            hentBehandlingMedBehandlingId: () => Promise.resolve(),
+            settIkkePersistertKomponent: mockedSettIkkePersistertKomponent,
+            nullstillIkkePersisterteKomponenter: jest.fn(),
         }));
     };
 
@@ -509,6 +518,7 @@ describe('Tester: VedtakContainer', () => {
                 })
             )
         );
+        expect(mockedSettIkkePersistertKomponent).toHaveBeenCalledWith('vedtak');
     });
 
     test('- vis og fyll ut - 1 fritekst påkrevet - fyller ut 1 ekstra fritekst - revurdering NFP', async () => {
@@ -668,6 +678,7 @@ describe('Tester: VedtakContainer', () => {
                 })
             )
         );
+        expect(mockedSettIkkePersistertKomponent).toHaveBeenCalledWith('vedtak');
     });
 
     test('- vis utfylt - 1 fritekst påkrevet - 1 ekstra fritekst', async () => {

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakContainer.tsx
@@ -78,7 +78,7 @@ const VedtakContainer: React.FC<IProps> = ({ behandling, fagsak }) => {
             Behandlingårsak.REVURDERING_FEILUTBETALT_BELØP_HELT_ELLER_DELVIS_BORTFALT;
 
     React.useEffect(() => {
-        // console.log('bør no trigge re-rendring');
+        // Skal trigge re-rendring
     }, [nonUsedKey]);
 
     if (!behandling) return null;

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
@@ -7,6 +7,7 @@ import { BodyShort, Link, Textarea } from '@navikt/ds-react';
 
 import { useFeilutbetalingVedtak } from './FeilutbetalingVedtakContext';
 import { UnderavsnittSkjemaData } from './typer/feilutbetalingVedtak';
+import { useBehandling } from '../../../context/BehandlingContext';
 import { harVerdi, isEmpty, validerTekstMaksLengde } from '../../../utils';
 import { Spacer8 } from '../../Felleskomponenter/Flytelementer';
 
@@ -27,12 +28,14 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
     maximumLength,
     erLesevisning,
 }) => {
-    const [fritekstfeltErSynlig, settFritekstfeltErSynlig] = React.useState<boolean>();
     const { oppdaterUnderavsnitt } = useFeilutbetalingVedtak();
+    const { settIkkePersistertKomponent } = useBehandling();
+    const { fritekst, fritekstPåkrevet, index, harFeil, feilmelding } = underavsnitt;
+    const [fritekstfeltErSynlig, settFritekstfeltErSynlig] = React.useState<boolean>();
 
     React.useEffect(() => {
-        settFritekstfeltErSynlig(harVerdi(underavsnitt.fritekst) || underavsnitt.fritekstPåkrevet);
-    }, [underavsnitt]);
+        settFritekstfeltErSynlig(harVerdi(fritekst) || fritekstPåkrevet);
+    }, [fritekst, fritekstPåkrevet]);
 
     const lenkeKnappErSynlig = !fritekstfeltErSynlig && !erLesevisning;
 
@@ -40,9 +43,10 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
         const maxLength = maximumLength ? maximumLength : 4000;
         const nyVerdi = e.target.value;
         const feilmelding =
-            isEmpty(nyVerdi) && !underavsnitt.fritekstPåkrevet
+            isEmpty(nyVerdi) && !fritekstPåkrevet
                 ? undefined
                 : validerTekstMaksLengde(maxLength)(nyVerdi);
+        settIkkePersistertKomponent('vedtak');
         oppdaterUnderavsnitt(avsnittIndex, {
             ...underavsnitt,
             fritekst: nyVerdi,
@@ -58,7 +62,7 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
                     <Spacer8 />
                     <Link
                         role="button"
-                        data-testid={`legg-til-fritekst-${avsnittIndex}-${underavsnitt.index}`}
+                        data-testid={`legg-til-fritekst-${avsnittIndex}-${index}`}
                         onClick={e => {
                             e.preventDefault();
                             settFritekstfeltErSynlig(true);
@@ -81,14 +85,14 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
                     <Spacer8 />
                     <Textarea
                         name={'fritekst'}
-                        data-testid={`fritekst-${avsnittIndex}-${underavsnitt.index}`}
+                        data-testid={`fritekst-${avsnittIndex}-${index}`}
                         label={!erLesevisning ? 'Utdypende tekst' : undefined}
                         readOnly={erLesevisning}
                         maxLength={maximumLength ? maximumLength : 4000}
                         minLength={3}
-                        value={underavsnitt.fritekst ? underavsnitt.fritekst : ''}
+                        value={fritekst ? fritekst : ''}
                         onChange={event => onChange(event)}
-                        error={underavsnitt.harFeil ? underavsnitt.feilmelding : null}
+                        error={harFeil ? feilmelding : null}
                     />
                     <Spacer8 />
                 </>

--- a/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vedtak/VedtakFritekstSkjema.tsx
@@ -7,7 +7,7 @@ import { BodyShort, Link, Textarea } from '@navikt/ds-react';
 
 import { useFeilutbetalingVedtak } from './FeilutbetalingVedtakContext';
 import { UnderavsnittSkjemaData } from './typer/feilutbetalingVedtak';
-import { isEmpty, validerTekstMaksLengde } from '../../../utils';
+import { harVerdi, isEmpty, validerTekstMaksLengde } from '../../../utils';
 import { Spacer8 } from '../../Felleskomponenter/Flytelementer';
 
 const StyledUndertekst = styled(BodyShort)`
@@ -27,12 +27,14 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
     maximumLength,
     erLesevisning,
 }) => {
-    const [isTextfieldHidden, hideTextField] = React.useState<boolean>();
+    const [fritekstfeltErSynlig, settFritekstfeltErSynlig] = React.useState<boolean>();
     const { oppdaterUnderavsnitt } = useFeilutbetalingVedtak();
 
     React.useEffect(() => {
-        hideTextField(!underavsnitt.fritekst && !underavsnitt.fritekstPåkrevet);
+        settFritekstfeltErSynlig(harVerdi(underavsnitt.fritekst) || underavsnitt.fritekstPåkrevet);
     }, [underavsnitt]);
+
+    const lenkeKnappErSynlig = !fritekstfeltErSynlig && !erLesevisning;
 
     const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const maxLength = maximumLength ? maximumLength : 4000;
@@ -51,7 +53,7 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
 
     return (
         <>
-            {isTextfieldHidden && !erLesevisning && (
+            {lenkeKnappErSynlig && (
                 <>
                     <Spacer8 />
                     <Link
@@ -59,12 +61,12 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
                         data-testid={`legg-til-fritekst-${avsnittIndex}-${underavsnitt.index}`}
                         onClick={e => {
                             e.preventDefault();
-                            hideTextField(false);
+                            settFritekstfeltErSynlig(true);
                         }}
                         onKeyUp={e => {
                             const key = e.code || e.keyCode;
                             if (key === 'Space' || key === 'Enter' || key === 32 || key === 13) {
-                                hideTextField(false);
+                                settFritekstfeltErSynlig(true);
                             }
                         }}
                         href="#"
@@ -74,7 +76,7 @@ const VedtakFritekstSkjema: React.FC<IProps> = ({
                     </Link>
                 </>
             )}
-            {!isTextfieldHidden && (
+            {fritekstfeltErSynlig && (
                 <>
                     <Spacer8 />
                     <Textarea

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.test.tsx
@@ -31,6 +31,11 @@ jest.mock('../../../api/behandling', () => ({
     useBehandlingApi: jest.fn(),
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => jest.fn(),
+}));
+
 describe('Tester: VergeContainer', () => {
     const setupMock = (
         behandlet: boolean,
@@ -60,7 +65,7 @@ describe('Tester: VergeContainer', () => {
             erStegBehandlet: () => behandlet,
             erStegAutoutført: () => autoutført,
             behandlingILesemodus: lesevisning,
-            hentBehandlingMedBehandlingId: jest.fn(),
+            hentBehandlingMedBehandlingId: () => Promise.resolve(),
         }));
     };
 

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.test.tsx
@@ -66,6 +66,8 @@ describe('Tester: VergeContainer', () => {
             erStegAutoutført: () => autoutført,
             behandlingILesemodus: lesevisning,
             hentBehandlingMedBehandlingId: () => Promise.resolve(),
+            settIkkePersistertKomponent: jest.fn(),
+            nullstillIkkePersisterteKomponenter: jest.fn(),
         }));
     };
 

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContainer.tsx
@@ -32,12 +32,13 @@ const StyledVStack = styled(VStack)`
 
 const VergeContainer: React.FC = () => {
     const { skjema, henterData, stegErBehandlet, erAutoutført, sendInn, vergeRespons } = useVerge();
-    const { behandlingILesemodus } = useBehandling();
+    const { behandlingILesemodus, settIkkePersistertKomponent } = useBehandling();
     const erLesevisning = !!behandlingILesemodus;
 
     const onChangeVergeType = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const nyVergetype = Vergetype[e.target.value as keyof typeof Vergetype];
         skjema.felter.vergetype.validerOgSettFelt(nyVergetype);
+        settIkkePersistertKomponent('verge');
     };
 
     const vergetypeValgt = !!skjema.felter.vergetype.verdi;
@@ -96,9 +97,10 @@ const VergeContainer: React.FC = () => {
                                 label={'Navn'}
                                 readOnly={erLesevisning}
                                 value={skjema.felter.navn.verdi}
-                                onChange={event =>
-                                    skjema.felter.navn.validerOgSettFelt(event.target.value)
-                                }
+                                onChange={event => {
+                                    skjema.felter.navn.validerOgSettFelt(event.target.value);
+                                    settIkkePersistertKomponent('verge');
+                                }}
                             />
                             {skjema.felter.vergetype.verdi === Vergetype.ADVOKAT ? (
                                 <TextField
@@ -108,11 +110,12 @@ const VergeContainer: React.FC = () => {
                                     label={'Organisasjonsnummer'}
                                     readOnly={erLesevisning}
                                     value={skjema.felter.organisasjonsnummer.verdi}
-                                    onChange={event =>
+                                    onChange={event => {
                                         skjema.felter.organisasjonsnummer.validerOgSettFelt(
                                             event.target.value
-                                        )
-                                    }
+                                        );
+                                        settIkkePersistertKomponent('verge');
+                                    }}
                                 />
                             ) : (
                                 <TextField
@@ -122,11 +125,12 @@ const VergeContainer: React.FC = () => {
                                     label={'Fødselsnummer'}
                                     readOnly={erLesevisning}
                                     value={skjema.felter.fødselsnummer.verdi}
-                                    onChange={event =>
+                                    onChange={event => {
                                         skjema.felter.fødselsnummer.validerOgSettFelt(
                                             event.target.value
-                                        )
-                                    }
+                                        );
+                                        settIkkePersistertKomponent('verge');
+                                    }}
                                 />
                             )}
                         </HGrid>
@@ -136,9 +140,10 @@ const VergeContainer: React.FC = () => {
                         label={'Begrunn endringene'}
                         value={skjema.felter.begrunnelse.verdi}
                         readOnly={erLesevisning}
-                        onChange={event =>
-                            skjema.felter.begrunnelse.validerOgSettFelt(event.target.value)
-                        }
+                        onChange={event => {
+                            skjema.felter.begrunnelse.validerOgSettFelt(event.target.value);
+                            settIkkePersistertKomponent('verge');
+                        }}
                         maxLength={400}
                     />
                     {feilmelding && <ErrorMessage size="small">{feilmelding}</ErrorMessage>}

--- a/src/frontend/komponenter/Fagsak/Verge/VergeContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Verge/VergeContext.tsx
@@ -16,6 +16,7 @@ import { byggFeiletRessurs, type Ressurs, RessursStatus } from '@navikt/familie-
 
 import { useBehandlingApi } from '../../../api/behandling';
 import { useBehandling } from '../../../context/BehandlingContext';
+import { useRedirectEtterLagring } from '../../../hooks/useRedirectEtterLagring';
 import { Vergetype } from '../../../kodeverk/verge';
 import { VergeDto, VergeStegPayload } from '../../../typer/api';
 import { Behandlingssteg, IBehandling } from '../../../typer/behandling';
@@ -47,7 +48,13 @@ const [VergeProvider, useVerge] = createUseContext(({ behandling, fagsak }: IPro
     const [senderInn, settSenderInn] = React.useState<boolean>(false);
     const [vergeRespons, settVergeRepons] = React.useState<Ressurs<string>>();
     const { gjerVergeKall, sendInnVerge } = useBehandlingApi();
-    const { erStegBehandlet, erStegAutoutført, hentBehandlingMedBehandlingId } = useBehandling();
+    const {
+        erStegBehandlet,
+        erStegAutoutført,
+        hentBehandlingMedBehandlingId,
+        nullstillIkkePersisterteKomponenter,
+    } = useBehandling();
+    const { utførRedirect } = useRedirectEtterLagring();
     const navigate = useNavigate();
 
     React.useEffect(() => {
@@ -161,7 +168,8 @@ const [VergeProvider, useVerge] = createUseContext(({ behandling, fagsak }: IPro
 
     const sendInn = () => {
         if (stegErBehandlet && !harEndretOpplysninger()) {
-            navigate(
+            nullstillIkkePersisterteKomponenter();
+            utførRedirect(
                 `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${sider.FAKTA.href}`
             );
         } else if (kanSendeSkjema()) {
@@ -188,6 +196,7 @@ const [VergeProvider, useVerge] = createUseContext(({ behandling, fagsak }: IPro
                 .then((respons: Ressurs<string>) => {
                     settSenderInn(false);
                     if (respons.status === RessursStatus.SUKSESS) {
+                        nullstillIkkePersisterteKomponenter();
                         hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
                             navigate(
                                 `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`

--- a/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Datovelger/Datovelger.tsx
@@ -18,6 +18,7 @@ interface IProps {
     kanKunVelgeFortid?: boolean;
     kanKunVelgeFremtid?: boolean;
     readOnly?: boolean;
+    settIkkePersistertKomponent?: () => void;
 }
 
 export enum Feilmelding {
@@ -40,6 +41,7 @@ const Datovelger = ({
     kanKunVelgeFortid = false,
     kanKunVelgeFremtid = false,
     readOnly = false,
+    settIkkePersistertKomponent,
 }: IProps) => {
     const [error, setError] = useState<Feilmelding | undefined>(undefined);
 
@@ -65,6 +67,9 @@ const Datovelger = ({
         defaultSelected: felt.verdi,
         onDateChange: (dato?: Date) => {
             felt.validerOgSettFelt(dato);
+            if (settIkkePersistertKomponent) {
+                settIkkePersistertKomponent();
+            }
         },
         fromDate: hentFromDate(),
         toDate: hentToDate(),

--- a/src/frontend/utils/validering.ts
+++ b/src/frontend/utils/validering.ts
@@ -125,3 +125,6 @@ export const validerDato = (dato?: string): ValideringsResultat => {
 
 export const validerGyldigDato = (felt: FeltState<Date | undefined>) =>
     felt.verdi && isValid(felt.verdi) ? ok(felt) : feil(felt, 'Du må velge en gyldig dato');
+
+export const harVerdi = (str: string | undefined | null): boolean =>
+    str !== undefined && str !== '' && str !== null;


### PR DESCRIPTION
Skal vise ikke-lagret-modal på vedtaksiden. Ved klikk på "lagre utkast" og "til godkjenning" og deretter godkjent validering skal man få lov til å navigere seg bort fra siden som vanlig.

Den opptrer både ved refresh og ved navigering:
![Skjermbilde 2024-05-22 kl  11 31 16](https://github.com/navikt/familie-tilbake-frontend/assets/32769446/86031108-4050-4d9a-aa53-ee9ce889402d)
![Skjermbilde 2024-05-22 kl  11 31 24](https://github.com/navikt/familie-tilbake-frontend/assets/32769446/bdd8d3fc-e5bb-4ce1-a110-0e9c751fd01e)
