### PR TITLE
Ekskluderer XU ukjent land i brevmottaker landvelger

### DIFF
--- a/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Brevmottaker/BrevmottakerSkjema.tsx
@@ -57,8 +57,8 @@ const BrevmottakerSkjema: React.FC<IProps> = ({ preutfyltNavn }) => {
                     flags
                     excludeList={
                         skjema.felter.mottaker.verdi === MottakerType.BRUKER_MED_UTENLANDSK_ADRESSE
-                            ? ['NO']
-                            : undefined
+                            ? ['NO', 'XU']
+                            : ['XU']
                     }
                     values={skjema.felter.land.verdi}
                     onOptionSelected={(land: { alpha2: string }) => {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23404

Vi forhindrer valg av XU (Ukjent Land)