### PR TITLE
Skal vise en advarsel dersom et kravgrunnlag peker på en annen revurd…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { BodyShort, Checkbox, Heading, HGrid, Textarea, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Checkbox, Heading, HGrid, Textarea, VStack } from '@navikt/ds-react';
 
 import FeilutbetalingFaktaPerioder from './FaktaPeriode/FeilutbetalingFaktaPerioder';
 import FaktaRevurdering from './FaktaRevurdering';
@@ -39,12 +39,25 @@ const FaktaSkjema: React.FC<IProps> = ({
     } = useFeilutbetalingFakta();
     const { settIkkePersistertKomponent } = useBehandling();
 
+    const erKravgrunnlagKnyttetTilEnEnEldreRevurdering =
+        behandling.fagsystemsbehandlingId !== feilutbetalingFakta.kravgrunnlagReferanse;
+
     return (
         <HGrid columns={2} gap="10">
             <VStack gap="5">
                 <Heading level="2" size="small">
                     Feilutbetaling
                 </Heading>
+                {erKravgrunnlagKnyttetTilEnEnEldreRevurdering && (
+                    <div>
+                        <Alert variant={'warning'} size={'small'}>
+                            Kravgrunnlaget refererer ikke til den nyeste revurderingen i
+                            vedtaksløsningen.
+                            <br />
+                            Dobbeltsjekk at beløp, perioder og årsak til utbetaling stemmer.
+                        </Alert>
+                    </div>
+                )}
                 <HGrid columns={3} gap="1">
                     <div>
                         <DetailBold>Periode med feilutbetaling</DetailBold>

--- a/src/frontend/komponenter/Felleskomponenter/Steginformasjon/StegInformasjon.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Steginformasjon/StegInformasjon.tsx
@@ -23,7 +23,7 @@ interface IProps {
 
 const Steginformasjon: React.FC<IProps> = ({ behandletSteg, infotekst }) => {
     return !behandletSteg ? (
-        <StyledAlert variant="warning" children={infotekst} />
+        <StyledAlert variant="info" size={'small'} children={infotekst} />
     ) : (
         <StyledDiv>
             <Label size="small">Behandlet:</Label> <BodyShort size="small">{infotekst}</BodyShort>

--- a/src/frontend/typer/feilutbetalingtyper.ts
+++ b/src/frontend/typer/feilutbetalingtyper.ts
@@ -47,6 +47,7 @@ export interface IFeilutbetalingFakta {
     };
     revurderingsvedtaksdato: string;
     begrunnelse?: string;
+    kravgrunnlagReferanse?: string;
 }
 
 export type ForeldelsePeriode = {


### PR DESCRIPTION
…ering enn den nyeste. Dette kan oppstå dersom man har gjort en revurdering med tilhørende tilbakekreving, men valgt _avvent_ og deretter gjør en ny revurdering og oppretter en tilbakekreving via simuleringsbildet. Da vil det være _bortkastet_ å saksbehandle tilbakekrevingen ettersom den nullstilles pga nytt kravgrunnlag som vil oppstå.

Endrer den vanlige "meldingen" på hvert steg fra å være en STOR WARNING (!!!) til å bli en liten info-alert. 
![Screenshot 2024-05-27 at 14 16 50](https://github.com/navikt/familie-tilbake-frontend/assets/402915/dc30968d-a210-42eb-8c72-bdb2c9f39e78)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20999)