### PR TITLE
Fjerner warning om deprecated globals og gjør testene 10% raskere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ci-tests/reports
 *.iml
 .pnpm-store/
 pnpm-debug.log
+.jest-cache

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,10 @@
 import type { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
-    // verbose: true,
     preset: 'ts-jest',
+    maxWorkers: '50%',
+    cache: true,
+    cacheDirectory: '<rootDir>/.jest-cache',
     testEnvironment: 'jsdom',
     setupFilesAfterEnv: ['<rootDir>/src/jest-setup.ts'],
     moduleNameMapper: {
@@ -13,12 +15,6 @@ const config: Config.InitialOptions = {
     },
     transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@navikt*|uuid|nanoid)/)'],
     transform: {
-        '\\.[jt]s?$': [
-            'ts-jest',
-            {
-                tsconfig: '<rootDir>/src/frontend/tsconfig.json',
-            },
-        ],
         '\\.[jt]sx?$': [
             'ts-jest',
             {
@@ -26,6 +22,7 @@ const config: Config.InitialOptions = {
             },
         ],
     },
+    silent: process.env.ENV === 'pre-prod' ? true : false,
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -22,7 +22,7 @@ const config: Config.InitialOptions = {
             },
         ],
     },
-    silent: process.env.ENV === 'pre-prod' ? true : false,
+    silent: process.env.ENV === 'local' ? true : false,
 };
 
 export default config;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,11 +4,6 @@ const config: Config.InitialOptions = {
     // verbose: true,
     preset: 'ts-jest',
     testEnvironment: 'jsdom',
-    globals: {
-        'ts-jest': {
-            tsconfig: '<rootDir>/src/frontend/tsconfig.json',
-        },
-    },
     setupFilesAfterEnv: ['<rootDir>/src/jest-setup.ts'],
     moduleNameMapper: {
         '.+\\.(css)$': 'identity-obj-proxy',
@@ -18,8 +13,18 @@ const config: Config.InitialOptions = {
     },
     transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@navikt*|uuid|nanoid)/)'],
     transform: {
-        '\\.[jt]s?$': 'ts-jest',
-        '\\.[jt]sx?$': 'ts-jest',
+        '\\.[jt]s?$': [
+            'ts-jest',
+            {
+                tsconfig: '<rootDir>/src/frontend/tsconfig.json',
+            },
+        ],
+        '\\.[jt]sx?$': [
+            'ts-jest',
+            {
+                tsconfig: '<rootDir>/src/frontend/tsconfig.json',
+            },
+        ],
     },
 };
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -22,7 +22,6 @@ const config: Config.InitialOptions = {
             },
         ],
     },
-    silent: process.env.ENV === 'local' ? true : false,
 };
 
 export default config;

--- a/src/frontend/utils/land.ts
+++ b/src/frontend/utils/land.ts
@@ -2,11 +2,11 @@ import type { Land } from '../komponenter/Felleskomponenter/Landvelger/Landvelge
 
 export const norskLandnavn = (alpha2: Land['alpha2']): string => {
     try {
-        const lokalLandnavn = new Intl.DisplayNames(['nb'], { type: 'region' }).of(alpha2);
-        if (!lokalLandnavn) {
-            return alpha2;
+        if (!/^[A-Z]{2}$/.test(alpha2)) {
+            throw new RangeError('Invalid region code format');
         }
-        return lokalLandnavn;
+        const lokalLandnavn = new Intl.DisplayNames(['nb'], { type: 'region' }).of(alpha2);
+        return lokalLandnavn || alpha2;
     } catch (error) {
         console.error(`Feil regionskode: ${alpha2}`, error);
         return alpha2;

--- a/src/frontend/utils/land.ts
+++ b/src/frontend/utils/land.ts
@@ -1,12 +1,15 @@
 import type { Land } from '../komponenter/Felleskomponenter/Landvelger/Landvelger';
 
 export const norskLandnavn = (alpha2: Land['alpha2']): string => {
+    if (!alpha2 || alpha2.length === 0) {
+        return alpha2;
+    }
     try {
-        if (!/^[A-Z]{2}$/.test(alpha2)) {
-            throw new RangeError('Invalid region code format');
-        }
         const lokalLandnavn = new Intl.DisplayNames(['nb'], { type: 'region' }).of(alpha2);
-        return lokalLandnavn || alpha2;
+        if (!lokalLandnavn) {
+            return alpha2;
+        }
+        return lokalLandnavn;
     } catch (error) {
         console.error(`Feil regionskode: ${alpha2}`, error);
         return alpha2;


### PR DESCRIPTION
Denne warningen kom foran alle testene våre og er nå fikset:
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```