### PR TITLE
Gjør det mulig å sende med begge perioder etter splitt

### DIFF
--- a/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Vilkårsvurdering/VilkårsvurderingContext.tsx
@@ -261,9 +261,10 @@ const [VilkårsvurderingProvider, useVilkårsvurdering] = createUseContext(
             const payload: VilkårdsvurderingStegPayload = {
                 '@type': 'VILKÅRSVURDERING',
                 vilkårsvurderingsperioder: ikkeForeldetPerioder
-                    .filter(periode => !!periode.begrunnelse)
+                    //Hvis det er splittet periode skal den uvurderte perioden også sendes inn
+                    .filter(periode => periode.erSplittet || !!periode.begrunnelse)
                     .map(periode => {
-                        if (!periode.begrunnelse)
+                        if (!periode.erSplittet && !periode.begrunnelse)
                             throw new Feil(
                                 `Periode ${periode.periode.fom} til ${periode.periode.tom} må ha en begrunnelse.`,
                                 400
@@ -271,7 +272,7 @@ const [VilkårsvurderingProvider, useVilkårsvurdering] = createUseContext(
                         const resultat = periode.vilkårsvurderingsresultatInfo;
                         return {
                             periode: periode.periode,
-                            begrunnelse: periode.begrunnelse,
+                            begrunnelse: periode.begrunnelse ?? null,
                             vilkårsvurderingsresultat:
                                 resultat?.vilkårsvurderingsresultat ?? Vilkårsresultat.Udefinert,
                             godTroDto: resultat?.godTro,

--- a/src/frontend/typer/api.ts
+++ b/src/frontend/typer/api.ts
@@ -39,7 +39,7 @@ export interface ForeldelseStegPayload {
 export interface PeriodeVilkårsvurderingStegPayload {
     periode: Periode;
     vilkårsvurderingsresultat: Vilkårsresultat;
-    begrunnelse: string;
+    begrunnelse: string | null;
     godTroDto: GodTro | undefined;
     aktsomhetDto: Aktsomhetsvurdering | undefined;
 }


### PR DESCRIPTION
- [ ] Backend gir 500 generisk feilmelding når begrunnelse er `null`. Må fikse det for `vilkårsvurdering` lik `UDEFINERT`