### PR TITLE
Skal disable valg for å sette behandling tilbake til fakta ut ifra eg…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
@@ -64,7 +64,7 @@ const SettBehandlingTilbakeTilFakta: React.FC<IProps> = ({
                     settBehandlingTilbakeTilFakta();
                     onListElementClick();
                 }}
-                disabled={!behandling.kanEndres}
+                disabled={!behandling.kanSetteTilbakeTilFakta}
             >
                 {'Sett behanling tilbake til fakta'}
             </BehandlingsMenyButton>

--- a/src/frontend/typer/behandling.ts
+++ b/src/frontend/typer/behandling.ts
@@ -170,6 +170,7 @@ export interface IBehandling {
     erBehandlingHenlagt?: boolean;
     erBehandlingPåVent?: boolean;
     kanEndres: boolean;
+    kanSetteTilbakeTilFakta: boolean;
     harVerge: boolean;
     kanHenleggeBehandling: boolean;
     kanRevurderingOpprettes: boolean;


### PR DESCRIPTION
…en variabel

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21394

PR, familie-tilbake: https://github.com/navikt/familie-tilbake/pull/1494

Skal altså også kunne disable valg for å sette tilbake i fakta i frontend basert på nye betingelser. 

![image](https://github.com/navikt/familie-tilbake-frontend/assets/56258085/ec3fecae-fbc3-4cd0-ac01-dd19adf800b4)
