### PR TITLE
Fargekoder per periodestatus

### DIFF
--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePerioder.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 
 import FeilutbetalingForeldelsePeriodeSkjema from './FeilutbetalingForeldelsePeriodeSkjema';
 import { Foreldelsevurdering } from '../../../../kodeverk';
+import { ClassNamePeriodeStatus } from '../../../../typer/periodeSkjemaData';
 import { Navigering } from '../../../Felleskomponenter/Flytelementer';
 import TilbakeTidslinje from '../../../Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje';
 import { useFeilutbetalingForeldelse } from '../FeilutbetalingForeldelseContext';
@@ -17,14 +18,14 @@ const finnClassNamePeriode = (periode: ForeldelsePeriode, aktivPeriode: boolean)
     const aktivPeriodeCss = aktivPeriode ? 'aktivPeriode' : '';
     switch (periode.foreldelsesvurderingstype) {
         case Foreldelsevurdering.Foreldet:
-            return classNames('avvist', aktivPeriodeCss);
+            return classNames(ClassNamePeriodeStatus.Avvist, aktivPeriodeCss);
         case Foreldelsevurdering.Tilleggsfrist:
         case Foreldelsevurdering.IkkeForeldet:
-            return classNames('behandlet', aktivPeriodeCss);
+            return classNames(ClassNamePeriodeStatus.Behandlet, aktivPeriodeCss);
         case Foreldelsevurdering.IkkeVurdert:
         case Foreldelsevurdering.Udefinert:
         default:
-            return classNames('ubehandlet', aktivPeriodeCss);
+            return classNames(ClassNamePeriodeStatus.Ubehandlet, aktivPeriodeCss);
     }
 };
 

--- a/src/frontend/komponenter/Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje.tsx
@@ -1,5 +1,6 @@
 import type { TimelinePeriodProps } from '@navikt/ds-react';
 
+import { CheckmarkCircleIcon, PencilIcon, XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { Timeline } from '@navikt/ds-react';
 import {
     AGreen200,
@@ -13,14 +14,19 @@ import {
     ARed300,
     ARed400,
     ARed500,
-    ARed600,
     ABorderStrong,
     ASpacing5,
+    AOrange800,
+    AGreen800,
+    ARed800,
+    ARed200,
 } from '@navikt/ds-tokens/dist/tokens';
-import { format } from 'date-fns';
+import classNames from 'classnames';
 import * as React from 'react';
 import { styled } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
+
+import { dateTilIsoDatoStringEllerUndefined } from '../../../utils/dato';
 
 const TidslinjeContainer = styled.div`
     border: 1px solid ${ABorderStrong};
@@ -35,25 +41,37 @@ const TidslinjeContainer = styled.div`
         background-color: ${AGreen200};
         border-color: ${AGreen400};
 
+        &:hover {
+            background-color: ${AGreen300};
+        }
+
         &.aktivPeriode {
             background-color: ${AGreen300};
             box-shadow: 0 0 0 2px ${AGreen500};
         }
     }
 
-    & .navds-timeline__period--error {
-        background-color: ${ARed300};
-        border-color: ${ARed500};
+    & .navds-timeline__period--danger {
+        background-color: ${ARed200};
+        border-color: ${ARed400};
+
+        &:hover {
+            background-color: ${ARed300};
+        }
 
         &.aktivPeriode {
-            background-color: ${ARed400};
-            box-shadow: 0 0 0 2px ${ARed600};
+            background-color: ${ARed300};
+            box-shadow: 0 0 0 2px ${ARed500};
         }
     }
 
     & .navds-timeline__period--warning {
         background-color: ${AOrange200};
         border-color: ${AOrange400};
+
+        &:hover {
+            background-color: ${AOrange300};
+        }
 
         &.aktivPeriode {
             background-color: ${AOrange300};
@@ -73,20 +91,57 @@ const TilbakeTidslinje: React.FC<IProps> = ({ rader, onSelectPeriode }) => {
             <Timeline>
                 {rader.map(rad => (
                     <Timeline.Row label="" key={uuidv4()}>
-                        {rad.map(periode => (
-                            <Timeline.Period
-                                key={periode.id}
-                                start={periode.start}
-                                end={periode.end}
-                                status={periode.status}
-                                isActive={periode.isActive}
-                                className={periode.className}
-                                onClick={() => onSelectPeriode(periode)}
-                            >
-                                Periode fra {format(new Date(periode.start), 'dd-MM-yyyy')} til{' '}
-                                {format(new Date(periode.end), 'dd-MM-yyyy')}
-                            </Timeline.Period>
-                        ))}
+                        {rad.map(periode => {
+                            const handling =
+                                periode.status === 'success'
+                                    ? 'Behandlet'
+                                    : periode.status === 'warning'
+                                      ? 'Ubehandlet'
+                                      : 'Avvist';
+                            const varighetTekst = `${handling} periode fra ${dateTilIsoDatoStringEllerUndefined(new Date(periode.start))} til ${dateTilIsoDatoStringEllerUndefined(new Date(periode.end))}`;
+                            const ikon =
+                                periode.status === 'warning' ? (
+                                    <PencilIcon
+                                        title="a11y-title"
+                                        fontSize="1.5rem"
+                                        aria-hidden="true"
+                                        style={{ color: AOrange800 }}
+                                    />
+                                ) : periode.status === 'success' ? (
+                                    <CheckmarkCircleIcon
+                                        title="a11y-title"
+                                        fontSize="1.5rem"
+                                        aria-hidden="true"
+                                        style={{ color: AGreen800 }}
+                                    />
+                                ) : (
+                                    <XMarkOctagonIcon
+                                        title="a11y-title"
+                                        fontSize="1.5rem"
+                                        aria-hidden="true"
+                                        style={{ color: ARed800 }}
+                                    />
+                                );
+                            console.log('xxx', periode.status);
+                            return (
+                                <Timeline.Period
+                                    key={periode.id}
+                                    icon={ikon}
+                                    start={periode.start}
+                                    end={periode.end}
+                                    status={periode.status}
+                                    isActive={periode.isActive}
+                                    className={classNames(
+                                        periode.className,
+                                        periode.isActive && 'aktivPeriode'
+                                    )}
+                                    aria-label={`${periode.status} ${varighetTekst}`}
+                                    onClick={() => onSelectPeriode(periode)}
+                                >
+                                    {varighetTekst}
+                                </Timeline.Period>
+                            );
+                        })}
                     </Timeline.Row>
                 ))}
             </Timeline>

--- a/src/frontend/typer/periodeSkjemaData.ts
+++ b/src/frontend/typer/periodeSkjemaData.ts
@@ -6,3 +6,9 @@ export interface IPeriodeSkjemaData {
     periode: Periode;
     erSplittet?: boolean | false;
 }
+
+export enum ClassNamePeriodeStatus {
+    Behandlet = 'behandlet',
+    Ubehandlet = 'ubehandlet',
+    Avvist = 'avvist',
+}


### PR DESCRIPTION
Ved splittet periode er de to nye periodene ubehandlet og har et ikon med en penn og oransje farge. Behandlede perioder beholder grønn og får et checkmark ikon:
![Skjermbilde 2025-06-18 kl  13 09 09](https://github.com/user-attachments/assets/78884065-b6fc-441f-9d09-397837be5741)

Foreldede perioder får avviste tidslinjer og rød farge med et kryss på for å indikere at det ikke er en gyldig periode:
![Skjermbilde 2025-06-18 kl  13 09 27](https://github.com/user-attachments/assets/97eb9c8b-cffa-4952-a5cc-ee46a6fc4a7d)
