### PR TITLE
Skal ha en mer generell advarsel dersom tilbakekrevingsbehandlingen i…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FaktaSkjema.tsx
@@ -51,8 +51,7 @@ const FaktaSkjema: React.FC<IProps> = ({
                 {erKravgrunnlagKnyttetTilEnEnEldreRevurdering && (
                     <div>
                         <Alert variant={'warning'} size={'small'}>
-                            Kravgrunnlaget refererer ikke til den nyeste revurderingen i
-                            vedtaksløsningen.
+                            Det finnes flere revurderinger knyttet til denne tilbakekrevingen.
                             <br />
                             Dobbeltsjekk at beløp, perioder og årsak til utbetaling stemmer.
                         </Alert>


### PR DESCRIPTION
…kke peker på siste revurdering i vedtaksløsningen. Dette kan oppstå når man oppretter revurdering med tilbakekreving og det foreligger et ventende kravgrunnlag i tilbakekrevingsløsningen, eller om man oppretter to revurderinger som trigger tilbakekreving som kun genererer ett kravgrunnlag.