### PR TITLE
Legger til støtte for redigerbare stønadstekster i forhåndsvarsel

### DIFF
--- a/src/frontend/kodeverk/fagsystem.ts
+++ b/src/frontend/kodeverk/fagsystem.ts
@@ -20,16 +20,6 @@ export enum Ytelsetype {
     Arbeidsavklaringspenger = 'ARBEIDSAVKLARINGSPENGER',
 }
 
-export const ytelsestypeTilBestemtEntall: Record<Ytelsetype, string> = {
-    [Ytelsetype.Barnetrygd]: 'barnetrygden',
-    [Ytelsetype.Overgangsstønad]: 'overgangsstønaden',
-    [Ytelsetype.Barnetilsyn]: 'barnetilsynet',
-    [Ytelsetype.Skolepenger]: 'skolepengene',
-    [Ytelsetype.Kontantstøtte]: 'kontantstøtten',
-    [Ytelsetype.Tilleggsstønad]: 'tilleggsstønaden',
-    [Ytelsetype.Arbeidsavklaringspenger]: 'arbeidsavklaringspengene',
-};
-
 const hendelseTyperForYtelse: Record<string, HendelseType[]> = {
     BARNETRYGD: [
         HendelseType.BorMedSøker,

--- a/src/frontend/kodeverk/fagsystem.ts
+++ b/src/frontend/kodeverk/fagsystem.ts
@@ -20,6 +20,16 @@ export enum Ytelsetype {
     Arbeidsavklaringspenger = 'ARBEIDSAVKLARINGSPENGER',
 }
 
+export const ytelsestypeTilBestemtEntall: Record<Ytelsetype, string> = {
+    [Ytelsetype.Barnetrygd]: 'barnetrygden',
+    [Ytelsetype.Overgangsstønad]: 'overgangsstønaden',
+    [Ytelsetype.Barnetilsyn]: 'barnetilsynet',
+    [Ytelsetype.Skolepenger]: 'skolepengene',
+    [Ytelsetype.Kontantstøtte]: 'kontantstøtten',
+    [Ytelsetype.Tilleggsstønad]: 'tilleggsstønaden',
+    [Ytelsetype.Arbeidsavklaringspenger]: 'arbeidsavklaringspengene',
+};
+
 const hendelseTyperForYtelse: Record<string, HendelseType[]> = {
     BARNETRYGD: [
         HendelseType.BorMedSøker,

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -1,9 +1,12 @@
 import type { RenderResult } from '@testing-library/react';
+import type { FaktaOmFeilutbetaling } from '~/generated-new';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import { FagsakContext } from '~/context/FagsakContext';
+import { behandlingFaktaQueryKey } from '~/generated-new/@tanstack/react-query.gen';
+import { Ytelsetype } from '~/kodeverk';
 import { Forhåndsvarsel } from '~/pages/fagsak/forhåndsvarsel/Forhåndsvarsel';
 import { useForhåndsvarselMutations } from '~/pages/fagsak/forhåndsvarsel/useForhåndsvarselMutations';
 import { useForhåndsvarselQueries } from '~/pages/fagsak/forhåndsvarsel/useForhåndsvarselQueries';
@@ -115,5 +118,85 @@ describe('ForhåndsvarselSkjema', () => {
             await screen.findByText('Har brukeren uttalt seg etter forhåndsvarselet ble sendt?')
         ).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Forhåndsvisning' })).not.toBeInTheDocument();
+    });
+});
+
+const lagFaktaOmFeilutbetaling = (vedtaksdato: string): FaktaOmFeilutbetaling =>
+    ({
+        feilutbetaling: {
+            beløp: 10000,
+            fom: '2025-01-01',
+            tom: '2025-06-30',
+            revurdering: {
+                årsak: 'Endring i inntekt',
+                vedtaksdato,
+                resultat: 'OPPHØRT',
+            },
+        },
+        tidligereVarsletBeløp: null,
+        muligeRettsligGrunnlag: [],
+        perioder: [],
+        vurdering: { årsak: null },
+        ferdigvurdert: false,
+    }) satisfies FaktaOmFeilutbetaling;
+
+const renderMedFaktaData = (ytelsestype: string, vedtaksdato: string): void => {
+    const behandling = lagBehandlingDto();
+    const queryClient = createTestQueryClient();
+
+    const queryKey = behandlingFaktaQueryKey({
+        path: { behandlingId: behandling.behandlingId },
+    });
+    queryClient.setQueryData(queryKey, lagFaktaOmFeilutbetaling(vedtaksdato));
+
+    render(
+        <FagsakContext value={lagFagsak({ ytelsestype: ytelsestype as never })}>
+            <TestBehandlingProvider behandling={behandling}>
+                <QueryClientProvider client={queryClient}>
+                    <Forhåndsvarsel />
+                </QueryClientProvider>
+            </TestBehandlingProvider>
+        </FagsakContext>
+    );
+
+    const fieldset = screen
+        .getByText('Skal det sendes forhåndsvarsel om tilbakekreving?')
+        .closest('fieldset');
+    if (!fieldset) throw new Error('Could not find fieldset');
+    const jaRadioButton = fieldset.querySelector('input[value="ja"]');
+    if (!jaRadioButton) throw new Error('Could not find "Ja" radio button');
+    fireEvent.click(jaRadioButton);
+};
+
+describe('Stønadstekst', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(useForhåndsvarselQueries).mockReturnValue(lagForhåndsvarselQueries());
+        vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
+    });
+
+    test('Initialiserer fritekst med stønadstekst basert på ytelsestype og vedtaksdato', async () => {
+        renderMedFaktaData(Ytelsetype.Barnetrygd, '2025-09-05');
+
+        const textarea = await screen.findByLabelText('Legg til utdypende tekst');
+        await waitFor(() => {
+            expect(textarea).toHaveValue(
+                'Barnetrygden din ble endret 5. september 2025, og endringen har ført til at du har fått utbetalt for mye.'
+            );
+        });
+    });
+
+    test('Overskriver ikke fritekst som brukeren har skrevet', async () => {
+        renderMedFaktaData(Ytelsetype.Barnetrygd, '2025-09-05');
+
+        const textarea = await screen.findByLabelText('Legg til utdypende tekst');
+        await waitFor(() => {
+            expect(textarea).toHaveValue(
+                'Barnetrygden din ble endret 5. september 2025, og endringen har ført til at du har fått utbetalt for mye.'
+            );
+        });
+
+        fireEvent.change(textarea, { target: { value: 'Egendefinert tekst' } });
+        expect(textarea).toHaveValue('Egendefinert tekst');
     });
 });

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -6,7 +6,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import { FagsakContext } from '~/context/FagsakContext';
 import { behandlingFaktaQueryKey } from '~/generated-new/@tanstack/react-query.gen';
