### PR TITLE
Legger til window.location.reload slik at siden oppdatere seg etter a…

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Behandlingsmeny/SettBehandlingTilbakeTilFakta/SettBehandlingTilbakeTilFakta.tsx
@@ -57,6 +57,7 @@ const SettBehandlingTilbakeTilFakta: React.FC<IProps> = ({
                     utførRedirect(
                         `/fagsystem/${fagsak.fagsystem}/fagsak/${fagsak.eksternFagsakId}/behandling/${behandling.eksternBrukId}`
                     );
+                    window.location.reload(); // Quick fix for å kunne trykke neste etter at en behandling har blitt tilbakestilt til fakta
                 });
             } else if (
                 respons.status === RessursStatus.FEILET ||


### PR DESCRIPTION
…t det har blitt kjørt en redirect. Dette er for å tilbakestille alle states, som kan har være årsaken til at det ikke alltid er mulig å navigere videre etter at behandling er tilbakestilt.