### PR TITLE
Manuelle brevmottakere i utlandet skal ikke sende med postnummer og poststed

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Fieldset, TextField } from '@navikt/ds-react';
+import { Alert, Fieldset, TextField } from '@navikt/ds-react';
 import { ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { Valideringsstatus } from '@navikt/familie-skjema';
 import CountrySelect from '@navikt/landvelger';
@@ -51,38 +51,6 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ preutfyltNavn }) => {
                         skjema.felter.navn.validerOgSettFelt(event.target.value);
                     }}
                 />
-                <TextField
-                    {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    label={'Adresselinje 1'}
-                    onChange={(event): void => {
-                        skjema.felter.adresselinje1.validerOgSettFelt(event.target.value);
-                    }}
-                />
-                <TextField
-                    {...skjema.felter.adresselinje2.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                    label={'Adresselinje 2 (valgfri)'}
-                    onChange={(event): void => {
-                        skjema.felter.adresselinje2.validerOgSettFelt(event.target.value);
-                    }}
-                />
-                <PostnummerOgStedContainer>
-                    <TextField
-                        {...skjema.felter.postnummer.hentNavBaseSkjemaProps(
-                            skjema.visFeilmeldinger
-                        )}
-                        label={'Postnummer'}
-                        onChange={(event): void => {
-                            skjema.felter.postnummer.validerOgSettFelt(event.target.value);
-                        }}
-                    />
-                    <TextField
-                        {...skjema.felter.poststed.hentNavBaseSkjemaProps(skjema.visFeilmeldinger)}
-                        label={'Poststed'}
-                        onChange={(event): void => {
-                            skjema.felter.poststed.validerOgSettFelt(event.target.value);
-                        }}
-                    />
-                </PostnummerOgStedContainer>
                 <CountrySelect
                     id={'country-select-brevmottaker'}
                     label={'Land'}
@@ -103,6 +71,56 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ preutfyltNavn }) => {
                             : ''
                     }
                 />
+                {skjema.felter.land.verdi && (
+                    <>
+                        <TextField
+                            {...skjema.felter.adresselinje1.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            label={'Adresselinje 1'}
+                            onChange={(event): void => {
+                                skjema.felter.adresselinje1.validerOgSettFelt(event.target.value);
+                            }}
+                        />
+                        <TextField
+                            {...skjema.felter.adresselinje2.hentNavBaseSkjemaProps(
+                                skjema.visFeilmeldinger
+                            )}
+                            label={'Adresselinje 2 (valgfri)'}
+                            onChange={(event): void => {
+                                skjema.felter.adresselinje2.validerOgSettFelt(event.target.value);
+                            }}
+                        />
+                        {skjema.felter.land.verdi !== 'NO' && (
+                            <Alert variant="info">
+                                Ved utenlandsk adresse skal postnummer og poststed legges i
+                                adresselinjene.
+                            </Alert>
+                        )}
+                        <PostnummerOgStedContainer>
+                            <TextField
+                                {...skjema.felter.postnummer.hentNavBaseSkjemaProps(
+                                    skjema.visFeilmeldinger
+                                )}
+                                disabled={skjema.felter.land.verdi !== 'NO'}
+                                label={'Postnummer'}
+                                onChange={(event): void => {
+                                    skjema.felter.postnummer.validerOgSettFelt(event.target.value);
+                                }}
+                            />
+                            <TextField
+                                {...skjema.felter.poststed.hentNavBaseSkjemaProps(
+                                    skjema.visFeilmeldinger
+                                )}
+                                disabled={skjema.felter.land.verdi !== 'NO'}
+                                label={'Poststed'}
+                                onChange={(event): void => {
+                                    skjema.felter.poststed.validerOgSettFelt(event.target.value);
+                                }}
+                            />
+                        </PostnummerOgStedContainer>
+                    </>
+                )}
             </StyledFieldset>
         </>
     );


### PR DESCRIPTION
For adresser i utlandet tar ikke Dokdist hensyn til postnummer og poststed. Denne infoen skal legges i adresselinjene.

Postnummer og poststed disables når andre land enn Norge er valgt. Setter også på ekstra validering at disse feltene kan være tomme når land i utlandet er valgt. Flytter også Land-feltet opp, siden feltene under er avhengig av det for å vise riktig.

Når det er norske manuelle brevmottakere:
<img width="564" alt="image" src="https://github.com/user-attachments/assets/1bec829d-bbd8-4d90-ab29-709bc60eaba9">

Når det er utenlandske manuelle brevmottakere:
<img width="691" alt="image" src="https://github.com/user-attachments/assets/2a5c9da8-24a4-4d15-be4a-70ef0385e4be">

Slik vises historikkinnslag med norske og utenlandske manuelle brevmottakere:
<img width="321" alt="image" src="https://github.com/user-attachments/assets/56bd98a4-f64f-4137-b5da-12eea4c1ecee">
