### PR TITLE
Omgjør til riktig ikon etter major-oppgradering i aksel-icons

### DIFF
--- a/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
+++ b/src/frontend/komponenter/Fagsak/Personlinje/Personlinje.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Buldings3Icon, ExternalLinkIcon, LeaveIcon } from '@navikt/aksel-icons';
+import { Buildings3Icon, ExternalLinkIcon, LeaveIcon } from '@navikt/aksel-icons';
 import { Link, Tag } from '@navikt/ds-react';
 import { AGray900, ATextOnInverted, ASpacing2, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
 import { RessursStatus } from '@navikt/familie-typer';
@@ -71,7 +71,7 @@ const Personlinje: React.FC<IProps> = ({ bruker, fagsak }) => {
             )}
             {fagsak.institusjon && (
                 <InstitusjonsTag variant="info" size="small">
-                    <Buldings3Icon fontSize={'1.25rem'} />
+                    <Buildings3Icon fontSize={'1.25rem'} />
                     <MaksLengdeInstitusjonNavn title={fagsak.institusjon.navn}>
                         {fagsak.institusjon.navn}
                     </MaksLengdeInstitusjonNavn>


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23466

Når vi kjørte en major bump av aksel-icons, var det en breaking change som vi ikke fikset. Dette fikser renamingen av et ikon som vi bruker når vi viser `Personlinje` for institusjoner.

`<Buldings3Icon />` endres til `<Buildings3Icon />`

Kilde: https://aksel.nav.no/grunnleggende/kode/migrering#194b60833d9e