### PR TITLE
Disabler knappene send til saksbehandler og godkjenn ved første klikk

### DIFF
--- a/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/TotrinnskontrollContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Høyremeny/Totrinnskontroll/TotrinnskontrollContext.tsx
@@ -208,8 +208,10 @@ const [TotrinnskontrollProvider, useTotrinnskontroll] = createUseContext(
 
         const sendInnSkjema = () => {
             if (validerToTrinn()) {
-                settSenderInn(false);
-
+                if (senderInn) {
+                    return;
+                }
+                settSenderInn(true);
                 const payload: FatteVedtakStegPayload = {
                     '@type': 'FATTE_VEDTAK',
                     // @ts-expect-error har verdi her
@@ -226,7 +228,6 @@ const [TotrinnskontrollProvider, useTotrinnskontroll] = createUseContext(
 
                 sendInnFatteVedtak(behandling.behandlingId, payload)
                     .then((respons: Ressurs<string>) => {
-                        settSenderInn(false);
                         if (respons.status === RessursStatus.SUKSESS) {
                             hentBehandlingMedBehandlingId(behandling.behandlingId).then(() => {
                                 navigate(
@@ -242,10 +243,12 @@ const [TotrinnskontrollProvider, useTotrinnskontroll] = createUseContext(
                     })
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     .catch((_error: AxiosError) => {
-                        settSenderInn(false);
                         settFatteVedtakRespons(
                             byggFeiletRessurs('Ukjent feil ved sending av vedtak')
                         );
+                    })
+                    .finally(() => {
+                        settSenderInn(false);
                     });
             }
         };


### PR DESCRIPTION
Dette er et forsøk på å unngå at det opprettes duplikate oppgaver i gosys. Har gjenskapt feilen ved dobbeltklikk på "Send til saksbehandler" i totrinnskontroll i preprod: https://tilbakekreving.ansatt.dev.nav.no/fagsystem/EF/fagsak/200055111/behandling/66a9ad2f-5190-4427-8d82-f89d74079bca/vedtak

Feilen ble meldt av saksbehandler og unngår at oppdaterSaksbehandler-task feiler med at det finnes flere åpne oppgaver for behandling: https://tilbakekreving-prosessering.intern.nav.no/service/tilbakekreving-backend/task/2422447
