### PR TITLE
Cursor jump

### DIFF
--- a/src/frontend/pages/fagsak/vedtak/Vedtaksbrev.test.tsx
+++ b/src/frontend/pages/fagsak/vedtak/Vedtaksbrev.test.tsx
@@ -1,4 +1,3 @@
-import type { VedtaksbrevFormData } from './schema';
 import type { RenderResult } from '@testing-library/react';
 import type { Avsnitt, Brevmottaker, VedtaksbrevData } from '~/generated-new';
 
@@ -10,12 +9,12 @@ import { TestBehandlingProvider } from '~/testdata/behandlingContextFactory';
 
 import { Vedtaksbrev } from './Vedtaksbrev';
 
-const renderVedtaksbrev = (vedtaksbrevData: VedtaksbrevFormData): RenderResult => {
+const renderVedtaksbrev = (vedtaksbrevData: VedtaksbrevData): RenderResult => {
     const client = new QueryClient();
     return render(
         <QueryClientProvider client={client}>
             <TestBehandlingProvider>
-                <Vedtaksbrev vedtaksbrevData={vedtaksbrevData} />
+                <Vedtaksbrev vedtaksbrevData={vedtaksbrevData} onSubmit={vitest.fn()} />
             </TestBehandlingProvider>
         </QueryClientProvider>
     );
@@ -30,6 +29,7 @@ describe('Vedtaksbrev', () => {
                 hovedavsnitt: {
                     tittel: 'Du må betale tilbake stønaden',
                     forklaring: 'Forklaring til hovedavsnitt',
+                    hjemler: '22-15',
                     underavsnitt: [
                         {
                             type: 'rentekst',
@@ -63,6 +63,7 @@ describe('Vedtaksbrev', () => {
                         id: '1',
                         tittel: 'Perioden 12.02.2025–12.03.2025',
                         forklaring: 'Forklaring til perioden',
+                        meldingerTilSaksbehandler: [],
                         underavsnitt: [
                             { type: 'rentekst', tekst: 'Første textarea' },
                             {
@@ -70,6 +71,7 @@ describe('Vedtaksbrev', () => {
                                 tittel: 'Hvordan har vi kommet frem til at du må betale tilbake?',
                                 begrunnelseType: 'SKAL_IKKE_UNNLATES_4_RETTSGEBYR',
                                 forklaring: '',
+                                meldingerTilSaksbehandler: [],
                                 underavsnitt: [{ type: 'rentekst', tekst: 'Andre textarea' }],
                             },
                             {
@@ -77,6 +79,7 @@ describe('Vedtaksbrev', () => {
                                 tittel: 'Hvorfor har vi ikke redusert beløpet?',
                                 begrunnelseType: 'IKKE_REDUSERT_SÆRLIGE_GRUNNER',
                                 forklaring: tredjeAvsnittForklaring,
+                                meldingerTilSaksbehandler: [],
                                 underavsnitt: [{ type: 'rentekst', tekst: 'Tredje textarea' }],
                             },
                         ],
@@ -116,6 +119,7 @@ const lagVedtaksbrevData = (overrides?: Partial<VedtaksbrevData>): VedtaksbrevDa
         hovedavsnitt: {
             tittel: 'Du må betale tilbake stønaden',
             forklaring: 'Forklaring til hovedavsnitt',
+            hjemler: '22-15',
             underavsnitt: [
                 {
                     type: 'rentekst',
@@ -141,5 +145,8 @@ const lagVedtaksbrevData = (overrides?: Partial<VedtaksbrevData>): VedtaksbrevDa
             ansvarligSaksbehandler: 'Ola Nordmann',
             besluttendeSaksbehandler: 'Kari Nordmann',
         } satisfies VedtaksbrevData['signatur'],
+        oppsummeringstabell: [],
+        bunntekster: [],
+        saksnummer: '123456',
     };
 };

--- a/src/frontend/pages/fagsak/vedtak/Vedtaksbrev.tsx
+++ b/src/frontend/pages/fagsak/vedtak/Vedtaksbrev.tsx
@@ -26,7 +26,11 @@ import {
 import { fraIsoStringTilDatoOgKlokkeslett } from '~/utils/dato';
 
 import { vedtaksbrevResolver } from './schema';
-import { tilVedtaksbrevDataWritable } from './utils';
+import {
+    tilFormData,
+    tilVedtaksbrevDataWritable,
+    tilVedtaksbrevRedigerbareDataUpdate,
+} from './utils';
 import { VedtaksbrevSkjema } from './VedtaksbrevSkjema';
 
 const useDebounce = (updateFunction: () => Promise<void> | void): (() => void) => {
@@ -56,10 +60,7 @@ export const Vedtaksbrev: FC<Props> = ({ vedtaksbrevData, onSubmit }) => {
     const methods = useForm<VedtaksbrevFormData>({
         resolver: vedtaksbrevResolver,
         mode: 'onSubmit',
-        values: {
-            hovedavsnitt: vedtaksbrevData.hovedavsnitt,
-            avsnitt: vedtaksbrevData.avsnitt,
-        },
+        values: tilFormData(vedtaksbrevData),
     });
 
     const [pdfSider, setPdfSider] = useState<string[]>([]);
@@ -102,7 +103,7 @@ export const Vedtaksbrev: FC<Props> = ({ vedtaksbrevData, onSubmit }) => {
         oppdaterForhåndsvisning(tilVedtaksbrevDataWritable(vedtaksbrevData, formData));
         oppdaterVedtaksbrevMutation.mutate({
             path: { behandlingId },
-            body: formData,
+            body: tilVedtaksbrevRedigerbareDataUpdate(vedtaksbrevData, formData),
         });
     });
     useEffect(() => {

--- a/src/frontend/pages/fagsak/vedtak/VedtaksbrevSkjema.tsx
+++ b/src/frontend/pages/fagsak/vedtak/VedtaksbrevSkjema.tsx
@@ -1,26 +1,15 @@
 import type { VedtaksbrevFormData } from './schema';
 import type { TextareaProps } from '@navikt/ds-react';
 import type { FC } from 'react';
-import type { FieldErrors, FieldPath, SubmitHandler } from 'react-hook-form';
-import type { Avsnitt, PakrevdBegrunnelse, RotElement, VedtaksbrevData } from '~/generated-new';
+import type { FieldPath, SubmitHandler } from 'react-hook-form';
+import type { Avsnitt, PakrevdBegrunnelse, VedtaksbrevData } from '~/generated-new';
 
 import { Textarea } from '@navikt/ds-react';
-import { useState } from 'react';
-import { get, useController, useFormContext } from 'react-hook-form';
+import { get, useFormContext } from 'react-hook-form';
 
 import { useBehandlingState } from '~/context/BehandlingStateContext';
 
-import { elementArrayTilTekst, tekstTilElementArray } from './utils';
 import { VEDTAKSBREV_FORM_ID } from './Vedtaksbrev';
-
-const hentFeilmelding = (
-    errors: FieldErrors<VedtaksbrevFormData>,
-    name: string
-): string | undefined => {
-    const fieldError = get(errors, name);
-    if (!fieldError) return undefined;
-    return fieldError.root?.message ?? fieldError.message;
-};
 
 type Props = {
     vedtaksbrevData: VedtaksbrevData;
@@ -32,109 +21,63 @@ export const VedtaksbrevSkjema: FC<Props> = ({ vedtaksbrevData, onSubmit }) => {
 
     return (
         <form id={VEDTAKSBREV_FORM_ID} onSubmit={handleSubmit(onSubmit)} className="contents">
-            <ElementTextarea
-                name="hovedavsnitt.underavsnitt"
-                description={vedtaksbrevData.hovedavsnitt.forklaring}
+            <TekstFelt
+                name="hovedavsnitt.tekst"
                 label={vedtaksbrevData.hovedavsnitt.tittel}
+                description={vedtaksbrevData.hovedavsnitt.forklaring}
             />
             {vedtaksbrevData.avsnitt.map((avsnitt, index) => (
-                <Avsnitt key={avsnitt.id} avsnitt={avsnitt} avsnittIndex={index} />
+                <AvsnittFelter key={avsnitt.id} avsnitt={avsnitt} avsnittIndex={index} />
             ))}
         </form>
     );
 };
 
-const Avsnitt: FC<{
-    avsnitt: Avsnitt;
-    avsnittIndex: number;
-}> = ({ avsnitt, avsnittIndex }) => {
-    const { behandlingILesemodus } = useBehandlingState();
-    const {
-        trigger,
-        formState: { errors, isSubmitted },
-    } = useFormContext<VedtaksbrevFormData>();
-    const name = `avsnitt.${avsnittIndex}.underavsnitt` satisfies FieldPath<VedtaksbrevFormData>;
-    const {
-        field: { ref, name: fieldName, onBlur, value, onChange },
-    } = useController<VedtaksbrevFormData>({ name });
-    const elementValue = value as RotElement[];
-    const [localText, setLocalText] = useState(() => elementArrayTilTekst(elementValue));
-
-    const opprinneligePåkrevdeBegrunnelser = avsnitt.underavsnitt.filter(
+const AvsnittFelter: FC<{ avsnitt: Avsnitt; avsnittIndex: number }> = ({
+    avsnitt,
+    avsnittIndex,
+}) => {
+    const påkrevdeBegrunnelser = avsnitt.underavsnitt.filter(
         (el): el is PakrevdBegrunnelse & { type: 'påkrevd_begrunnelse' } =>
             el.type === 'påkrevd_begrunnelse'
     );
 
     return (
         <>
-            <Textarea
-                ref={ref}
-                name={fieldName}
-                onBlur={onBlur}
+            <TekstFelt
+                name={`avsnitt.${avsnittIndex}.tekst`}
                 label={avsnitt.tittel}
                 description={avsnitt.forklaring}
-                value={localText}
-                error={hentFeilmelding(errors, name)}
-                onChange={e => {
-                    setLocalText(e.target.value);
-                    const nyeRentekst = tekstTilElementArray(e.target.value);
-                    const andreElementer = elementValue.filter(({ type }) => type !== 'rentekst');
-                    onChange([...nyeRentekst, ...andreElementer]);
-                    if (isSubmitted) void trigger();
-                }}
-                size="small"
-                maxLength={3000}
-                minRows={3}
-                resize
-                readOnly={behandlingILesemodus}
             />
-
-            {elementValue.map((element, elementIndex) => {
-                if (element.type !== 'påkrevd_begrunnelse') return null;
-                const opprinnelig = opprinneligePåkrevdeBegrunnelser.find(
-                    el => el.begrunnelseType === element.begrunnelseType
-                );
-                return (
-                    <ElementTextarea
-                        key={element.begrunnelseType}
-                        name={`avsnitt.${avsnittIndex}.underavsnitt.${elementIndex}.underavsnitt`}
-                        label={opprinnelig?.tittel ?? ''}
-                        description={opprinnelig?.forklaring}
-                    />
-                );
-            })}
+            {påkrevdeBegrunnelser.map((begrunnelse, begrunnelseIndex) => (
+                <TekstFelt
+                    key={begrunnelse.begrunnelseType}
+                    name={`avsnitt.${avsnittIndex}.påkrevdeBegrunnelser.${begrunnelseIndex}.tekst`}
+                    label={begrunnelse.tittel}
+                    description={begrunnelse.forklaring}
+                />
+            ))}
         </>
     );
 };
 
-const ElementTextarea: FC<
-    Omit<TextareaProps, 'onChange' | 'value'> & {
-        name: FieldPath<VedtaksbrevFormData>;
-    }
-> = ({ name, ...props }) => {
+type TekstFeltProps = Omit<TextareaProps, 'error' | 'name' | 'ref' | 'value'> & {
+    name: FieldPath<VedtaksbrevFormData>;
+};
+
+const TekstFelt: FC<TekstFeltProps> = ({ name, ...props }) => {
     const { behandlingILesemodus } = useBehandlingState();
     const {
-        trigger,
-        formState: { errors, isSubmitted },
+        register,
+        formState: { errors },
     } = useFormContext<VedtaksbrevFormData>();
-    const {
-        field: { ref, name: fieldName, onBlur, value, onChange },
-    } = useController<VedtaksbrevFormData>({ name });
-    const [localText, setLocalText] = useState(() => elementArrayTilTekst(value as RotElement[]));
+    const feilmelding = get(errors, name)?.message;
 
     return (
         <Textarea
             {...props}
-            ref={ref}
-            name={fieldName}
-            onBlur={onBlur}
-            value={localText}
-            error={hentFeilmelding(errors, name)}
-            onChange={e => {
-                setLocalText(e.target.value);
-                onChange(tekstTilElementArray(e.target.value));
-                if (isSubmitted) void trigger();
-            }}
+            {...register(name)}
+            error={feilmelding}
             size="small"
             maxLength={3000}
             minRows={3}

--- a/src/frontend/pages/fagsak/vedtak/VedtaksbrevSkjema.tsx
+++ b/src/frontend/pages/fagsak/vedtak/VedtaksbrevSkjema.tsx
@@ -6,7 +6,7 @@ import type { Avsnitt, PakrevdBegrunnelse, RotElement, VedtaksbrevData } from '~
 
 import { Textarea } from '@navikt/ds-react';
 import { useState } from 'react';
-import { get, useFormContext, useWatch } from 'react-hook-form';
+import { get, useController, useFormContext } from 'react-hook-form';
 
 import { useBehandlingState } from '~/context/BehandlingStateContext';
 
@@ -50,14 +50,14 @@ const Avsnitt: FC<{
 }> = ({ avsnitt, avsnittIndex }) => {
     const { behandlingILesemodus } = useBehandlingState();
     const {
-        register,
-        setValue,
         trigger,
         formState: { errors, isSubmitted },
     } = useFormContext<VedtaksbrevFormData>();
     const name = `avsnitt.${avsnittIndex}.underavsnitt` satisfies FieldPath<VedtaksbrevFormData>;
-    const { ref } = register(name);
-    const elementValue = useWatch<VedtaksbrevFormData>({ name }) as RotElement[];
+    const {
+        field: { ref, name: fieldName, onBlur, value, onChange },
+    } = useController<VedtaksbrevFormData>({ name });
+    const elementValue = value as RotElement[];
     const [localText, setLocalText] = useState(() => elementArrayTilTekst(elementValue));
 
     const opprinneligePåkrevdeBegrunnelser = avsnitt.underavsnitt.filter(
@@ -69,7 +69,8 @@ const Avsnitt: FC<{
         <>
             <Textarea
                 ref={ref}
-                name={name}
+                name={fieldName}
+                onBlur={onBlur}
                 label={avsnitt.tittel}
                 description={avsnitt.forklaring}
                 value={localText}
@@ -78,7 +79,7 @@ const Avsnitt: FC<{
                     setLocalText(e.target.value);
                     const nyeRentekst = tekstTilElementArray(e.target.value);
                     const andreElementer = elementValue.filter(({ type }) => type !== 'rentekst');
-                    setValue(name, [...nyeRentekst, ...andreElementer], { shouldDirty: true });
+                    onChange([...nyeRentekst, ...andreElementer]);
                     if (isSubmitted) void trigger();
                 }}
                 size="small"
@@ -113,25 +114,25 @@ const ElementTextarea: FC<
 > = ({ name, ...props }) => {
     const { behandlingILesemodus } = useBehandlingState();
     const {
-        register,
-        setValue,
         trigger,
         formState: { errors, isSubmitted },
     } = useFormContext<VedtaksbrevFormData>();
-    const { ref } = register(name);
-    const elementValue = useWatch<VedtaksbrevFormData>({ name }) as RotElement[];
-    const [localText, setLocalText] = useState(() => elementArrayTilTekst(elementValue));
+    const {
+        field: { ref, name: fieldName, onBlur, value, onChange },
+    } = useController<VedtaksbrevFormData>({ name });
+    const [localText, setLocalText] = useState(() => elementArrayTilTekst(value as RotElement[]));
 
     return (
         <Textarea
             {...props}
             ref={ref}
-            name={name}
+            name={fieldName}
+            onBlur={onBlur}
             value={localText}
             error={hentFeilmelding(errors, name)}
             onChange={e => {
                 setLocalText(e.target.value);
-                setValue(name, tekstTilElementArray(e.target.value), { shouldDirty: true });
+                onChange(tekstTilElementArray(e.target.value));
                 if (isSubmitted) void trigger();
             }}
             size="small"

--- a/src/frontend/pages/fagsak/vedtak/schema.ts
+++ b/src/frontend/pages/fagsak/vedtak/schema.ts
@@ -1,46 +1,28 @@
-import type { VedtaksbrevRedigerbareDataUpdate } from '~/generated-new';
-
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
-export type VedtaksbrevFormData = VedtaksbrevRedigerbareDataUpdate;
-
 const MINIMUM_TEKST_LENGDE = 3;
 const FEILMELDING = 'Du må fylle inn minst 3 tegn';
+const tekstFelt = z.string().min(MINIMUM_TEKST_LENGDE, FEILMELDING);
 
-const samletRentekstLengde = (elementer: { type: string; tekst?: string }[]): number =>
-    elementer
-        .filter(el => el.type === 'rentekst')
-        .reduce((acc, el) => acc + (el.tekst?.length ?? 0), 0);
+const påkrevdBegrunnelseSchema = z.object({
+    begrunnelseType: z.string(),
+    tekst: tekstFelt,
+});
 
-const harForLiteRentekst = (elementer: { type: string; tekst?: string }[]): boolean =>
-    samletRentekstLengde(elementer) < MINIMUM_TEKST_LENGDE;
-
-const validerUnderavsnitt = z.array(z.any()).superRefine((arr, ctx) => {
-    if (harForLiteRentekst(arr)) {
-        ctx.addIssue({ code: 'custom', message: FEILMELDING });
-    }
-
-    arr.forEach((element, index) => {
-        if (element.type !== 'påkrevd_begrunnelse') return;
-        if (harForLiteRentekst(element.underavsnitt ?? [])) {
-            ctx.addIssue({ code: 'custom', message: FEILMELDING, path: [index, 'underavsnitt'] });
-        }
-    });
+const avsnittSchema = z.object({
+    id: z.string(),
+    tekst: tekstFelt,
+    påkrevdeBegrunnelser: z.array(påkrevdBegrunnelseSchema),
 });
 
 const vedtaksbrevSchema = z.object({
     hovedavsnitt: z.object({
-        tittel: z.string(),
-        underavsnitt: validerUnderavsnitt,
+        tekst: tekstFelt,
     }),
-    avsnitt: z.array(
-        z.object({
-            tittel: z.string(),
-            id: z.string(),
-            underavsnitt: validerUnderavsnitt,
-        })
-    ),
+    avsnitt: z.array(avsnittSchema),
 });
+
+export type VedtaksbrevFormData = z.infer<typeof vedtaksbrevSchema>;
 
 export const vedtaksbrevResolver = zodResolver(vedtaksbrevSchema);

--- a/src/frontend/pages/fagsak/vedtak/utils.test.ts
+++ b/src/frontend/pages/fagsak/vedtak/utils.test.ts
@@ -4,14 +4,19 @@ import type { Avsnitt, VedtaksbrevData } from '~/generated-new';
 import { describe, expect, test } from 'vitest';
 
 import { vedtaksbrevResolver } from './schema';
-import { elementArrayTilTekst, tekstTilElementArray, tilVedtaksbrevDataWritable } from './utils';
+import {
+    elementArrayTilTekst,
+    tekstTilElementArray,
+    tilFormData,
+    tilVedtaksbrevDataWritable,
+} from './utils';
 
 const lagVedtaksbrevData = (overrides: Partial<VedtaksbrevData> = {}): VedtaksbrevData => ({
     hovedavsnitt: {
         tittel: 'Du må ikke betale tilbake barnetrygden',
-        forklaring:
-            'Her viser du til vedtaksbrevet om revurdering, det feilutbetalte beløpet og hva brukeren skal betale tilbake.',
+        forklaring: 'Forklaring',
         underavsnitt: [{ type: 'rentekst', tekst: 'Opprinnelig hovedtekst' }],
+        hjemler: '§ 22-15',
     },
     avsnitt: [],
     sistOppdatert: '2026-04-16T12:00:00Z',
@@ -30,12 +35,53 @@ const lagVedtaksbrevData = (overrides: Partial<VedtaksbrevData> = {}): Vedtaksbr
 });
 
 const lagFormData = (overrides: Partial<VedtaksbrevFormData> = {}): VedtaksbrevFormData => ({
-    hovedavsnitt: {
-        tittel: 'Du må ikke betale tilbake barnetrygden',
-        underavsnitt: [{ type: 'rentekst', tekst: 'Redigert hovedtekst' }],
-    },
+    hovedavsnitt: { tekst: 'Redigert hovedtekst' },
     avsnitt: [],
     ...overrides,
+});
+
+const lagOpprinneligAvsnittMedBegrunnelse = (): Avsnitt => ({
+    tittel: 'Dette er grunnen til at du har fått for mye utbetalt',
+    forklaring: 'Skal ikke med',
+    meldingerTilSaksbehandler: [],
+    id: 'avsnitt-1',
+    underavsnitt: [
+        { type: 'rentekst', tekst: 'Opprinnelig tekst' },
+        {
+            type: 'påkrevd_begrunnelse',
+            tittel: 'Særlige grunner',
+            forklaring: 'Forklar dette',
+            meldingerTilSaksbehandler: [],
+            begrunnelseType: 'særlige_grunner',
+            underavsnitt: [{ type: 'rentekst', tekst: 'Opprinnelig begrunnelse' }],
+        },
+    ],
+});
+
+describe('tilFormData', () => {
+    test('flater ut hovedavsnitt og avsnitt med påkrevde begrunnelser', () => {
+        const vedtaksbrevData = lagVedtaksbrevData({
+            avsnitt: [lagOpprinneligAvsnittMedBegrunnelse()],
+        });
+
+        const result = tilFormData(vedtaksbrevData);
+
+        expect(result).toEqual({
+            hovedavsnitt: { tekst: 'Opprinnelig hovedtekst' },
+            avsnitt: [
+                {
+                    id: 'avsnitt-1',
+                    tekst: 'Opprinnelig tekst',
+                    påkrevdeBegrunnelser: [
+                        {
+                            begrunnelseType: 'særlige_grunner',
+                            tekst: 'Opprinnelig begrunnelse',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });
 
 describe('tilVedtaksbrevDataWritable', () => {
@@ -51,44 +97,22 @@ describe('tilVedtaksbrevDataWritable', () => {
         expect(resultat).not.toHaveProperty('sistOppdatert');
     });
 
-    test('mapper avsnitt med redigerte underavsnitt og skriver på påkrevd_begrunnelse', () => {
-        const opprinneligAvsnitt = [
-            {
-                tittel: 'Dette er grunnen til at du har fått for mye utbetalt',
-                forklaring: 'Skal ikke med',
-                meldingerTilSaksbehandler: [],
-                id: 'avsnitt-1',
-                underavsnitt: [
-                    { type: 'rentekst', tekst: 'Opprinnelig tekst' },
-                    {
-                        type: 'påkrevd_begrunnelse',
-                        tittel: 'Særlige grunner',
-                        forklaring: 'Forklar dette',
-                        meldingerTilSaksbehandler: [],
-                        begrunnelseType: 'særlige_grunner',
-                        underavsnitt: [{ type: 'rentekst', tekst: 'Opprinnelig begrunnelse' }],
-                    },
-                ],
-            } satisfies Avsnitt,
-        ];
+    test('mapper avsnitt med redigerte underavsnitt og bevarer tittel på påkrevd_begrunnelse', () => {
+        const vedtaksbrevData = lagVedtaksbrevData({
+            avsnitt: [lagOpprinneligAvsnittMedBegrunnelse()],
+        });
 
-        const formAvsnitt: VedtaksbrevFormData['avsnitt'] = [
-            {
-                tittel: 'Dette er grunnen til at du har fått for mye utbetalt',
-                id: 'avsnitt-1',
-                underavsnitt: [
-                    { type: 'rentekst', tekst: 'Redigert tekst' },
-                    {
-                        type: 'påkrevd_begrunnelse',
-                        begrunnelseType: 'særlige_grunner',
-                        underavsnitt: [{ type: 'rentekst', tekst: 'Redigert begrunnelse' }],
-                    },
-                ],
-            },
-        ];
-
-        const vedtaksbrevData = lagVedtaksbrevData({ avsnitt: opprinneligAvsnitt });
-        const formData = lagFormData({ avsnitt: formAvsnitt });
+        const formData = lagFormData({
+            avsnitt: [
+                {
+                    id: 'avsnitt-1',
+                    tekst: 'Redigert tekst',
+                    påkrevdeBegrunnelser: [
+                        { begrunnelseType: 'særlige_grunner', tekst: 'Redigert begrunnelse' },
+                    ],
+                },
+            ],
+        });
 
         const resultat = tilVedtaksbrevDataWritable(vedtaksbrevData, formData);
 
@@ -111,19 +135,17 @@ describe('tilVedtaksbrevDataWritable', () => {
 
 describe('elementArrayTilTekst', () => {
     test('konverterer ett element til tekst', () => {
-        const input = [{ type: 'rentekst' as const, tekst: 'Dette er en tekst' }];
-        const result = elementArrayTilTekst(input);
-
-        expect(result).toBe('Dette er en tekst');
+        expect(elementArrayTilTekst([{ type: 'rentekst', tekst: 'Dette er en tekst' }])).toBe(
+            'Dette er en tekst'
+        );
     });
 
     test('konverterer flere elementer til tekst med dobbelt linjeskift', () => {
-        const input = [
-            { type: 'rentekst' as const, tekst: 'Første avsnitt' },
-            { type: 'rentekst' as const, tekst: 'Andre avsnitt' },
-            { type: 'rentekst' as const, tekst: 'Tredje avsnitt' },
-        ];
-        const result = elementArrayTilTekst(input);
+        const result = elementArrayTilTekst([
+            { type: 'rentekst', tekst: 'Første avsnitt' },
+            { type: 'rentekst', tekst: 'Andre avsnitt' },
+            { type: 'rentekst', tekst: 'Tredje avsnitt' },
+        ]);
 
         expect(result).toBe('Første avsnitt\n\nAndre avsnitt\n\nTredje avsnitt');
     });
@@ -131,15 +153,13 @@ describe('elementArrayTilTekst', () => {
 
 describe('tekstTilElementArray', () => {
     test('konverterer en enkel tekst til element', () => {
-        const result = tekstTilElementArray('Dette er en tekst');
-
-        expect(result).toEqual([{ type: 'rentekst', tekst: 'Dette er en tekst' }]);
+        expect(tekstTilElementArray('Dette er en tekst')).toEqual([
+            { type: 'rentekst', tekst: 'Dette er en tekst' },
+        ]);
     });
 
     test('konverterer tekst med dobbelt linjeskift til flere elementer', () => {
-        const result = tekstTilElementArray('Første avsnitt\n\nAndre avsnitt\n\nTredje avsnitt');
-
-        expect(result).toEqual([
+        expect(tekstTilElementArray('Første avsnitt\n\nAndre avsnitt\n\nTredje avsnitt')).toEqual([
             { type: 'rentekst', tekst: 'Første avsnitt' },
             { type: 'rentekst', tekst: 'Andre avsnitt' },
             { type: 'rentekst', tekst: 'Tredje avsnitt' },
@@ -147,9 +167,7 @@ describe('tekstTilElementArray', () => {
     });
 
     test('håndterer flere påfølgende linjeskift som ett skille', () => {
-        const result = tekstTilElementArray('Første\n\n\n\nAndre\n\n\n\n\nTredje');
-
-        expect(result).toEqual([
+        expect(tekstTilElementArray('Første\n\n\n\nAndre\n\n\n\n\nTredje')).toEqual([
             { type: 'rentekst', tekst: 'Første' },
             { type: 'rentekst', tekst: 'Andre' },
             { type: 'rentekst', tekst: 'Tredje' },
@@ -157,9 +175,7 @@ describe('tekstTilElementArray', () => {
     });
 
     test('bevarer enkelt linjeskift innenfor samme element', () => {
-        const result = tekstTilElementArray('Første linje\nAndre linje\n\nNytt avsnitt');
-
-        expect(result).toEqual([
+        expect(tekstTilElementArray('Første linje\nAndre linje\n\nNytt avsnitt')).toEqual([
             { type: 'rentekst', tekst: 'Første linje\nAndre linje' },
             { type: 'rentekst', tekst: 'Nytt avsnitt' },
         ]);
@@ -170,105 +186,57 @@ describe('vedtaksbrevResolver', () => {
     const kjørResolver = async (
         data: VedtaksbrevFormData
     ): Promise<ReturnType<typeof vedtaksbrevResolver>> =>
-        vedtaksbrevResolver(
-            data,
-            {},
-            {
-                names: [],
-                fields: {},
-                shouldUseNativeValidation: false,
-            }
-        );
+        vedtaksbrevResolver(data, {}, { names: [], fields: {}, shouldUseNativeValidation: false });
 
     const FORVENTET_FEILMELDING = 'Du må fylle inn minst 3 tegn';
 
-    const lagAvsnitt = (
-        underavsnitt: VedtaksbrevFormData['avsnitt'][number]['underavsnitt']
-    ): VedtaksbrevFormData['avsnitt'][number] => ({
-        tittel: 'Avsnittstittel',
-        id: '550e8400-e29b-41d4-a716-446655440000',
-        underavsnitt,
-    });
-
     test('passerer for gyldig data', async () => {
         const { errors } = await kjørResolver({
-            hovedavsnitt: {
-                tittel: 'Hovedtittel',
-                underavsnitt: [{ type: 'rentekst', tekst: 'noe tekst' }],
-            },
+            hovedavsnitt: { tekst: 'noe tekst' },
             avsnitt: [
-                lagAvsnitt([
-                    { type: 'rentekst', tekst: 'periodetekst' },
-                    {
-                        type: 'påkrevd_begrunnelse',
-                        begrunnelseType: 'test',
-                        underavsnitt: [{ type: 'rentekst', tekst: 'begrunnelse' }],
-                    },
-                ]),
+                {
+                    id: 'a-1',
+                    tekst: 'periodetekst',
+                    påkrevdeBegrunnelser: [{ begrunnelseType: 'test', tekst: 'begrunnelse' }],
+                },
             ],
         });
 
         expect(errors).toEqual({});
     });
 
-    test('gir feil når hovedavsnitt har under 3 tegn rentekst', async () => {
+    test('gir feil når hovedavsnitt har under 3 tegn', async () => {
         const { errors } = await kjørResolver({
-            hovedavsnitt: {
-                tittel: 'Hovedtittel',
-                underavsnitt: [{ type: 'rentekst', tekst: 'ab' }],
-            },
+            hovedavsnitt: { tekst: 'ab' },
             avsnitt: [],
         });
 
-        expect(errors).toHaveProperty(
-            ['hovedavsnitt', 'underavsnitt', 'message'],
-            FORVENTET_FEILMELDING
-        );
+        expect(errors).toHaveProperty(['hovedavsnitt', 'tekst', 'message'], FORVENTET_FEILMELDING);
     });
 
-    test('gir feil når avsnitt mangler rentekst-elementer', async () => {
+    test('gir feil når avsnitt-tekst er for kort', async () => {
         const { errors } = await kjørResolver({
-            hovedavsnitt: {
-                tittel: 'Hovedtittel',
-                underavsnitt: [{ type: 'rentekst', tekst: 'noe tekst' }],
-            },
+            hovedavsnitt: { tekst: 'noe tekst' },
+            avsnitt: [{ id: 'a-1', tekst: '', påkrevdeBegrunnelser: [] }],
+        });
+
+        expect(errors).toHaveProperty(['avsnitt', 0, 'tekst', 'message'], FORVENTET_FEILMELDING);
+    });
+
+    test('gir feil når påkrevd begrunnelse er for kort', async () => {
+        const { errors } = await kjørResolver({
+            hovedavsnitt: { tekst: 'noe tekst' },
             avsnitt: [
-                lagAvsnitt([
-                    {
-                        type: 'påkrevd_begrunnelse',
-                        begrunnelseType: 'test',
-                        underavsnitt: [{ type: 'rentekst', tekst: 'begrunnelse' }],
-                    },
-                ]),
+                {
+                    id: 'a-1',
+                    tekst: 'noe tekst',
+                    påkrevdeBegrunnelser: [{ begrunnelseType: 'test', tekst: '' }],
+                },
             ],
         });
 
         expect(errors).toHaveProperty(
-            ['avsnitt', 0, 'underavsnitt', 'message'],
-            FORVENTET_FEILMELDING
-        );
-    });
-
-    test('gir feil når påkrevd_begrunnelse har for lite rentekst', async () => {
-        const { errors } = await kjørResolver({
-            hovedavsnitt: {
-                tittel: 'Hovedtittel',
-                underavsnitt: [{ type: 'rentekst', tekst: 'noe tekst' }],
-            },
-            avsnitt: [
-                lagAvsnitt([
-                    { type: 'rentekst', tekst: 'noe tekst' },
-                    {
-                        type: 'påkrevd_begrunnelse',
-                        begrunnelseType: 'test',
-                        underavsnitt: [],
-                    },
-                ]),
-            ],
-        });
-
-        expect(errors).toHaveProperty(
-            ['avsnitt', 0, 'underavsnitt', 1, 'underavsnitt', 'message'],
+            ['avsnitt', 0, 'påkrevdeBegrunnelser', 0, 'tekst', 'message'],
             FORVENTET_FEILMELDING
         );
     });

--- a/src/frontend/pages/fagsak/vedtak/utils.test.ts
+++ b/src/frontend/pages/fagsak/vedtak/utils.test.ts
@@ -28,7 +28,7 @@ const lagVedtaksbrevData = (overrides: Partial<VedtaksbrevData> = {}): Vedtaksbr
         ansvarligSaksbehandler: 'Saksbehandler A',
         besluttendeSaksbehandler: null,
     },
-    oppsummeringstabell: [],
+    oppsummeringstabell: { beregnerSkatt: false, perioder: [] },
     bunntekster: [],
     saksnummer: '0012345678',
     ...overrides,

--- a/src/frontend/pages/fagsak/vedtak/utils.ts
+++ b/src/frontend/pages/fagsak/vedtak/utils.ts
@@ -1,7 +1,6 @@
 import type { VedtaksbrevFormData } from './schema';
 import type {
     PakrevdBegrunnelseUpdateItem,
-    RotElement,
     RotElementUpdateItem,
     RotElementWritable,
     VedtaksbrevData,
@@ -9,17 +8,21 @@ import type {
     VedtaksbrevRedigerbareDataUpdate,
 } from '~/generated-new';
 
-export const elementArrayTilTekst = (elementer: RotElement[]): string =>
+type RentekstElement = { type: 'rentekst'; tekst: string };
+
+export const elementArrayTilTekst = (
+    elementer: readonly { type: string; tekst?: string }[]
+): string =>
     elementer
-        .filter(e => e.type === 'rentekst')
-        .map(e => (e.type === 'rentekst' ? e.tekst : ''))
+        .filter((e): e is RentekstElement => e.type === 'rentekst')
+        .map(e => e.tekst)
         .join('\n\n');
 
-export const tekstTilElementArray = (tekst: string): RotElement[] =>
+export const tekstTilElementArray = (tekst: string): RentekstElement[] =>
     tekst
         .split(/\n\n+/)
         .filter(t => t.length > 0)
-        .map(t => ({ type: 'rentekst' as const, tekst: t }));
+        .map(t => ({ type: 'rentekst', tekst: t }));
 
 export const tilFormData = (vedtaksbrevData: VedtaksbrevData): VedtaksbrevFormData => ({
     hovedavsnitt: {
@@ -32,13 +35,25 @@ export const tilFormData = (vedtaksbrevData: VedtaksbrevData): VedtaksbrevFormDa
             .filter(el => el.type === 'påkrevd_begrunnelse')
             .map(el => ({
                 begrunnelseType: el.begrunnelseType,
-                tekst: el.underavsnitt
-                    .filter(u => u.type === 'rentekst')
-                    .map(u => u.tekst)
-                    .join('\n\n'),
+                tekst: elementArrayTilTekst(el.underavsnitt),
             })),
     })),
 });
+
+const finnFormPåkrevd = (
+    formAvsnitt: VedtaksbrevFormData['avsnitt'][number],
+    begrunnelseType: string
+): VedtaksbrevFormData['avsnitt'][number]['påkrevdeBegrunnelser'][number] => {
+    const formPåkrevd = formAvsnitt.påkrevdeBegrunnelser.find(
+        p => p.begrunnelseType === begrunnelseType
+    );
+    if (!formPåkrevd) {
+        throw new Error(
+            `Fant ikke matchende 'påkrevd_begrunnelse' med begrunnelseType '${begrunnelseType}' i form-data`
+        );
+    }
+    return formPåkrevd;
+};
 
 export const tilVedtaksbrevDataWritable = (
     vedtaksbrevData: VedtaksbrevData,
@@ -55,30 +70,16 @@ export const tilVedtaksbrevDataWritable = (
         },
         avsnitt: formData.avsnitt.map((formAvsnitt, i) => {
             const opprinnelig = avsnitt[i];
-            const påkrevdeFraDto = opprinnelig.underavsnitt.filter(
-                el => el.type === 'påkrevd_begrunnelse'
-            );
-            const påkrevdeWritable: RotElementWritable[] = påkrevdeFraDto.map(
-                opprinneligPåkrevd => {
-                    const formPåkrevd = formAvsnitt.påkrevdeBegrunnelser.find(
-                        p => p.begrunnelseType === opprinneligPåkrevd.begrunnelseType
-                    );
-                    if (!formPåkrevd) {
-                        throw new Error(
-                            `Fant ikke matchende 'påkrevd_begrunnelse' med begrunnelseType '${opprinneligPåkrevd.begrunnelseType}' i form-data`
-                        );
-                    }
-                    return {
-                        type: 'påkrevd_begrunnelse',
-                        tittel: opprinneligPåkrevd.tittel,
-                        begrunnelseType: opprinneligPåkrevd.begrunnelseType,
-                        underavsnitt: formPåkrevd.tekst
-                            .split(/\n\n+/)
-                            .filter(t => t.length > 0)
-                            .map(t => ({ type: 'rentekst' as const, tekst: t })),
-                    };
-                }
-            );
+            const påkrevdeWritable: RotElementWritable[] = opprinnelig.underavsnitt
+                .filter(el => el.type === 'påkrevd_begrunnelse')
+                .map(opprinneligPåkrevd => ({
+                    type: 'påkrevd_begrunnelse',
+                    tittel: opprinneligPåkrevd.tittel,
+                    begrunnelseType: opprinneligPåkrevd.begrunnelseType,
+                    underavsnitt: tekstTilElementArray(
+                        finnFormPåkrevd(formAvsnitt, opprinneligPåkrevd.begrunnelseType).tekst
+                    ),
+                }));
             return {
                 tittel: opprinnelig.tittel,
                 id: formAvsnitt.id,
@@ -98,27 +99,17 @@ export const tilVedtaksbrevRedigerbareDataUpdate = (
     },
     avsnitt: formData.avsnitt.map((formAvsnitt, i) => {
         const opprinnelig = vedtaksbrevData.avsnitt[i];
-        const påkrevdeFraDto = opprinnelig.underavsnitt.filter(
-            el => el.type === 'påkrevd_begrunnelse'
-        );
-        const påkrevdeUpdate: RotElementUpdateItem[] = påkrevdeFraDto.map(opprinneligPåkrevd => {
-            const formPåkrevd = formAvsnitt.påkrevdeBegrunnelser.find(
-                p => p.begrunnelseType === opprinneligPåkrevd.begrunnelseType
-            );
-            if (!formPåkrevd) {
-                throw new Error(
-                    `Fant ikke matchende 'påkrevd_begrunnelse' med begrunnelseType '${opprinneligPåkrevd.begrunnelseType}' i form-data`
-                );
-            }
-            const update = {
-                begrunnelseType: opprinneligPåkrevd.begrunnelseType,
-                underavsnitt: formPåkrevd.tekst
-                    .split(/\n\n+/)
-                    .filter(t => t.length > 0)
-                    .map(t => ({ type: 'rentekst' as const, tekst: t })),
-            } satisfies PakrevdBegrunnelseUpdateItem;
-            return { type: 'påkrevd_begrunnelse', ...update };
-        });
+        const påkrevdeUpdate: RotElementUpdateItem[] = opprinnelig.underavsnitt
+            .filter(el => el.type === 'påkrevd_begrunnelse')
+            .map(opprinneligPåkrevd => {
+                const update: PakrevdBegrunnelseUpdateItem = {
+                    begrunnelseType: opprinneligPåkrevd.begrunnelseType,
+                    underavsnitt: tekstTilElementArray(
+                        finnFormPåkrevd(formAvsnitt, opprinneligPåkrevd.begrunnelseType).tekst
+                    ),
+                };
+                return { type: 'påkrevd_begrunnelse', ...update };
+            });
         return {
             tittel: opprinnelig.tittel,
             id: formAvsnitt.id,

--- a/src/frontend/pages/fagsak/vedtak/utils.ts
+++ b/src/frontend/pages/fagsak/vedtak/utils.ts
@@ -1,29 +1,44 @@
 import type { VedtaksbrevFormData } from './schema';
 import type {
+    PakrevdBegrunnelseUpdateItem,
     RotElement,
     RotElementUpdateItem,
     RotElementWritable,
     VedtaksbrevData,
     VedtaksbrevDataWritable,
+    VedtaksbrevRedigerbareDataUpdate,
 } from '~/generated-new';
 
-const tilRotElementWritable = (
-    oppdatert: RotElementUpdateItem,
-    opprinneligeElementer: RotElement[]
-): RotElementWritable => {
-    if (oppdatert.type !== 'påkrevd_begrunnelse') {
-        return oppdatert satisfies RotElementWritable;
-    }
-    const opprinnelig = opprinneligeElementer.find(
-        e => e.type === 'påkrevd_begrunnelse' && e.begrunnelseType === oppdatert.begrunnelseType
-    );
-    if (!opprinnelig || opprinnelig.type !== 'påkrevd_begrunnelse') {
-        throw new Error(
-            `Fant ikke matchende 'påkrevd_begrunnelse' med begrunnelseType '${oppdatert.begrunnelseType}' i opprinneligdata`
-        );
-    }
-    return { ...oppdatert, tittel: opprinnelig.tittel } satisfies RotElementWritable;
-};
+export const elementArrayTilTekst = (elementer: RotElement[]): string =>
+    elementer
+        .filter(e => e.type === 'rentekst')
+        .map(e => (e.type === 'rentekst' ? e.tekst : ''))
+        .join('\n\n');
+
+export const tekstTilElementArray = (tekst: string): RotElement[] =>
+    tekst
+        .split(/\n\n+/)
+        .filter(t => t.length > 0)
+        .map(t => ({ type: 'rentekst' as const, tekst: t }));
+
+export const tilFormData = (vedtaksbrevData: VedtaksbrevData): VedtaksbrevFormData => ({
+    hovedavsnitt: {
+        tekst: elementArrayTilTekst(vedtaksbrevData.hovedavsnitt.underavsnitt),
+    },
+    avsnitt: vedtaksbrevData.avsnitt.map(avsnitt => ({
+        id: avsnitt.id,
+        tekst: elementArrayTilTekst(avsnitt.underavsnitt),
+        påkrevdeBegrunnelser: avsnitt.underavsnitt
+            .filter(el => el.type === 'påkrevd_begrunnelse')
+            .map(el => ({
+                begrunnelseType: el.begrunnelseType,
+                tekst: el.underavsnitt
+                    .filter(u => u.type === 'rentekst')
+                    .map(u => u.tekst)
+                    .join('\n\n'),
+            })),
+    })),
+});
 
 export const tilVedtaksbrevDataWritable = (
     vedtaksbrevData: VedtaksbrevData,
@@ -34,32 +49,80 @@ export const tilVedtaksbrevDataWritable = (
     return {
         ...statiskeData,
         hovedavsnitt: {
-            tittel: formData.hovedavsnitt.tittel,
-            hjemler: vedtaksbrevData.hovedavsnitt.hjemler,
-            underavsnitt: formData.hovedavsnitt.underavsnitt.map(el =>
-                tilRotElementWritable(el, hovedavsnitt.underavsnitt)
-            ),
+            tittel: hovedavsnitt.tittel,
+            hjemler: hovedavsnitt.hjemler,
+            underavsnitt: tekstTilElementArray(formData.hovedavsnitt.tekst),
         },
-        avsnitt: formData.avsnitt.map((formAvsnitt, i) => ({
-            tittel: formAvsnitt.tittel,
-            id: formAvsnitt.id,
-            underavsnitt: formAvsnitt.underavsnitt.map(el =>
-                tilRotElementWritable(el, avsnitt[i].underavsnitt)
-            ),
-        })),
+        avsnitt: formData.avsnitt.map((formAvsnitt, i) => {
+            const opprinnelig = avsnitt[i];
+            const påkrevdeFraDto = opprinnelig.underavsnitt.filter(
+                el => el.type === 'påkrevd_begrunnelse'
+            );
+            const påkrevdeWritable: RotElementWritable[] = påkrevdeFraDto.map(
+                opprinneligPåkrevd => {
+                    const formPåkrevd = formAvsnitt.påkrevdeBegrunnelser.find(
+                        p => p.begrunnelseType === opprinneligPåkrevd.begrunnelseType
+                    );
+                    if (!formPåkrevd) {
+                        throw new Error(
+                            `Fant ikke matchende 'påkrevd_begrunnelse' med begrunnelseType '${opprinneligPåkrevd.begrunnelseType}' i form-data`
+                        );
+                    }
+                    return {
+                        type: 'påkrevd_begrunnelse',
+                        tittel: opprinneligPåkrevd.tittel,
+                        begrunnelseType: opprinneligPåkrevd.begrunnelseType,
+                        underavsnitt: formPåkrevd.tekst
+                            .split(/\n\n+/)
+                            .filter(t => t.length > 0)
+                            .map(t => ({ type: 'rentekst' as const, tekst: t })),
+                    };
+                }
+            );
+            return {
+                tittel: opprinnelig.tittel,
+                id: formAvsnitt.id,
+                underavsnitt: [...tekstTilElementArray(formAvsnitt.tekst), ...påkrevdeWritable],
+            };
+        }),
     };
 };
 
-export const elementArrayTilTekst = (elementer: RotElement[]): string => {
-    return elementer
-        .filter(e => e.type === 'rentekst')
-        .map(e => (e.type === 'rentekst' ? e.tekst : undefined))
-        .join('\n\n');
-};
-
-export const tekstTilElementArray = (tekst: string): RotElement[] => {
-    return tekst
-        .split(/\n\n+/)
-        .filter(t => t.length > 0)
-        .map(t => ({ type: 'rentekst' as const, tekst: t }));
-};
+export const tilVedtaksbrevRedigerbareDataUpdate = (
+    vedtaksbrevData: VedtaksbrevData,
+    formData: VedtaksbrevFormData
+): VedtaksbrevRedigerbareDataUpdate => ({
+    hovedavsnitt: {
+        tittel: vedtaksbrevData.hovedavsnitt.tittel,
+        underavsnitt: tekstTilElementArray(formData.hovedavsnitt.tekst),
+    },
+    avsnitt: formData.avsnitt.map((formAvsnitt, i) => {
+        const opprinnelig = vedtaksbrevData.avsnitt[i];
+        const påkrevdeFraDto = opprinnelig.underavsnitt.filter(
+            el => el.type === 'påkrevd_begrunnelse'
+        );
+        const påkrevdeUpdate: RotElementUpdateItem[] = påkrevdeFraDto.map(opprinneligPåkrevd => {
+            const formPåkrevd = formAvsnitt.påkrevdeBegrunnelser.find(
+                p => p.begrunnelseType === opprinneligPåkrevd.begrunnelseType
+            );
+            if (!formPåkrevd) {
+                throw new Error(
+                    `Fant ikke matchende 'påkrevd_begrunnelse' med begrunnelseType '${opprinneligPåkrevd.begrunnelseType}' i form-data`
+                );
+            }
+            const update = {
+                begrunnelseType: opprinneligPåkrevd.begrunnelseType,
+                underavsnitt: formPåkrevd.tekst
+                    .split(/\n\n+/)
+                    .filter(t => t.length > 0)
+                    .map(t => ({ type: 'rentekst' as const, tekst: t })),
+            } satisfies PakrevdBegrunnelseUpdateItem;
+            return { type: 'påkrevd_begrunnelse', ...update };
+        });
+        return {
+            tittel: opprinnelig.tittel,
+            id: formAvsnitt.id,
+            underavsnitt: [...tekstTilElementArray(formAvsnitt.tekst), ...påkrevdeUpdate],
+        };
+    }),
+});


### PR DESCRIPTION
-  PUT-kontrakten (`VedtaksbrevRedigerbareDataUpdate`) bygges nå eksplisitt i `tilVedtaksbrevRedigerbareDataUpdate(vedtaksbrevData, formData)` og sendes som
  body. Den henter tittel fra vedtaksbrevData (siden form-modellen er flat og bare har tekstene), og bygger `RotElementUpdateItem[]` for hvert avsnitt.
- Inkludert `påkrevd_begrunnelse`-elementer der kun `begrunnelseType` og underavsnitt sendes (ikke tittel, slik kontrakten krever).