### PR TITLE
Gjøre vilkårsvurdering på nytt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainer.test.tsx
@@ -115,7 +115,10 @@ const setupHttpMock = () => {
         request: () => {
             return Promise.resolve({
                 status: RessursStatus.Suksess,
-                data: mock<IBehandling>({ eksternBrukId: '1' }),
+                data: mock<IBehandling>({
+                    eksternBrukId: '1',
+                    behandlingsstegsinfo: [],
+                }),
             });
         },
     }));
@@ -141,7 +144,7 @@ describe('Tester: VilkårsvurderingContainer', () => {
 
     test('- totalbeløp under 4 rettsgebyr - alle perioder har ikke brukt 6.ledd', async () => {
         setupUseBehandlingApiMock(feilutbetalingVilkårsvurdering);
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getByRole, getByLabelText, getByTestId, queryAllByText, queryByText } =
@@ -320,7 +323,10 @@ describe('Tester: VilkårsvurderingContainer', () => {
             eksternFagsakId: '1',
             ytelsestype: Ytelsetype.Barnetilsyn,
         });
-        const behandling = mock<IBehandling>({ eksternBrukId: '1' });
+        const behandling = mock<IBehandling>({
+            eksternBrukId: '1',
+            behandlingsstegsinfo: [],
+        });
 
         const { getByText, getByRole, getByLabelText, queryAllByText } =
             renderVilkårsvurderingContainer(behandling, fagsak);
@@ -416,7 +422,7 @@ describe('Tester: VilkårsvurderingContainer', () => {
             ],
             rettsgebyr: 1199,
         });
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({
             ytelsestype: Ytelsetype.Barnetrygd,
         });
@@ -560,7 +566,10 @@ describe('Tester: VilkårsvurderingContainer', () => {
             ],
             rettsgebyr: 1199,
         });
-        const behandling = mock<IBehandling>({ status: Behandlingstatus.FatterVedtak });
+        const behandling = mock<IBehandling>({
+            status: Behandlingstatus.FatterVedtak,
+            behandlingsstegsinfo: [],
+        });
         const fagsak = mock<IFagsak>({
             ytelsestype: Ytelsetype.Barnetrygd,
         });
@@ -747,7 +756,7 @@ describe('Tester: VilkårsvurderingContainer', () => {
             ],
             rettsgebyr: 1199,
         });
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({
             ytelsestype: Ytelsetype.Overgangsstønad,
         });

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainerAutoutført.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContainerAutoutført.test.tsx
@@ -109,7 +109,7 @@ describe('Tester: VilkårsvurderingContainer', () => {
     test('- vis autoutført', async () => {
         setupMock(false, false, true, feilutbetalingVilkårsvurdering);
 
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getByRole } = render(

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -373,7 +373,9 @@ const VilkårsvurderingPeriodeSkjema: FC<IProps> = ({
                         <Select
                             className="pb-8 w-[15rem]"
                             name="perioderForKopi"
-                            onChange={event => onKopierPeriode(event)}
+                            onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+                                onKopierPeriode(event)
+                            }
                             label={<Detail>Kopier vilkårsvurdering fra</Detail>}
                             readOnly={erLesevisning}
                             size="small"
@@ -418,7 +420,7 @@ const VilkårsvurderingPeriodeSkjema: FC<IProps> = ({
                                 maxLength={3000}
                                 readOnly={erLesevisning}
                                 value={skjema.felter.vilkårsresultatBegrunnelse.verdi}
-                                onChange={event => {
+                                onChange={(event: { target: { value: string } }) => {
                                     skjema.felter.vilkårsresultatBegrunnelse.validerOgSettFelt(
                                         event.target.value
                                     );
@@ -481,7 +483,7 @@ const VilkårsvurderingPeriodeSkjema: FC<IProps> = ({
                                             ? skjema.felter.aktsomhetBegrunnelse.verdi
                                             : ''
                                     }
-                                    onChange={event => {
+                                    onChange={(event: { target: { value: string } }) => {
                                         skjema.felter.aktsomhetBegrunnelse.validerOgSettFelt(
                                             event.target.value
                                         );

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema.tsx
@@ -181,7 +181,6 @@ const VilkårsvurderingPeriodeSkjema: FC<IProps> = ({
     // Hvis vedtak er tilbakeført, marker vilkårsvurdering som "har ulagrede endringer"
     React.useEffect(() => {
         if (erVedtakTilbakeført && !erLesevisning) {
-            console.log('erVedtakTilbakeført', erVedtakTilbakeført);
             settIkkePersistertKomponent('vilkårsvurdering');
         }
     }, [erVedtakTilbakeført, erLesevisning, settIkkePersistertKomponent]);

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaBA.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaBA.test.tsx
@@ -76,7 +76,7 @@ describe('Tester: VilkårsvurderingPeriodeSkjema', () => {
         user = userEvent.setup();
         jest.clearAllMocks();
     });
-    const behandling = mock<IBehandling>();
+    const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
     const fagsak = mock<IFagsak>({
         ytelsestype: Ytelsetype.Barnetrygd,
     });

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaOS.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjemaOS.test.tsx
@@ -54,7 +54,7 @@ describe('Tester: VilkårsvurderingPeriodeSkjema', () => {
         user = userEvent.setup();
         jest.clearAllMocks();
     });
-    const behandling = mock<IBehandling>();
+    const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
     const fagsak = mock<IFagsak>({
         ytelsestype: Ytelsetype.Overgangsstønad,
     });

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.test.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.test.tsx
@@ -117,7 +117,10 @@ const setupMocks = () => {
         request: () => {
             return Promise.resolve({
                 status: RessursStatus.Suksess,
-                data: mock<IBehandling>({ eksternBrukId: '1' }),
+                data: mock<IBehandling>({
+                    eksternBrukId: '1',
+                    behandlingsstegsinfo: [],
+                }),
             });
         },
     }));
@@ -174,7 +177,7 @@ describe('Tester: VilkårsvurderingPerioder', () => {
     });
 
     test('skal bytte periode direkte når det ikke er ulagrede endringer', async () => {
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getAllByRole } = renderVilkårsvurderingPerioder(behandling, fagsak);
@@ -197,7 +200,7 @@ describe('Tester: VilkårsvurderingPerioder', () => {
     });
 
     test('skal vise modal ved bytte av periode med ulagrede endringer', async () => {
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getByRole, getAllByRole, getByLabelText } =
@@ -230,7 +233,7 @@ describe('Tester: VilkårsvurderingPerioder', () => {
     });
 
     test('skal bytte uten å lagre når "Bytt uten å lagre" klikkes', async () => {
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getByRole, getAllByRole, getByLabelText, queryByText } =
@@ -269,7 +272,7 @@ describe('Tester: VilkårsvurderingPerioder', () => {
     });
 
     test('skal lagre og bytte når "Lagre og bytt periode" klikkes', async () => {
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getByRole, getAllByRole, getByLabelText, queryByText } =
@@ -320,7 +323,7 @@ describe('Tester: VilkårsvurderingPerioder', () => {
     });
 
     test('skal lukke modal og forbli på nåværende periode når "Lukk" klikkes', async () => {
-        const behandling = mock<IBehandling>();
+        const behandling = mock<IBehandling>({ behandlingsstegsinfo: [] });
         const fagsak = mock<IFagsak>({ ytelsestype: Ytelsetype.Barnetilsyn });
 
         const { getByText, getByRole, getAllByRole, getByLabelText, queryByText } =

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
@@ -1,5 +1,4 @@
 import type { VilkårsvurderingPeriodeSkjemaData } from './typer/feilutbetalingVilkårsvurdering';
-import type { IBehandling } from '../../../typer/behandling';
 import type { IFagsak } from '../../../typer/fagsak';
 
 import { BodyShort, VStack, type TimelinePeriodProps } from '@navikt/ds-react';
@@ -8,6 +7,7 @@ import * as React from 'react';
 import { useVilkårsvurdering } from './VilkårsvurderingContext';
 import VilkårsvurderingPeriodeSkjema from './VilkårsvurderingPeriode/VilkårsvurderingPeriodeSkjema';
 import { Vilkårsresultat } from '../../../kodeverk';
+import { type IBehandling } from '../../../typer/behandling';
 import { ClassNamePeriodeStatus } from '../../../typer/periodeSkjemaData';
 import { FTAlertStripe } from '../../Felleskomponenter/Flytelementer';
 import TilbakeTidslinje from '../../Felleskomponenter/TilbakeTidslinje/TilbakeTidslinje';
@@ -94,6 +94,9 @@ const VilkårsvurderingPerioder: React.FC<IProps> = ({
 
         settPendingPeriode(vilkårsvurderingPeriode);
     };
+
+    console.log('behandling', behandling);
+    console.log('perioder', perioder);
 
     return perioder && tidslinjeRader ? (
         <VStack gap="5">

--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingPerioder.tsx
@@ -95,9 +95,6 @@ const VilkårsvurderingPerioder: React.FC<IProps> = ({
         settPendingPeriode(vilkårsvurderingPeriode);
     };
 
-    console.log('behandling', behandling);
-    console.log('perioder', perioder);
-
     return perioder && tidslinjeRader ? (
         <VStack gap="5">
             {valideringsFeilmelding && (


### PR DESCRIPTION
Lagt til deteksjon av når ForeslåVedtak-steget har blitt tilbakeført, som markerer vilkårsvurdering som "har ulagrede endringer" for å hindre utilsiktet navigering bort fra siden uten å lagre. Dette sikrer at brukere må håndtere konsekvensene av det tilbakeførte vedtaket før de kan gå videre i behandlingsflyten