### PR TITLE
Gjør logging uavhengig av config.ts

### DIFF
--- a/src/backend/backend/typer.ts
+++ b/src/backend/backend/typer.ts
@@ -18,7 +18,6 @@ export interface IAppConfig {
     sessionSecret: string;
     backendApiScope: string;
     version: string;
-    logLevel: string;
     graphApiUrl: string;
 }
 

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -12,7 +12,6 @@ export const appConfig: IAppConfig = {
     sessionSecret: envVar('SESSION_SECRET'),
     backendApiScope: envVar('TILBAKE_SCOPE'),
     version: envVar('APP_VERSION'),
-    logLevel: envVar('LOG_LEVEL', false, 'info'),
     graphApiUrl: 'https://graph.microsoft.com/v1.0/me',
 };
 

--- a/src/backend/logging/logging.ts
+++ b/src/backend/logging/logging.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import winston from 'winston';
 
-import { appConfig } from '../config';
-
 export enum LogLevel {
     Error = 3,
     Warning = 2,
@@ -17,7 +15,8 @@ const secureLogPath = () =>
 
 export const stdoutLogger = winston.createLogger({
     format: winston.format.json(),
-    level: appConfig.logLevel,
+    // Kan ikke skje via appConfig siden den har en avhengighet til logg
+    level: process.env.LOG_LEVEL ?? 'info',
     transports: [new winston.transports.Console()],
 });
 


### PR DESCRIPTION
Før var det en sirkulær avhengighet til appConfig, som ikke kunne laste før logging hadde lastet.