### PR TITLE
Add graceful SIGTERM shutdown for server

### DIFF
--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -45,7 +45,15 @@ import setupRouter from './router';
     app.use(urlencoded({ limit: '200mb', extended: true }));
     app.use('/', await setupRouter(texasClient, router));
 
-    app.listen(port, '0.0.0.0', () => {
+    const server = app.listen(port, '0.0.0.0', () => {
         logInfo(`Server startet på port ${port}. Build version: ${appConfig.version}.`);
+    });
+
+    process.on('SIGTERM', () => {
+        logInfo('Mottok SIGTERM, stenger server...');
+        server.close(() => {
+            logInfo('Server stengt.');
+            process.exit(0);
+        });
     });
 })();


### PR DESCRIPTION
The server had no SIGTERM handler, meaning Kubernetes would force-kill the process during deploys/scale-downs, dropping any in-flight requests.

This change captures the return value of app.listen() and adds a process.on('SIGTERM') handler that stops accepting new connections and waits for active requests to finish before exiting cleanly.