### PR TITLE
Velger automatisk hendelsesundertype uten useEffect

### DIFF
--- a/src/frontend/kodeverk/feilutbetalingsÅrsak.ts
+++ b/src/frontend/kodeverk/feilutbetalingsÅrsak.ts
@@ -77,6 +77,7 @@ export const hendelsetyper: Record<HendelseType, string> = {
 };
 
 export enum HendelseUndertype {
+    Ingen = '-',
     // Felles
     AnnetFritekst = 'ANNET_FRITEKST',
     BrukerFlyttetFraNorge = 'BRUKER_FLYTTET_FRA_NORGE',
@@ -200,6 +201,7 @@ export enum HendelseUndertype {
 }
 
 export const hendelseundertyper: Record<HendelseUndertype, string> = {
+    [HendelseUndertype.Ingen]: '-',
     // Felles
     [HendelseUndertype.AnnetFritekst]: 'Annet fritekst',
     [HendelseUndertype.BrukerFlyttetFraNorge]: 'Bruker flyttet fra Norge',
@@ -499,6 +501,8 @@ const undertyper = {
     ],
 };
 
-export const hentHendelseUndertyper = (hendelseType: HendelseType): HendelseUndertype[] => {
-    return undertyper[hendelseType];
+export const hentHendelseUndertyper = (
+    hendelseType: HendelseType | undefined
+): HendelseUndertype[] => {
+    return hendelseType ? undertyper[hendelseType] : [];
 };

--- a/src/frontend/kodeverk/feilutbetalingsÅrsak.ts
+++ b/src/frontend/kodeverk/feilutbetalingsÅrsak.ts
@@ -77,7 +77,6 @@ export const hendelsetyper: Record<HendelseType, string> = {
 };
 
 export enum HendelseUndertype {
-    Ingen = '-',
     // Felles
     AnnetFritekst = 'ANNET_FRITEKST',
     BrukerFlyttetFraNorge = 'BRUKER_FLYTTET_FRA_NORGE',
@@ -201,7 +200,6 @@ export enum HendelseUndertype {
 }
 
 export const hendelseundertyper: Record<HendelseUndertype, string> = {
-    [HendelseUndertype.Ingen]: '-',
     // Felles
     [HendelseUndertype.AnnetFritekst]: 'Annet fritekst',
     [HendelseUndertype.BrukerFlyttetFraNorge]: 'Bruker flyttet fra Norge',

--- a/src/frontend/komponenter/Fagsak/Fakta/FeilutbetalingFaktaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FeilutbetalingFaktaContext.tsx
@@ -150,8 +150,10 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
 
         const oppdaterÅrsakPåPeriode = (
             periode: FaktaPeriodeSkjemaData,
-            nyÅrsak: HendelseType
+            nyÅrsak: HendelseType | undefined
         ): void => {
+            console.log('Setter årsak på periode:', periode.index, nyÅrsak);
+
             if (behandlePerioderSamlet) {
                 oppdaterÅrsaker(nyÅrsak);
             } else {
@@ -162,7 +164,7 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
 
         const oppdaterUnderårsakPåPeriode = (
             periode: FaktaPeriodeSkjemaData,
-            nyUnderårsak: HendelseUndertype
+            nyUnderårsak: HendelseUndertype | undefined
         ): void => {
             if (behandlePerioderSamlet) {
                 oppdaterUnderårsaker(periode, nyUnderårsak);
@@ -172,7 +174,7 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
             settIkkePersistertKomponent('fakta');
         };
 
-        const oppdaterÅrsaker = (nyÅrsak: HendelseType): void => {
+        const oppdaterÅrsaker = (nyÅrsak: HendelseType | undefined): void => {
             const nyePerioder = skjemaData.perioder.map(periode => {
                 return { ...periode, hendelsestype: nyÅrsak, hendelsesundertype: undefined };
             });
@@ -182,10 +184,15 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
             });
         };
 
-        const oppdaterÅrsak = (periode: FaktaPeriodeSkjemaData, nyÅrsak: HendelseType): void => {
+        const oppdaterÅrsak = (
+            periode: FaktaPeriodeSkjemaData,
+            nyÅrsak: HendelseType | undefined
+        ): void => {
             const gammelPeriodeIndex = skjemaData.perioder.findIndex(
                 gammelPeriode => gammelPeriode.index === periode.index
             );
+            console.log('Oppdaterer årsak for periode:', periode.index, nyÅrsak);
+
             const nyPeriode = { ...periode, hendelsestype: nyÅrsak, hendelsesundertype: undefined };
             const nyePerioder = skjemaData.perioder.toSpliced(gammelPeriodeIndex, 1, nyPeriode);
 
@@ -196,7 +203,7 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
 
         const oppdaterUnderårsaker = (
             periode: FaktaPeriodeSkjemaData,
-            nyUnderårsak: HendelseUndertype
+            nyUnderårsak: HendelseUndertype | undefined
         ): void => {
             const nyePerioder = skjemaData.perioder.map(gammelPeriode => {
                 if (gammelPeriode.hendelsestype === periode.hendelsestype) {
@@ -212,7 +219,7 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
 
         const oppdaterUnderårsak = (
             periode: FaktaPeriodeSkjemaData,
-            nyUnderårsak: HendelseUndertype
+            nyUnderårsak: HendelseUndertype | undefined
         ): void => {
             const gammelPeriodeIndex = skjemaData.perioder.findIndex(
                 gammelPeriode => gammelPeriode.index === periode.index

--- a/src/frontend/komponenter/Fagsak/Fakta/FeilutbetalingFaktaContext.tsx
+++ b/src/frontend/komponenter/Fagsak/Fakta/FeilutbetalingFaktaContext.tsx
@@ -152,8 +152,6 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
             periode: FaktaPeriodeSkjemaData,
             nyÅrsak: HendelseType | undefined
         ): void => {
-            console.log('Setter årsak på periode:', periode.index, nyÅrsak);
-
             if (behandlePerioderSamlet) {
                 oppdaterÅrsaker(nyÅrsak);
             } else {
@@ -191,8 +189,6 @@ const [FeilutbetalingFaktaProvider, useFeilutbetalingFakta] = createUseContext(
             const gammelPeriodeIndex = skjemaData.perioder.findIndex(
                 gammelPeriode => gammelPeriode.index === periode.index
             );
-            console.log('Oppdaterer årsak for periode:', periode.index, nyÅrsak);
-
             const nyPeriode = { ...periode, hendelsestype: nyÅrsak, hendelsesundertype: undefined };
             const nyePerioder = skjemaData.perioder.toSpliced(gammelPeriodeIndex, 1, nyPeriode);
 


### PR DESCRIPTION
- [x] Velger Annet + Annet fritekst når det ikke finnes alternativer
- [x] Har ikke `-` ved kun ett valg
- [x] Vil ikke utløse `harUlagreEndringer` ved innlasting av faktasiden (Dette som var buggen)
https://github.com/user-attachments/assets/f577fb2b-177f-4360-ac63-c72f1207a8db

