### PR TITLE
Legger på visning av feilmelding på utsending av brev

### DIFF
--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMelding.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { BodyShort, Button, Heading, Select, Textarea } from '@navikt/ds-react';
+import { BodyShort, Button, Fieldset, Heading, Select, Textarea } from '@navikt/ds-react';
 
 import ForhåndsvisBrev from './ForhåndsvisBrev/ForhåndsvisBrev';
 import { useSendMelding } from './SendMeldingContext';
@@ -24,7 +24,7 @@ interface IProps {
 }
 
 const SendMelding: React.FC<IProps> = ({ fagsak, behandling }) => {
-    const { maler, skjema, senderInn, sendBrev } = useSendMelding();
+    const { maler, skjema, senderInn, sendBrev, feilmelding } = useSendMelding();
     const { behandlingILesemodus } = useBehandling();
     const erLesevisning = !!behandlingILesemodus;
 
@@ -36,7 +36,7 @@ const SendMelding: React.FC<IProps> = ({ fagsak, behandling }) => {
     const kanSende = skjema.felter.maltype.verdi !== '' && skjema.felter.fritekst.verdi !== '';
 
     return (
-        <div>
+        <Fieldset error={feilmelding} legend={'Send brev'} hideLegend>
             {behandling.manuelleBrevmottakere.length ? (
                 <>
                     <Heading size="xsmall" spacing>
@@ -109,7 +109,7 @@ const SendMelding: React.FC<IProps> = ({ fagsak, behandling }) => {
                 </Button>
                 {kanSende && <ForhåndsvisBrev />}
             </Navigering>
-        </div>
+        </Fieldset>
     );
 };
 

--- a/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMeldingContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/SendMelding/SendMeldingContext.tsx
@@ -19,7 +19,11 @@ import { DokumentMal } from '../../../../kodeverk';
 import { BrevPayload } from '../../../../typer/api';
 import { IBehandling } from '../../../../typer/behandling';
 import { IFagsak } from '../../../../typer/fagsak';
-import { erFeltetEmpty, validerTekstFeltMaksLengde } from '../../../../utils';
+import {
+    erFeltetEmpty,
+    hentFrontendFeilmelding,
+    validerTekstFeltMaksLengde,
+} from '../../../../utils';
 import { sider } from '../../../Felleskomponenter/Venstremeny/sider';
 
 interface Mottaker {
@@ -50,6 +54,7 @@ interface IProps {
 
 const [SendMeldingProvider, useSendMelding] = createUseContext(({ behandling, fagsak }: IProps) => {
     const [senderInn, settSenderInn] = React.useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = React.useState<string | undefined>();
     const { hentBehandlingMedBehandlingId } = useBehandling();
     const { bestillBrev } = useDokumentApi();
     const navigate = useNavigate();
@@ -104,6 +109,7 @@ const [SendMeldingProvider, useSendMelding] = createUseContext(({ behandling, fa
             settSenderInn(true);
             bestillBrev(hentBrevdata()).then((respons: Ressurs<void>) => {
                 settSenderInn(false);
+                settFeilmelding(undefined);
                 if (respons.status === RessursStatus.SUKSESS) {
                     nullstillSkjema();
                     hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
@@ -111,6 +117,8 @@ const [SendMeldingProvider, useSendMelding] = createUseContext(({ behandling, fa
                             `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}/${sider.VERGE.href}`
                         );
                     });
+                } else {
+                    settFeilmelding(hentFrontendFeilmelding(respons));
                 }
             });
         } else {
@@ -126,6 +134,7 @@ const [SendMeldingProvider, useSendMelding] = createUseContext(({ behandling, fa
         kanSendeSkjema,
         senderInn,
         sendBrev,
+        feilmelding,
     };
 });
 


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23182
Hvis utsending av brev feiler var det før ingen visning av feilmeldingen som kommer fra requesten. Legger på visning av feilmeldingen, som ser slik ut:

<img width="343" alt="image" src="https://github.com/user-attachments/assets/5ab05963-c798-43c1-a8aa-218517690812">


Relatert til https://github.com/navikt/familie-tilbake/pull/1581