### PR TITLE
Skal ikke ha høyre og venstre-meny ved historisk visning av fakta og …

### DIFF
--- a/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Fagsak/BehandlingContainer.tsx
@@ -28,6 +28,7 @@ import { useBehandling } from '../../context/BehandlingContext';
 import { Behandlingstatus, IBehandling } from '../../typer/behandling';
 import { IFagsak } from '../../typer/fagsak';
 import {
+    erHistoriskSide,
     erØnsketSideTilgjengelig,
     utledBehandlingSide,
 } from '../Felleskomponenter/Venstremeny/sider';
@@ -68,6 +69,7 @@ const BehandlingContainer: React.FC<IProps> = ({ fagsak, behandling }) => {
     const location = useLocation();
 
     const ønsketSide = location.pathname.split('/')[7];
+    const erHistoriskeVerdier = erHistoriskSide(ønsketSide);
     const erØnsketSideLovlig = ønsketSide && erØnsketSideTilgjengelig(ønsketSide, behandling);
     const behandlingUrl = `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`;
 
@@ -107,6 +109,34 @@ const BehandlingContainer: React.FC<IProps> = ({ fagsak, behandling }) => {
                 <Høyremeny fagsak={fagsak} behandling={behandling} />
             </StyledHøyremenyContainer>
         </>
+    ) : erHistoriskeVerdier ? (
+        <>
+            <StyledMainContainer id={'fagsak-main'}>
+                <HistoriskeVurderingermeny behandling={behandling} fagsak={fagsak} />
+                <Routes>
+                    <Route
+                        path={BEHANDLING_KONTEKST_PATH + '/inaktiv-fakta'}
+                        element={
+                            <HistoriskFaktaProvider behandling={behandling}>
+                                <HistoriskFaktaContainer behandling={behandling} fagsak={fagsak} />
+                            </HistoriskFaktaProvider>
+                        }
+                    />
+                    <Route
+                        path={BEHANDLING_KONTEKST_PATH + '/inaktiv-vilkaarsvurdering'}
+                        element={
+                            <HistoriskVilkårsvurderingProvider behandling={behandling}>
+                                <HistoriskVilkårsvurderingContainer
+                                    behandling={behandling}
+                                    fagsak={fagsak}
+                                />
+                            </HistoriskVilkårsvurderingProvider>
+                        }
+                    />
+                    <Route path={BEHANDLING_KONTEKST_PATH + '/inaktiv'} element={<></>} />
+                </Routes>
+            </StyledMainContainer>
+        </>
     ) : harKravgrunnlag ? (
         <>
             <StyledVenstremenyContainer>
@@ -120,14 +150,6 @@ const BehandlingContainer: React.FC<IProps> = ({ fagsak, behandling }) => {
                             <FeilutbetalingFaktaProvider behandling={behandling} fagsak={fagsak}>
                                 <FaktaContainer ytelse={fagsak.ytelsestype} />
                             </FeilutbetalingFaktaProvider>
-                        }
-                    />
-                    <Route
-                        path={BEHANDLING_KONTEKST_PATH + '/inaktiv-fakta'}
-                        element={
-                            <HistoriskFaktaProvider behandling={behandling}>
-                                <HistoriskFaktaContainer behandling={behandling} fagsak={fagsak} />
-                            </HistoriskFaktaProvider>
                         }
                     />
                     <Route
@@ -156,24 +178,6 @@ const BehandlingContainer: React.FC<IProps> = ({ fagsak, behandling }) => {
                             </FeilutbetalingVilkårsvurderingProvider>
                         }
                     />
-                    <Route
-                        path={BEHANDLING_KONTEKST_PATH + '/inaktiv-vilkaarsvurdering'}
-                        element={
-                            <HistoriskVilkårsvurderingProvider behandling={behandling}>
-                                <HistoriskVilkårsvurderingContainer
-                                    behandling={behandling}
-                                    fagsak={fagsak}
-                                />
-                            </HistoriskVilkårsvurderingProvider>
-                        }
-                    />
-                    <Route
-                        path={BEHANDLING_KONTEKST_PATH + '/inaktiv'}
-                        element={
-                            <HistoriskeVurderingermeny behandling={behandling} fagsak={fagsak} />
-                        }
-                    />
-
                     <Route
                         path={BEHANDLING_KONTEKST_PATH + '/vedtak'}
                         element={

--- a/src/frontend/komponenter/Fagsak/HistoriskeVurderingermeny/HistoriskeVurderingermeny.tsx
+++ b/src/frontend/komponenter/Fagsak/HistoriskeVurderingermeny/HistoriskeVurderingermeny.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Link, List } from '@navikt/ds-react';
+import { BodyLong, Heading, HStack, Link } from '@navikt/ds-react';
 
 import { IBehandling } from '../../../typer/behandling';
 import { IFagsak } from '../../../typer/fagsak';
@@ -17,26 +17,14 @@ const HistoriskeVurderingermeny: React.FC<{ fagsak: IFagsak; behandling: IBehand
     const basePath = `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`;
     return (
         <Container>
-            <List
-                as={'ol'}
-                title={'Historiske verdier'}
-                description={
-                    'Her kan du se tidligere verdier i de forskjellige stegene. Foreløpig er det kun støtte for å se vilkårsvurdering.'
-                }
-            >
-                <List.Item>
-                    <Link href={`${basePath}/inaktiv-fakta`}>Fakta</Link>
-                </List.Item>
-                <List.Item>
-                    <Link href={`${basePath}/inaktiv-foreldelse`}>Foreldelse</Link>
-                </List.Item>
-                <List.Item>
-                    <Link href={`${basePath}/inaktiv-vilkaarsvurdering`}>Vilkårsvurdering</Link>
-                </List.Item>
-                <List.Item>
-                    <Link href={`${basePath}/inaktiv-vedtak`}>Vedtak</Link>
-                </List.Item>
-            </List>
+            <Heading size={'small'}>Historiske verdier</Heading>
+            <BodyLong>
+                Her kan du se tidligere lagrede verdier på de stegene Fakta og Vilkårsvurdering.
+            </BodyLong>
+            <HStack gap={'4'}>
+                <Link href={`${basePath}/inaktiv-fakta`}>Fakta</Link>
+                <Link href={`${basePath}/inaktiv-vilkaarsvurdering`}>Vilkårsvurdering</Link>
+            </HStack>
         </Container>
     );
 };

--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HistoriskeVurderinger/HistoriskeVurderinger.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/HistoriskeVurderinger/HistoriskeVurderinger.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { ToggleName } from '../../../../../context/toggles';
 import { useToggles } from '../../../../../context/TogglesContext';
@@ -18,7 +16,6 @@ interface IProps {
 const HistoriskeVurderinger: React.FC<IProps> = ({ behandling, fagsak, onListElementClick }) => {
     const { behandlingILesemodus } = useBehandling();
     const { innloggetSaksbehandler } = useApp();
-    const navigate = useNavigate();
     const { toggles } = useToggles();
     const harTilgang =
         behandling.kanEndres &&
@@ -33,7 +30,7 @@ const HistoriskeVurderinger: React.FC<IProps> = ({ behandling, fagsak, onListEle
                     variant="tertiary"
                     onClick={() => {
                         onListElementClick();
-                        navigate(
+                        window.open(
                             `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/inaktiv`
                         );
                     }}

--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Buldings3Icon, ExternalLinkIcon } from '@navikt/aksel-icons';
+import { Buldings3Icon, ExternalLinkIcon, LeaveIcon } from '@navikt/aksel-icons';
 import { Link, Tag } from '@navikt/ds-react';
 import { AGray900, ATextOnInverted, ASpacing2, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -14,6 +14,8 @@ import { useFagsak } from '../../../context/FagsakContext';
 import { IFagsak } from '../../../typer/fagsak';
 import { IPerson } from '../../../typer/person';
 import { formatterDatostring, hentAlder } from '../../../utils';
+import { useLocation } from 'react-router-dom';
+import { erHistoriskSide } from '../../Felleskomponenter/Venstremeny/sider';
 
 const PlaceholderDiv = styled.div`
     flex: 1;
@@ -49,6 +51,10 @@ interface IProps {
 
 const Personlinje: React.FC<IProps> = ({ bruker, fagsak }) => {
     const { behandling, lagLenkeTilRevurdering } = useBehandling();
+    const location = useLocation();
+    const behandlingsPath = location.pathname.split('/').at(-1);
+    const erHistoriskVisning = behandlingsPath && erHistoriskSide(behandlingsPath);
+    console.log(behandlingsPath);
     const { lagSaksoversiktUrl } = useFagsak();
     return (
         <Visittkort
@@ -75,17 +81,25 @@ const Personlinje: React.FC<IProps> = ({ bruker, fagsak }) => {
             )}
             <PlaceholderDiv />
 
-            {behandling?.status === RessursStatus.SUKSESS && (
+            {behandling?.status === RessursStatus.SUKSESS && !erHistoriskVisning && (
                 <Link href={lagLenkeTilRevurdering()} target="_blank">
                     Gå til revurderingen
                     <ExternalLinkIcon aria-label="Gå til revurderingen" fontSize={'1.375rem'} />
                 </Link>
             )}
 
-            <Link href={lagSaksoversiktUrl()} target="_blank">
-                Gå til saksoversikt
-                <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
-            </Link>
+            {!erHistoriskVisning && (
+                <Link href={lagSaksoversiktUrl()} target="_blank">
+                    Gå til saksoversikt
+                    <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize={'1.375rem'} />
+                </Link>
+            )}
+            {erHistoriskVisning && (
+                <Link href={`${location.pathname.replace(behandlingsPath, '')}`}>
+                    Gå til behandling
+                    <LeaveIcon title={'Tilbake til behandlingen'} fontSize={'1.375rem'} />
+                </Link>
+            )}
 
             <Behandlingsmeny fagsak={fagsak} />
         </Visittkort>

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/historikk/HistoriskVilkårsvurderingVisning.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/historikk/HistoriskVilkårsvurderingVisning.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../../kodeverk';
 import { VilkårsvurderingPeriodeSkjemaData } from '../typer/feilutbetalingVilkårsvurdering';
 import TilbakekrevingAktivitetTabell from '../VilkårsvurderingPeriode/TilbakekrevingAktivitetTabell';
+import { formatCurrencyNoKr, formatterDatostring } from '../../../../utils';
 
 interface IProps {
     perioder: VilkårsvurderingPeriodeSkjemaData[];
@@ -40,11 +41,17 @@ const HistoriskVilkårsvurderingVisning: React.FC<IProps> = ({ perioder }) => {
                         <HGrid columns={{ lg: 2, md: 1 }} gap="8">
                             <VStack gap="4">
                                 <Box>
-                                    <LabelVerdiVisning label={'Fra'} verdi={skjema.periode.fom} />
-                                    <LabelVerdiVisning label={'Til'} verdi={skjema.periode.tom} />
+                                    <LabelVerdiVisning
+                                        label={'Fra'}
+                                        verdi={formatterDatostring(skjema.periode.fom)}
+                                    />
+                                    <LabelVerdiVisning
+                                        label={'Til'}
+                                        verdi={formatterDatostring(skjema.periode.tom)}
+                                    />
                                     <LabelVerdiVisning
                                         label={'Feilutbetalt beløp'}
-                                        verdi={skjema.feilutbetaltBeløp}
+                                        verdi={formatCurrencyNoKr(skjema.feilutbetaltBeløp)}
                                     />
                                     <TilbakekrevingAktivitetTabell ytelser={skjema.aktiviteter} />
                                 </Box>
@@ -95,7 +102,9 @@ const HistoriskVilkårsvurderingVisning: React.FC<IProps> = ({ perioder }) => {
                                                 label={'Tilbakekrevd beløp'}
                                                 verdi={
                                                     godTro.beløpErIBehold
-                                                        ? godTro.beløpTilbakekreves
+                                                        ? formatCurrencyNoKr(
+                                                              godTro.beløpTilbakekreves
+                                                          )
                                                         : 'Ingen tilbakekreving'
                                                 }
                                             />
@@ -157,7 +166,9 @@ const HistoriskVilkårsvurderingVisning: React.FC<IProps> = ({ perioder }) => {
                                             {aktsomhet.beløpTilbakekreves && (
                                                 <LabelVerdiVisning
                                                     label={'Beløp tilbakekreves'}
-                                                    verdi={aktsomhet.beløpTilbakekreves}
+                                                    verdi={formatCurrencyNoKr(
+                                                        aktsomhet.beløpTilbakekreves
+                                                    )}
                                                 />
                                             )}
                                             {aktsomhet.tilbakekrevSmåbeløp === false && (

--- a/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
+++ b/src/frontend/komponenter/Felleskomponenter/Venstremeny/sider.ts
@@ -113,7 +113,7 @@ const historiskeSider = [
     'inaktiv',
 ];
 
-const erHistoriskSide = (side: string) => {
+export const erHistoriskSide = (side: string) => {
     return historiskeSider.includes(side);
 };
 export const erØnsketSideTilgjengelig = (ønsketSide: string, behandling: IBehandling): boolean => {


### PR DESCRIPTION
…vilkårsvurdering. Skal heller ikke ha eksterne lenker, men lenke tilbake til behandlingen. Ønsker å åpne historisk visning i ny tab for å ikke miste behandlingen siden historiske verdier ofte skal brukes for å kopieres inn i selve behandlingen.

Løser kommentarene i denne [Favroen](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20721)