### PR TITLE
Dele periode

### DIFF
--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/FeilutbetalingForeldelsePeriodeSkjema.tsx
@@ -16,6 +16,7 @@ import {
     Textarea,
     VStack,
 } from '@navikt/ds-react';
+import { differenceInMonths, parseISO } from 'date-fns';
 import * as React from 'react';
 import { styled } from 'styled-components';
 
@@ -138,6 +139,12 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
         }
     };
 
+    const kanSplittePeriode = (periode: ForeldelsePeriodeSkjemeData): boolean => {
+        const fom = parseISO(periode.periode.fom);
+        const tom = parseISO(periode.periode.tom);
+        return differenceInMonths(tom, fom) >= 1;
+    };
+
     return (
         <StyledBox padding="4" borderColor="border-strong" borderWidth="1">
             <StyledStack
@@ -149,7 +156,7 @@ const FeilutbetalingForeldelsePeriodeSkjema: React.FC<IProps> = ({
                     Detaljer for valgt periode
                 </Heading>
 
-                {!erLesevisning && (
+                {!erLesevisning && kanSplittePeriode(periode) && (
                     <SplittPeriode
                         behandling={behandling}
                         periode={periode}

--- a/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/SplittPeriode/SplittPeriode.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Foreldelse/ForeldelsePeriode/SplittPeriode/SplittPeriode.test.tsx
@@ -54,6 +54,6 @@ describe('Tester: SplittPeriode - Foreldelse', () => {
             })
         ).toBeInTheDocument();
         expect(getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
-        expect(getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue('april 2021');
+        expect(getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue('januar 2021');
     });
 });

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.test.tsx
@@ -57,6 +57,6 @@ describe('Tester: SplittPeriode - Vilkårsvurdering', () => {
             })
         ).toBeInTheDocument();
         expect(getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
-        expect(getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue('april 2021');
+        expect(getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue('januar 2021');
     });
 });

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/SplittPeriode/SplittPeriode.tsx
@@ -8,21 +8,13 @@ import type { TimelinePeriodProps } from '@navikt/ds-react';
 
 import { Detail, Link } from '@navikt/ds-react';
 import * as React from 'react';
-import { styled } from 'styled-components';
+import { useCallback, useEffect, useState } from 'react';
 
 import splitPeriodImageUrl from '../../../../../images/splitt.svg';
 import splitPeriodImageHoverUrl from '../../../../../images/splitt_hover.svg';
 import { flyttDatoISODateStr } from '../../../../../utils';
 import Image from '../../../../Felleskomponenter/Image/Image';
 import { DelOppPeriode, useDelOppPeriode } from '../../../../Felleskomponenter/Modal/DelOppPeriode';
-
-const InlineUndertekst = styled(Detail)`
-    margin-left: 0.1rem;
-`;
-
-const StyledContainer = styled.div`
-    text-align: right;
-`;
 
 const konverterPeriode = (periode: VilkårsvurderingPeriodeSkjemaData): TimelinePeriodProps => {
     return {
@@ -44,7 +36,7 @@ interface IProps {
 
 const SplittPeriode: React.FC<IProps> = ({ behandling, periode, onBekreft }) => {
     const [splittetPerioder, settSplittetPerioder] =
-        React.useState<VilkårsvurderingPeriodeSkjemaData[]>();
+        useState<VilkårsvurderingPeriodeSkjemaData[]>();
     const {
         visModal,
         settVisModal,
@@ -56,51 +48,47 @@ const SplittPeriode: React.FC<IProps> = ({ behandling, periode, onBekreft }) => 
         vedDatoEndring,
         sendInnSkjema,
         validateNyPeriode,
-    } = useDelOppPeriode(periode.periode.tom, behandling.behandlingId);
+    } = useDelOppPeriode(periode.periode.fom, behandling.behandlingId);
 
-    React.useEffect(() => {
-        const perRad: TimelinePeriodProps = konverterPeriode(periode);
-        settTidslinjeRader([[perRad]]);
-        settSplittDato(periode.periode.tom);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [periode]);
-
-    const onChangeDato = (nyVerdi?: string) => {
-        vedDatoEndring((månedsslutt: string) => {
-            const per: Periode = periode.periode;
-            if (validateNyPeriode(per, månedsslutt)) {
-                const nyePerioder: VilkårsvurderingPeriodeSkjemaData[] = [
-                    {
-                        ...periode,
-                        index: `${periode.index}_1`,
-                        periode: {
-                            fom: per.fom,
-                            tom: månedsslutt,
+    const onChangeDato = useCallback(
+        (nyVerdi?: string) => {
+            vedDatoEndring((månedsslutt: string) => {
+                const per: Periode = periode.periode;
+                if (validateNyPeriode(per, månedsslutt)) {
+                    const nyePerioder: VilkårsvurderingPeriodeSkjemaData[] = [
+                        {
+                            ...periode,
+                            index: `${periode.index}_1`,
+                            periode: {
+                                fom: per.fom,
+                                tom: månedsslutt,
+                            },
+                            vilkårsvurderingsresultatInfo: undefined,
+                            erSplittet: true,
                         },
-                        vilkårsvurderingsresultatInfo: undefined,
-                        erSplittet: true,
-                    },
-                    {
-                        ...periode,
-                        index: `${periode.index}_2`,
-                        periode: {
-                            fom: flyttDatoISODateStr(månedsslutt, { days: 1 }),
-                            tom: per.tom,
+                        {
+                            ...periode,
+                            index: `${periode.index}_2`,
+                            periode: {
+                                fom: flyttDatoISODateStr(månedsslutt, { days: 1 }),
+                                tom: per.tom,
+                            },
+                            vilkårsvurderingsresultatInfo: undefined,
+                            erSplittet: true,
                         },
-                        vilkårsvurderingsresultatInfo: undefined,
-                        erSplittet: true,
-                    },
-                ];
-                settSplittetPerioder(nyePerioder);
-                settTidslinjeRader([
-                    [konverterPeriode(nyePerioder[0]), konverterPeriode(nyePerioder[1])],
-                ]);
-            } else {
-                settSplittetPerioder([periode]);
-                settSplittDato(periode.periode.tom);
-            }
-        }, nyVerdi);
-    };
+                    ];
+                    settSplittetPerioder(nyePerioder);
+                    settTidslinjeRader([
+                        [konverterPeriode(nyePerioder[0]), konverterPeriode(nyePerioder[1])],
+                    ]);
+                } else {
+                    settSplittetPerioder([periode]);
+                    settSplittDato(periode.periode.fom);
+                }
+            }, nyVerdi);
+        },
+        [periode, settSplittDato, settTidslinjeRader, validateNyPeriode, vedDatoEndring]
+    );
 
     const onSubmit = () => {
         if (splittetPerioder) {
@@ -128,17 +116,22 @@ const SplittPeriode: React.FC<IProps> = ({ behandling, periode, onBekreft }) => 
         }
     };
 
+    useEffect(() => {
+        if (periode.periode.fom) {
+            onChangeDato(periode.periode.fom);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [periode.periode.fom]);
+
     return periode && tidslinjeRader ? (
-        <StyledContainer>
+        <div className="text-right">
             <Link
                 href="#"
                 role="button"
-                onClick={() => {
-                    settVisModal(true);
-                }}
+                onClick={() => settVisModal(true)}
                 onKeyUp={e => {
-                    const key = e.code || e.keyCode;
-                    if (key === 'Space' || key === 'Enter' || key === 32 || key === 13) {
+                    if (e.code === 'Space' || e.code === 'Enter') {
+                        e.preventDefault();
                         settVisModal(true);
                     }
                 }}
@@ -150,7 +143,7 @@ const SplittPeriode: React.FC<IProps> = ({ behandling, periode, onBekreft }) => 
                     altText="Del opp perioden"
                     aria-label="Del opp perioden"
                 />
-                <InlineUndertekst>Del opp perioden</InlineUndertekst>
+                <Detail className="ml-0.5">Del opp perioden</Detail>
             </Link>
             {visModal && (
                 <DelOppPeriode
@@ -158,14 +151,13 @@ const SplittPeriode: React.FC<IProps> = ({ behandling, periode, onBekreft }) => 
                     tidslinjeRader={tidslinjeRader}
                     splittDato={splittDato}
                     visModal={visModal}
-                    senderInn={!splittetPerioder || splittetPerioder.length === 0}
                     settVisModal={settVisModal}
                     onChangeDato={onChangeDato}
                     onSubmit={onSubmit}
                     feilmelding={feilmelding}
                 />
             )}
-        </StyledContainer>
+        </div>
     ) : null;
 };
 

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -18,6 +18,7 @@ import {
     Textarea,
     VStack,
 } from '@navikt/ds-react';
+import { differenceInMonths, parseISO } from 'date-fns';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 
@@ -282,6 +283,12 @@ const VilkårsvurderingPeriodeSkjema: FC<IProps> = ({
         }
     };
 
+    const kanSplittePeriode = (periode: VilkårsvurderingPeriodeSkjemaData): boolean => {
+        const fom = parseISO(periode.periode.fom);
+        const tom = parseISO(periode.periode.tom);
+        return differenceInMonths(tom, fom) >= 1;
+    };
+
     const erSistePeriode = periode.index === perioder[perioder.length - 1].index;
     const handleNesteKnapp = async (): Promise<void> => {
         const handling = erSistePeriode
@@ -321,7 +328,7 @@ const VilkårsvurderingPeriodeSkjema: FC<IProps> = ({
                     <Heading size="small" level="2">
                         Detaljer for valgt periode
                     </Heading>
-                    {!erLesevisning && !periode.foreldet && (
+                    {!erLesevisning && !periode.foreldet && kanSplittePeriode(periode) && (
                         <SplittPeriode
                             behandling={behandling}
                             periode={periode}

--- a/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriode.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriode.tsx
@@ -11,7 +11,7 @@ import {
     useMonthpicker,
 } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing6 } from '@navikt/ds-tokens/dist/tokens';
-import { endOfMonth } from 'date-fns';
+import { endOfMonth, subMonths } from 'date-fns';
 import * as React from 'react';
 import { styled } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
@@ -27,6 +27,10 @@ const TidslinjeContainer = styled.div`
     .etiketter div:last-child {
         max-width: max-content;
     }
+
+    .navds-timeline__period {
+        cursor: default;
+    }
 `;
 
 interface IProps {
@@ -34,7 +38,6 @@ interface IProps {
     tidslinjeRader: TimelinePeriodProps[][];
     splittDato: string;
     visModal: boolean;
-    senderInn: boolean;
     settVisModal: (vis: boolean) => void;
     onChangeDato: (nyVerdi: string | undefined) => void;
     onSubmit: () => void;
@@ -46,7 +49,6 @@ export const DelOppPeriode: React.FC<IProps> = ({
     tidslinjeRader,
     splittDato,
     visModal,
-    senderInn,
     settVisModal,
     onChangeDato,
     onSubmit,
@@ -54,7 +56,7 @@ export const DelOppPeriode: React.FC<IProps> = ({
 }) => {
     const { monthpickerProps, inputProps } = useMonthpicker({
         fromDate: isoStringTilDate(periode.periode.fom),
-        toDate: isoStringTilDate(periode.periode.tom),
+        toDate: subMonths(isoStringTilDate(periode.periode.tom), 1),
         defaultSelected: isoStringTilDate(splittDato),
         onMonthChange: (dato?: Date) =>
             onChangeDato(dato ? dateTilIsoDatoString(endOfMonth(dato)) : undefined),
@@ -68,7 +70,7 @@ export const DelOppPeriode: React.FC<IProps> = ({
                         heading: 'Del opp perioden',
                         size: 'medium',
                     }}
-                    portal={true}
+                    portal
                     width="small"
                     onClose={() => {
                         settVisModal(false);
@@ -111,21 +113,13 @@ export const DelOppPeriode: React.FC<IProps> = ({
                         </MonthPicker>
                     </Modal.Body>
                     <Modal.Footer>
-                        <Button
-                            variant="primary"
-                            key="bekreft"
-                            onClick={onSubmit}
-                            disabled={senderInn}
-                            size="small"
-                        >
+                        <Button variant="primary" key="bekreft" onClick={onSubmit} size="small">
                             Bekreft
                         </Button>
                         <Button
                             variant="tertiary"
                             key="avbryt"
-                            onClick={() => {
-                                settVisModal(false);
-                            }}
+                            onClick={() => settVisModal(false)}
                             size="small"
                         >
                             Lukk

--- a/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriodeContext.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Modal/DelOppPeriode/DelOppPeriodeContext.tsx
@@ -1,17 +1,17 @@
 import type { IBeregnSplittetPeriodeRespons, Periode } from '../../../../typer/feilutbetalingtyper';
 import type { TimelinePeriodProps } from '@navikt/ds-react';
 
-import * as React from 'react';
+import { useState } from 'react';
 
 import { useHttp } from '../../../../api/http/HttpProvider';
 import { type Ressurs, RessursStatus } from '../../../../typer/ressurs';
 import { getEndOfMonthISODateStr, validerDato } from '../../../../utils';
 
-export const useDelOppPeriode = (tom: string, behandlingId: string) => {
-    const [visModal, settVisModal] = React.useState<boolean>(false);
-    const [splittDato, settSplittDato] = React.useState<string>(tom);
-    const [tidslinjeRader, settTidslinjeRader] = React.useState<TimelinePeriodProps[][]>();
-    const [feilmelding, settFeilmelding] = React.useState<string>();
+export const useDelOppPeriode = (fom: string, behandlingId: string) => {
+    const [visModal, settVisModal] = useState(false);
+    const [splittDato, settSplittDato] = useState(fom);
+    const [tidslinjeRader, settTidslinjeRader] = useState<TimelinePeriodProps[][]>();
+    const [feilmelding, settFeilmelding] = useState('');
     const { request } = useHttp();
 
     const vedDatoEndring = (splittPeriode: (månedsslutt: string) => void, nyVerdi?: string) => {
@@ -19,7 +19,7 @@ export const useDelOppPeriode = (tom: string, behandlingId: string) => {
         if (feilmelding) {
             settFeilmelding(feilmelding);
         } else {
-            settFeilmelding(undefined);
+            settFeilmelding('');
             const månedsslutt = getEndOfMonthISODateStr(nyVerdi);
             if (nyVerdi && månedsslutt) {
                 splittPeriode(månedsslutt);


### PR DESCRIPTION
Endringer:
- Velger nå fom som default og ikke tom (tom dato er en måned for sent til å splitte)
- Knappen er ikke lenger disabled
- Nå vil perioden være splittet som default og fom som default dato (Da er det mulig å trykke bekreft i stedet for å velge på nytt hvis fom dato er den man ville splitte på)
- Fjernet siste måned i perioden på mulige måneder å splitte på (Siden dette gir feilmelding)
- Ikke mulig å splitte på perioder med kun 1 måned