### PR TITLE
Ikke returner 200 med nytt CSRF token for sider som ikke finnes

### DIFF
--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -61,7 +61,7 @@ export default async (texasClient: TexasClient, router: Router) => {
     }
 
     router.get(
-        ['/', '/*splat'],
+        ['/', '/fagsystem/*splat'],
         ensureAuthenticated(texasClient, false),
         async (req: Request, res: Response): Promise<void> => {
             prometheusTellere.appLoad.inc();


### PR DESCRIPTION
Siden routeren matchet på alle URL-er ville den generere nytt CSRF token for alle requests, selv de som ikke eksisterer. Dette førte til at en request til /favicon.ico ville generere nytt CSRF token og ingen requests som er beskyttet mot CSRF ville fungere.