-import { Ytelsetype } from '~/kodeverk';
 import { Forhåndsvarsel } from '~/pages/fagsak/forhåndsvarsel/Forhåndsvarsel';
 import { useForhåndsvarselMutations } from '~/pages/fagsak/forhåndsvarsel/useForhåndsvarselMutations';
 import { useForhåndsvarselQueries } from '~/pages/fagsak/forhåndsvarsel/useForhåndsvarselQueries';
@@ -140,7 +139,7 @@ const lagFaktaOmFeilutbetaling = (vedtaksdato: string): FaktaOmFeilutbetaling =>
         ferdigvurdert: false,
     }) satisfies FaktaOmFeilutbetaling;
 
-const renderMedFaktaData = (ytelsestype: string, vedtaksdato: string): void => {
+const renderMedFaktaData = (vedtaksdato: string): void => {
     const behandling = lagBehandlingDto();
     const queryClient = createTestQueryClient();
 
@@ -150,7 +149,7 @@ const renderMedFaktaData = (ytelsestype: string, vedtaksdato: string): void => {
     queryClient.setQueryData(queryKey, lagFaktaOmFeilutbetaling(vedtaksdato));
 
     render(
-        <FagsakContext value={lagFagsak({ ytelsestype: ytelsestype as never })}>
+        <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={queryClient}>
                     <Forhåndsvarsel />
@@ -176,7 +175,7 @@ describe('Stønadstekst', () => {
     });
 
     test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', async () => {
-        renderMedFaktaData(Ytelsetype.Barnetrygd, '2025-09-05');
+        renderMedFaktaData('2025-09-05');
 
         const textarea = await screen.findByLabelText('Legg til utdypende tekst');
         await waitFor(() => {
@@ -187,7 +186,7 @@ describe('Stønadstekst', () => {
     });
 
     test('Overskriver ikke fritekst som brukeren har skrevet', async () => {
-        renderMedFaktaData(Ytelsetype.Barnetrygd, '2025-09-05');
+        renderMedFaktaData('2025-09-05');
 
         const textarea = await screen.findByLabelText('Legg til utdypende tekst');
         await waitFor(() => {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -2,7 +2,7 @@ import type { RenderResult } from '@testing-library/react';
 import type { FaktaOmFeilutbetaling } from '~/generated-new';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import { FagsakContext } from '~/context/FagsakContext';
 import { behandlingFaktaQueryKey } from '~/generated-new/@tanstack/react-query.gen';
@@ -179,22 +179,18 @@ describe('Stønadstekst', () => {
     test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', async () => {
         const { getByRole } = renderMedFaktaData('2025-09-05');
 
-        await waitFor(() => {
-            expect(getByRole('textbox', { name: 'Legg til utdypende tekst' })).toHaveValue(
-                'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
-            );
-        });
+        expect(getByRole('textbox', { name: 'Legg til utdypende tekst' })).toHaveValue(
+            'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
+        );
     });
 
     test('Overskriver ikke fritekst som brukeren har skrevet', async () => {
         const { getByRole } = renderMedFaktaData('2025-09-05');
 
         const textarea = getByRole('textbox', { name: 'Legg til utdypende tekst' });
-        await waitFor(() => {
-            expect(textarea).toHaveValue(
-                'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
-            );
-        });
+        expect(textarea).toHaveValue(
+            'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
+        );
 
         fireEvent.change(textarea, { target: { value: 'Egendefinert tekst' } });
         expect(textarea).toHaveValue('Egendefinert tekst');

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -139,7 +139,7 @@ const lagFaktaOmFeilutbetaling = (vedtaksdato: string): FaktaOmFeilutbetaling =>
         ferdigvurdert: false,
     }) satisfies FaktaOmFeilutbetaling;
 
-const renderMedFaktaData = (vedtaksdato: string): void => {
+const renderMedFaktaData = (vedtaksdato: string): RenderResult => {
     const behandling = lagBehandlingDto();
     const queryClient = createTestQueryClient();
 
@@ -148,7 +148,7 @@ const renderMedFaktaData = (vedtaksdato: string): void => {
     });
     queryClient.setQueryData(queryKey, lagFaktaOmFeilutbetaling(vedtaksdato));
 
-    render(
+    const renderForhåndsvarsel = render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={queryClient}>
@@ -165,6 +165,8 @@ const renderMedFaktaData = (vedtaksdato: string): void => {
     const jaRadioButton = fieldset.querySelector('input[value="ja"]');
     if (!jaRadioButton) throw new Error('Could not find "Ja" radio button');
     fireEvent.click(jaRadioButton);
+
+    return renderForhåndsvarsel;
 };
 
 describe('Stønadstekst', () => {
@@ -175,20 +177,19 @@ describe('Stønadstekst', () => {
     });
 
     test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', async () => {
-        renderMedFaktaData('2025-09-05');
+        const { getByRole } = renderMedFaktaData('2025-09-05');
 
-        const textarea = await screen.findByLabelText('Legg til utdypende tekst');
         await waitFor(() => {
-            expect(textarea).toHaveValue(
+            expect(getByRole('textbox', { name: 'Legg til utdypende tekst' })).toHaveValue(
                 'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
             );
         });
     });
 
     test('Overskriver ikke fritekst som brukeren har skrevet', async () => {
-        renderMedFaktaData('2025-09-05');
+        const { getByRole } = renderMedFaktaData('2025-09-05');
 
-        const textarea = await screen.findByLabelText('Legg til utdypende tekst');
+        const textarea = getByRole('textbox', { name: 'Legg til utdypende tekst' });
         await waitFor(() => {
             expect(textarea).toHaveValue(
                 'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -175,13 +175,13 @@ describe('Stønadstekst', () => {
         vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
     });
 
-    test('Initialiserer fritekst med stønadstekst basert på ytelsestype og vedtaksdato', async () => {
+    test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', async () => {
         renderMedFaktaData(Ytelsetype.Barnetrygd, '2025-09-05');
 
         const textarea = await screen.findByLabelText('Legg til utdypende tekst');
         await waitFor(() => {
             expect(textarea).toHaveValue(
-                'Barnetrygden din ble endret 5. september 2025, og endringen har ført til at du har fått utbetalt for mye.'
+                'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
             );
         });
     });
@@ -192,7 +192,7 @@ describe('Stønadstekst', () => {
         const textarea = await screen.findByLabelText('Legg til utdypende tekst');
         await waitFor(() => {
             expect(textarea).toHaveValue(
-                'Barnetrygden din ble endret 5. september 2025, og endringen har ført til at du har fått utbetalt for mye.'
+                'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
             );
         });
 

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
@@ -11,19 +11,13 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 import { useBehandling } from '~/context/BehandlingContext';
 import { useBehandlingState } from '~/context/BehandlingStateContext';
-import { useFagsak } from '~/context/FagsakContext';
 import { behandlingFaktaOptions } from '~/generated-new/@tanstack/react-query.gen';
-import { type Ytelsetype, ytelsestypeTilBestemtEntall } from '~/kodeverk';
 import { SkalSendesForhåndsvarsel } from '~/pages/fagsak/forhåndsvarsel/schema';
 
 import { Unntak } from './UnntakSkjema';
 
-const lagStønadstekst = (
-    vedtaksdato: string | undefined,
-    ytelsestype: string
-): string | undefined => {
-    const ytelseNavn = ytelsestypeTilBestemtEntall[ytelsestype as Ytelsetype];
-    if (!vedtaksdato || !ytelseNavn) return undefined;
+const lagStønadstekst = (vedtaksdato: string | undefined): string | undefined => {
+    if (!vedtaksdato) return undefined;
 
     const formatertDato = parseISO(vedtaksdato).toLocaleDateString('no-NO', {
         day: 'numeric',
@@ -47,7 +41,6 @@ export const SkalSendeSkjema: FC<Props> = ({
     const maksAntallTegn = 4000;
     const { behandlingILesemodus } = useBehandlingState();
     const { behandlingId } = useBehandling();
-    const { ytelsestype } = useFagsak();
     const {
         control,
         register,
@@ -62,8 +55,7 @@ export const SkalSendeSkjema: FC<Props> = ({
     );
 
     const stønadstekst = lagStønadstekst(
-        faktaOmFeilutbetaling?.feilutbetaling.revurdering.vedtaksdato,
-        ytelsestype
+        faktaOmFeilutbetaling?.feilutbetaling.revurdering.vedtaksdato
     );
 
     useEffect(() => {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
@@ -4,10 +4,16 @@ import type { Section, Varselbrevtekst } from '~/generated';
 import type { ForhåndsvarselFormData } from '~/pages/fagsak/forhåndsvarsel/schema';
 
 import { BodyLong, Heading, Radio, RadioGroup, Textarea, VStack } from '@navikt/ds-react';
-import { Fragment } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { parseISO } from 'date-fns';
+import { Fragment, useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
+import { useBehandling } from '~/context/BehandlingContext';
 import { useBehandlingState } from '~/context/BehandlingStateContext';
+import { useFagsak } from '~/context/FagsakContext';
+import { behandlingFaktaOptions } from '~/generated-new/@tanstack/react-query.gen';
+import { type Ytelsetype, ytelsestypeTilBestemtEntall } from '~/kodeverk';
 import { SkalSendesForhåndsvarsel } from '~/pages/fagsak/forhåndsvarsel/schema';
 
 import { Unntak } from './UnntakSkjema';
@@ -25,12 +31,41 @@ export const SkalSendeSkjema: FC<Props> = ({
 }) => {
     const maksAntallTegn = 4000;
     const { behandlingILesemodus } = useBehandlingState();
+    const { behandlingId } = useBehandling();
+    const { ytelsestype } = useFagsak();
     const {
         control,
         register,
         handleSubmit,
+        setValue,
+        getValues,
         formState: { errors },
     } = useFormContext<ForhåndsvarselFormData>();
+
+    const { data: faktaOmFeilutbetaling } = useQuery(
+        behandlingFaktaOptions({ path: { behandlingId } })
+    );
+
+    const lagStønadstekst = (): string | undefined => {
+        const vedtaksdato = faktaOmFeilutbetaling?.feilutbetaling.revurdering.vedtaksdato;
+        const ytelseNavn = ytelsestypeTilBestemtEntall[ytelsestype as Ytelsetype];
+        if (!vedtaksdato || !ytelseNavn) return undefined;
+
+        const formatertDato = parseISO(vedtaksdato).toLocaleDateString('no-NO', {
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+        });
+        return `${ytelseNavn.charAt(0).toUpperCase()}${ytelseNavn.slice(1)} din ble endret ${formatertDato}, og endringen har ført til at du har fått utbetalt for mye.`;
+    };
+
+    const stønadstekst = lagStønadstekst();
+
+    useEffect(() => {
+        if (stønadstekst && !getValues('fritekst')) {
+            setValue('fritekst', stønadstekst);
+        }
+    }, [stønadstekst, setValue, getValues]);
 
     const fieldError: FieldErrors<
         Extract<ForhåndsvarselFormData, { skalSendesForhåndsvarsel: SkalSendesForhåndsvarsel.Ja }>
@@ -82,23 +117,30 @@ export const SkalSendeSkjema: FC<Props> = ({
                         {varselbrevtekster.avsnitter.map((avsnitt: Section) => (
                             <Fragment key={avsnitt.title}>
                                 {/* I første element er tittel er tom */}
-                                {avsnitt.title && (
+                                {avsnitt.title && avsnitt.title !== 'Dette har skjedd' && (
                                     <Heading level="4" size="xsmall">
                                         {avsnitt.title}
                                     </Heading>
                                 )}
-                                <BodyLong size="small">{avsnitt.body}</BodyLong>
+                                {avsnitt.title !== 'Dette har skjedd' && (
+                                    <BodyLong size="small">{avsnitt.body}</BodyLong>
+                                )}
                                 {avsnitt.title === 'Dette har skjedd' && (
-                                    <Textarea
-                                        {...register('fritekst')}
-                                        size="small"
-                                        minRows={3}
-                                        label="Legg til utdypende tekst"
-                                        maxLength={maksAntallTegn}
-                                        error={fieldError.fritekst?.message}
-                                        readOnly={varselErSendt}
-                                        resize
-                                    />
+                                    <VStack gap="space-16">
+                                        <Heading level="4" size="xsmall">
+                                            {avsnitt.title}
+                                        </Heading>
+                                        <Textarea
+                                            {...register('fritekst')}
+                                            size="small"
+                                            minRows={3}
+                                            label="Legg til utdypende tekst"
+                                            maxLength={maksAntallTegn}
+                                            error={fieldError.fritekst?.message}
+                                            readOnly={varselErSendt}
+                                            resize
+                                        />
+                                    </VStack>
                                 )}
                             </Fragment>
                         ))}

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
@@ -30,7 +30,7 @@ const lagStønadstekst = (
         month: 'long',
         year: 'numeric',
     });
-    return `${ytelseNavn.charAt(0).toUpperCase()}${ytelseNavn.slice(1)} din ble endret ${formatertDato}, og endringen har ført til at du har fått utbetalt for mye.`;
+    return `Det er gjort en endring i saken din ${formatertDato}. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.`;
 };
 
 type Props = {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/skjema/SkalSendeSkjema.tsx
@@ -5,7 +5,6 @@ import type { ForhåndsvarselFormData } from '~/pages/fagsak/forhåndsvarsel/sch
 
 import { BodyLong, Heading, Radio, RadioGroup, Textarea, VStack } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
-import { parseISO } from 'date-fns';
 import { Fragment, useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
@@ -13,17 +12,14 @@ import { useBehandling } from '~/context/BehandlingContext';
 import { useBehandlingState } from '~/context/BehandlingStateContext';
 import { behandlingFaktaOptions } from '~/generated-new/@tanstack/react-query.gen';
 import { SkalSendesForhåndsvarsel } from '~/pages/fagsak/forhåndsvarsel/schema';
+import { formatterDatostringLangt } from '~/utils/dateUtils';
 
 import { Unntak } from './UnntakSkjema';
 
 const lagStønadstekst = (vedtaksdato: string | undefined): string | undefined => {
     if (!vedtaksdato) return undefined;
 
-    const formatertDato = parseISO(vedtaksdato).toLocaleDateString('no-NO', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-    });
+    const formatertDato = formatterDatostringLangt(vedtaksdato);
     return `Det er gjort en endring i saken din ${formatertDato}. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.`;
 };
 
@@ -113,16 +109,7 @@ export const SkalSendeSkjema: FC<Props> = ({
                         </Heading>
                         {varselbrevtekster.avsnitter.map((avsnitt: Section) => (
                             <Fragment key={avsnitt.title}>
-                                {/* I første element er tittel er tom */}
-                                {avsnitt.title && avsnitt.title !== 'Dette har skjedd' && (
-                                    <Heading level="4" size="xsmall">
-                                        {avsnitt.title}
-                                    </Heading>
-                                )}
-                                {avsnitt.title !== 'Dette har skjedd' && (
-                                    <BodyLong size="small">{avsnitt.body}</BodyLong>
-                                )}
-                                {avsnitt.title === 'Dette har skjedd' && (
+                                {avsnitt.title === 'Dette har skjedd' ? (
                                     <VStack gap="space-16">
                                         <Heading level="4" size="xsmall">
                                             {avsnitt.title}
@@ -138,6 +125,15 @@ export const SkalSendeSkjema: FC<Props> = ({
                                             resize
                                         />
                                     </VStack>
+                                ) : (
+                                    <>
+                                        {avsnitt.title && (
+                                            <Heading level="4" size="xsmall">
+                                                {avsnitt.title}
+                                            </Heading>
+                                        )}
+                                        <BodyLong size="small">{avsnitt.body}</BodyLong>
+                                    </>
                                 )}
                             </Fragment>
                         ))}

--- a/src/frontend/utils/dateUtils.ts
+++ b/src/frontend/utils/dateUtils.ts
@@ -44,6 +44,11 @@ export const formatterDatostring = (datoAsString: string): string => {
     return dato.toLocaleDateString('no-NO', datoformat);
 };
 
+export const formatterDatostringLangt = (datoAsString: string): string => {
+    const dato = parseISO(datoAsString);
+    return dato.toLocaleDateString('no-NO', { day: 'numeric', month: 'long', year: 'numeric' });
+};
+
 export const formatterDatoOgTidstring = (datoAsString: string): string => {
     const dato = parseISO(datoAsString);
     return `${dato.toLocaleDateString('no-NO', {


### PR DESCRIPTION
<img width="3433" height="1210" alt="Skjermbilde 2026-05-06 kl  15 23 26" src="https://github.com/user-attachments/assets/e81febee-07e2-40da-a493-ea4041d5e7fb" />
