### PR TITLE
Oppgraderer ESLint til recommendedTypeChecked

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ import tseslint from 'typescript-eslint';
 
 export default defineConfig(
     eslint.configs.recommended,
-    ...tseslint.configs.recommended,
+    ...tseslint.configs.recommendedTypeChecked,
     eslintReact.configs['recommended-typescript'],
     jsxA11y.flatConfigs.recommended,
     eslintPluginPrettierRecommended,
@@ -17,6 +17,14 @@ export default defineConfig(
         languageOptions: {
             parserOptions: {
                 ecmaFeatures: { jsx: true },
+                projectService: {
+                    allowDefaultProject: [
+                        'src/vitest-setup.ts',
+                        'src/frontend/tailwind.config.js',
+                        'src/frontend/vite.config.js',
+                    ],
+                },
+                tsconfigRootDir: import.meta.dirname,
             },
         },
     },
@@ -89,6 +97,23 @@ export default defineConfig(
             '@typescript-eslint/no-non-null-assertion': 'error',
             '@typescript-eslint/no-explicit-any': 'warn',
             '@typescript-eslint/sort-type-constituents': 'warn',
+            // Type-aware regler nedgradert til 'warn' inntil eksisterende
+            // brudd er ryddet opp i. Se sporings-issue.
+            '@typescript-eslint/no-redundant-type-constituents': 'warn',
+            '@typescript-eslint/no-floating-promises': 'warn',
+            '@typescript-eslint/no-unsafe-member-access': 'warn',
+            '@typescript-eslint/no-misused-promises': 'warn',
+            '@typescript-eslint/no-unsafe-assignment': 'warn',
+            '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
+            '@typescript-eslint/no-unsafe-return': 'warn',
+            '@typescript-eslint/no-unsafe-call': 'warn',
+            '@typescript-eslint/no-unsafe-argument': 'warn',
+            '@typescript-eslint/require-await': 'warn',
+            '@typescript-eslint/no-base-to-string': 'warn',
+            '@typescript-eslint/restrict-template-expressions': 'warn',
+            '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+            '@typescript-eslint/no-duplicate-type-constituents': 'warn',
+            '@typescript-eslint/prefer-promise-reject-errors': 'warn',
         },
     },
     [globalIgnores(['src/frontend/generated/', 'src/frontend/generated-new/'])]


### PR DESCRIPTION
Aktiverer type-aware regler via tseslint.configs.recommendedTypeChecked med projectService for raskere parsing.

De 15 reglene som genererer eksisterende brudd er nedgradert til 'warn' for å holde CI grønn. Disse skal ryddes opp i og oppgraderes til 'error' i oppfølgings-PRer (én regel per PR), totalt 315 advarsler.

Anbefaling kommer herfra: https://typescript-eslint.io/getting-started/typed-linting/