### PR TITLE
Fjernet waitFor og bruker screen i alle tester

### DIFF
--- a/.github/instructions/testing-typescript.instructions.md
+++ b/.github/instructions/testing-typescript.instructions.md
@@ -10,7 +10,7 @@ TypeScript-spesifikke testmønstre for Nav: Vitest, mocking, async og React-komp
 - Unngå mocking så langt det lar seg gjøre. La det være mulig å sende ned ekte data og funksjoner for mer realistiske tester.
 - Lag variabler og funksjoner i testene for å unngå duplisering og gjøre det enklere å endre testdata.
 - bruk rolle i stedet for å lete etter tekst når du tester interaksjoner på knapper, lenker og andre elementer som kan ha varierende tekst. For underelementer, bruk within og getByRole på det spesifikke elementet.
-- Unngå waitFor så langt det lar seg gjøre. 
+- Unngå waitFor så langt det lar seg gjøre. Bruk heller findBy* for å vente på elementer i DOM-en. waitFor kan føre til unødvendige forsinkelser og gjøre testene mindre pålitelige.
 
 ## Test Structure
 

--- a/.github/instructions/testing-typescript.instructions.md
+++ b/.github/instructions/testing-typescript.instructions.md
@@ -11,6 +11,7 @@ TypeScript-spesifikke testmønstre for Nav: Vitest, mocking, async og React-komp
 - Lag variabler og funksjoner i testene for å unngå duplisering og gjøre det enklere å endre testdata.
 - bruk rolle i stedet for å lete etter tekst når du tester interaksjoner på knapper, lenker og andre elementer som kan ha varierende tekst. For underelementer, bruk within og getByRole på det spesifikke elementet.
 - Unngå waitFor så langt det lar seg gjøre. Bruk heller findBy* for asynkrone tester. waitFor kan føre til unødvendige forsinkelser og gjøre testene mindre pålitelige.
+- Bruk alltid screen for å få tilgang til elementer i DOM-en. Unngå å returnere render-resultatet og bruke destructuring for å få tilgang til getBy* og findBy*-funksjonene, da dette kan føre til forvirring og mindre lesbare tester.
 
 ## Test Structure
 

--- a/.github/instructions/testing-typescript.instructions.md
+++ b/.github/instructions/testing-typescript.instructions.md
@@ -10,7 +10,7 @@ TypeScript-spesifikke testmønstre for Nav: Vitest, mocking, async og React-komp
 - Unngå mocking så langt det lar seg gjøre. La det være mulig å sende ned ekte data og funksjoner for mer realistiske tester.
 - Lag variabler og funksjoner i testene for å unngå duplisering og gjøre det enklere å endre testdata.
 - bruk rolle i stedet for å lete etter tekst når du tester interaksjoner på knapper, lenker og andre elementer som kan ha varierende tekst. For underelementer, bruk within og getByRole på det spesifikke elementet.
-- Unngå waitFor så langt det lar seg gjøre. Bruk heller findBy* for å vente på elementer i DOM-en. waitFor kan føre til unødvendige forsinkelser og gjøre testene mindre pålitelige.
+- Unngå waitFor så langt det lar seg gjøre. Bruk heller findBy* for asynkrone tester. waitFor kan føre til unødvendige forsinkelser og gjøre testene mindre pålitelige.
 
 ## Test Structure
 

--- a/src/frontend/komponenter/action-bar/ActionBar.test.tsx
+++ b/src/frontend/komponenter/action-bar/ActionBar.test.tsx
@@ -1,5 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
-
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -12,8 +10,8 @@ const renderActionBar = (
     onForrige: () => void,
     onNeste: () => void,
     isLoading: boolean = false
-): RenderResult => {
-    return render(
+): void => {
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider>
                 <ActionBar

--- a/src/frontend/komponenter/header/Header.test.tsx
+++ b/src/frontend/komponenter/header/Header.test.tsx
@@ -1,5 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
-
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -16,9 +14,9 @@ import { Header } from './Header';
 const mockHentBrukerlenkeBaseUrl = vi.mocked(hentBrukerlenkeBaseUrl);
 const mockHentAInntektUrl = vi.mocked(hentAInntektUrl);
 
-const renderHeader = (): RenderResult => {
+const renderHeader = (): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <Header />
         </QueryClientProvider>

--- a/src/frontend/komponenter/header/Header.test.tsx
+++ b/src/frontend/komponenter/header/Header.test.tsx
@@ -103,7 +103,7 @@ describe('Header', () => {
         expect(modiaLenke).toHaveAttribute('href', 'https://modia.nav.no');
     });
 
-    test('Viser ingen menyknapp når ingen gyldige lenker eksisterer', async () => {
+    test('Viser ingen menyknapp når ingen gyldige lenker eksisterer', () => {
         mockHentBrukerlenkeBaseUrl.mockResolvedValue({
             aInntektUrl: '',
             gosysBaseUrl: '',

--- a/src/frontend/komponenter/header/Header.test.tsx
+++ b/src/frontend/komponenter/header/Header.test.tsx
@@ -55,9 +55,7 @@ describe('Header', () => {
         renderHeader();
 
         expect(await screen.findByText('Modia')).toBeInTheDocument();
-
-        const modiaPersonoversiktLenkeTekst = screen.queryByText('Modia personoversikt');
-        expect(modiaPersonoversiktLenkeTekst).not.toBeInTheDocument();
+        expect(screen.queryByText('Modia personoversikt')).not.toBeInTheDocument();
     });
 
     test('Har riktig lenke til A-inntekt, Gosys og Modia når personIdent er satt', async () => {
@@ -114,9 +112,10 @@ describe('Header', () => {
 
         renderHeader();
 
-        const menyknapp = screen.queryByRole('button', {
-            name: 'Systemer og oppslagsverk',
-        });
-        expect(menyknapp).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', {
+                name: 'Systemer og oppslagsverk',
+            })
+        ).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/header/Header.test.tsx
+++ b/src/frontend/komponenter/header/Header.test.tsx
@@ -1,7 +1,7 @@
 import type { RenderResult } from '@testing-library/react';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('~/api/brukerlenker');
@@ -50,16 +50,13 @@ describe('Header', () => {
 
     test('hentBrukerlenkeBaseUrl blir kalt én gang ved rendering', () => {
         renderHeader();
-
         expect(mockHentBrukerlenkeBaseUrl).toHaveBeenCalledTimes(1);
     });
 
     test('Viser riktig titler når ingen personIdent er satt', async () => {
         renderHeader();
 
-        await waitFor(() => {
-            expect(screen.getByText('Modia')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Modia')).toBeInTheDocument();
 
         const modiaPersonoversiktLenkeTekst = screen.queryByText('Modia personoversikt');
         expect(modiaPersonoversiktLenkeTekst).not.toBeInTheDocument();
@@ -75,20 +72,14 @@ describe('Header', () => {
         });
         renderHeader();
 
-        await waitFor(() => {
-            expect(mockHentAInntektUrl).toHaveBeenCalled();
-        });
+        expect(mockHentAInntektUrl).toHaveBeenCalled();
 
-        await waitFor(() => {
-            expect(screen.getByTitle('Systemer og oppslagsverk')).toBeInTheDocument();
-        });
-
-        const menyknapp = screen.getByTitle('Systemer og oppslagsverk');
+        const menyknapp = await screen.findByRole('button', { name: 'Systemer og oppslagsverk' });
         await userEvent.click(menyknapp);
 
-        const aInntektLenke = screen.getByText('A-inntekt personoversikt').closest('a');
-        const gosysLenke = screen.getByText('Gosys personoversikt').closest('a');
-        const modiaLenke = screen.getByText('Modia personoversikt').closest('a');
+        const aInntektLenke = screen.getByRole('link', { name: 'A-inntekt personoversikt' });
+        const gosysLenke = screen.getByRole('link', { name: 'Gosys personoversikt' });
+        const modiaLenke = screen.getByRole('link', { name: 'Modia personoversikt' });
 
         expect(aInntektLenke).toHaveAttribute(
             'href',
@@ -104,16 +95,12 @@ describe('Header', () => {
     test('Gir kun baseUrl når personIdent ikke er satt', async () => {
         renderHeader();
 
-        await waitFor(() => {
-            expect(screen.getByTitle('Systemer og oppslagsverk')).toBeInTheDocument();
-        });
-
-        const menyknapp = screen.getByTitle('Systemer og oppslagsverk');
+        const menyknapp = await screen.findByRole('button', { name: 'Systemer og oppslagsverk' });
         await userEvent.click(menyknapp);
 
-        const aInntektLenke = screen.getByText('A-inntekt').closest('a');
-        const gosysLenke = screen.getByText('Gosys').closest('a');
-        const modiaLenke = screen.getByText('Modia').closest('a');
+        const aInntektLenke = screen.getByRole('link', { name: 'A-inntekt' });
+        const gosysLenke = screen.getByRole('link', { name: 'Gosys' });
+        const modiaLenke = screen.getByRole('link', { name: 'Modia' });
 
         expect(aInntektLenke).toHaveAttribute('href', 'https://a-inntekt.nav.no');
         expect(gosysLenke).toHaveAttribute('href', 'https://gosys.nav.no');
@@ -129,9 +116,9 @@ describe('Header', () => {
 
         renderHeader();
 
-        await waitFor(() => {
-            const menyknapp = screen.queryByTitle('Systemer og oppslagsverk');
-            expect(menyknapp).not.toBeInTheDocument();
+        const menyknapp = screen.queryByRole('button', {
+            name: 'Systemer og oppslagsverk',
         });
+        expect(menyknapp).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/landvelger/Landvelger.test.tsx
+++ b/src/frontend/komponenter/landvelger/Landvelger.test.tsx
@@ -39,7 +39,7 @@ describe('Landvelger', () => {
         const combobox = screen.getByRole('combobox');
         await user.click(combobox);
 
-        const danmarkValg = await screen.findByText('Danmark');
+        const danmarkValg = screen.getByText('Danmark');
         expect(danmarkValg).toBeInTheDocument();
 
         expect(screen.queryByText('Sverige')).not.toBeInTheDocument();

--- a/src/frontend/komponenter/meny/henlegg/henleggModal/HenleggModal.test.tsx
+++ b/src/frontend/komponenter/meny/henlegg/henleggModal/HenleggModal.test.tsx
@@ -6,7 +6,7 @@ import type { BehandlingDto, BehandlingsresultatstypeEnum } from '~/generated';
 import type { Ressurs } from '~/typer/ressurs';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -56,6 +56,10 @@ const setupMocks = (): void => {
     }));
 };
 
+const henleggKnapp = (): HTMLElement => screen.getByRole('button', { name: 'Henlegg' });
+const henleggTittel = (): HTMLElement =>
+    screen.getByRole('heading', { name: 'Henlegg tilbakekrevingen', level: 1 });
+
 describe('HenleggModal', () => {
     let user: UserEvent;
     beforeEach(() => {
@@ -65,86 +69,52 @@ describe('HenleggModal', () => {
     });
 
     test('Henlegger behandling med varsel sendt', async () => {
-        const { getByLabelText, getByRole, queryByText, queryAllByText } = renderHenleggModal(
+        const { getByLabelText, queryByText, queryAllByText } = renderHenleggModal(
             lagBehandling({ varselSendt: true }),
             ['HENLAGT_FEILOPPRETTET']
         );
 
-        await waitFor(() => {
-            expect(
-                getByRole('heading', { name: 'Henlegg tilbakekrevingen', level: 1 })
-            ).toBeInTheDocument();
-        });
+        expect(henleggTittel()).toBeInTheDocument();
 
         expect(queryByText('Informer søker:')).toBeInTheDocument();
         expect(queryByText('Forhåndsvis brev')).toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.type(getByLabelText('Begrunnelse'), 'Feilutbetalingen er mottregnet');
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
     });
 
     test('Henlegger behandling med varsel ikke sendt', async () => {
-        const { getByLabelText, getByRole, queryByText, queryAllByText } = renderHenleggModal(
+        const { getByLabelText, queryByText, queryAllByText } = renderHenleggModal(
             lagBehandling(),
             ['HENLAGT_FEILOPPRETTET']
         );
 
-        await waitFor(() => {
-            expect(
-                getByRole('heading', { name: 'Henlegg tilbakekrevingen', level: 1 })
-            ).toBeInTheDocument();
-        });
+        expect(henleggTittel()).toBeInTheDocument();
 
         expect(queryByText('Informer søker:')).not.toBeInTheDocument();
         expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.type(getByLabelText('Begrunnelse'), 'Feilutbetalingen er mottregnet');
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
     });
 
     test('Henlegger revurdering, med brev', async () => {
-        const { getByText, getByLabelText, getByRole, queryByText, queryAllByText } =
+        const { getByRole, getByText, getByLabelText, queryByRole, queryByText, queryAllByText } =
             renderHenleggModal(lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }), [
                 'HENLAGT_FEILOPPRETTET_MED_BREV',
                 'HENLAGT_FEILOPPRETTET_UTEN_BREV',
             ]);
 
-        await waitFor(() => {
-            expect(
-                getByRole('heading', { name: 'Henlegg tilbakekrevingen', level: 1 })
-            ).toBeInTheDocument();
-        });
-
         expect(queryByText('Informer søker:')).not.toBeInTheDocument();
-        expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
+        expect(queryByRole('link', { name: 'Forhåndsvis brev' })).not.toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
@@ -153,15 +123,8 @@ describe('HenleggModal', () => {
         );
         await user.type(getByLabelText('Begrunnelse'), 'Revurdering er feilopprettet');
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
-
-        expect(queryByText('Informer søker:')).not.toBeInTheDocument();
-        expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
 
         await user.type(
             getByRole('textbox', { name: 'Fritekst til brev' }),
@@ -169,36 +132,23 @@ describe('HenleggModal', () => {
         );
 
         expect(getByText('Informer søker:')).toBeInTheDocument();
-        expect(getByText('Forhåndsvis brev')).toBeInTheDocument();
+        expect(getByRole('link', { name: 'Forhåndsvis brev' })).toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
     });
 
     test('Henlegger revurdering, uten brev', async () => {
-        const { getByLabelText, getByRole, queryByText, queryByRole, queryAllByText } =
-            renderHenleggModal(lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }), [
-                'HENLAGT_FEILOPPRETTET_MED_BREV',
-                'HENLAGT_FEILOPPRETTET_UTEN_BREV',
-            ]);
+        const { getByLabelText, queryByText, queryByRole, queryAllByText } = renderHenleggModal(
+            lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }),
+            ['HENLAGT_FEILOPPRETTET_MED_BREV', 'HENLAGT_FEILOPPRETTET_UTEN_BREV']
+        );
 
-        await waitFor(() => {
-            expect(
-                getByRole('heading', { name: 'Henlegg tilbakekrevingen', level: 1 })
-            ).toBeInTheDocument();
-        });
+        expect(henleggTittel()).toBeInTheDocument();
 
         expect(queryByText('Informer søker:')).not.toBeInTheDocument();
         expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
@@ -211,10 +161,6 @@ describe('HenleggModal', () => {
         expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
         expect(queryByRole('textbox', { name: 'Fritekst til brev' })).not.toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Henlegg',
-            })
-        );
+        await user.click(henleggKnapp());
     });
 });

--- a/src/frontend/komponenter/meny/henlegg/henleggModal/HenleggModal.test.tsx
+++ b/src/frontend/komponenter/meny/henlegg/henleggModal/HenleggModal.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { RefObject } from 'react';
 import type { BehandlingApiHook } from '~/api/behandling';
@@ -27,10 +26,10 @@ vi.mock('~/api/behandling', () => ({
 const renderHenleggModal = (
     behandling: BehandlingDto,
     årsaker: BehandlingsresultatstypeEnum[]
-): RenderResult => {
+): void => {
     const queryClient = createTestQueryClient();
     const mockDialogRef: RefObject<HTMLDialogElement | null> = { current: null };
-    const renderModal = render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider behandling={behandling}>
@@ -40,8 +39,6 @@ const renderHenleggModal = (
         </QueryClientProvider>
     );
     mockDialogRef.current?.showModal();
-
-    return renderModal;
 };
 
 const setupMocks = (): void => {
@@ -69,97 +66,92 @@ describe('HenleggModal', () => {
     });
 
     test('Henlegger behandling med varsel sendt', async () => {
-        const { getByLabelText, queryByText, queryAllByText } = renderHenleggModal(
-            lagBehandling({ varselSendt: true }),
-            ['HENLAGT_FEILOPPRETTET']
-        );
+        renderHenleggModal(lagBehandling({ varselSendt: true }), ['HENLAGT_FEILOPPRETTET']);
 
         expect(henleggTittel()).toBeInTheDocument();
 
-        expect(queryByText('Informer søker:')).toBeInTheDocument();
-        expect(queryByText('Forhåndsvis brev')).toBeInTheDocument();
+        expect(screen.getByText('Informer søker:')).toBeInTheDocument();
+        expect(screen.getByText('Forhåndsvis brev')).toBeInTheDocument();
 
         await user.click(henleggKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
-        await user.type(getByLabelText('Begrunnelse'), 'Feilutbetalingen er mottregnet');
+        await user.type(screen.getByLabelText('Begrunnelse'), 'Feilutbetalingen er mottregnet');
         await user.click(henleggKnapp());
     });
 
     test('Henlegger behandling med varsel ikke sendt', async () => {
-        const { getByLabelText, queryByText, queryAllByText } = renderHenleggModal(
-            lagBehandling(),
-            ['HENLAGT_FEILOPPRETTET']
-        );
+        renderHenleggModal(lagBehandling(), ['HENLAGT_FEILOPPRETTET']);
 
         expect(henleggTittel()).toBeInTheDocument();
 
-        expect(queryByText('Informer søker:')).not.toBeInTheDocument();
-        expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
+        expect(screen.queryByText('Informer søker:')).not.toBeInTheDocument();
+        expect(screen.queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
 
         await user.click(henleggKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
-        await user.type(getByLabelText('Begrunnelse'), 'Feilutbetalingen er mottregnet');
+        await user.type(screen.getByLabelText('Begrunnelse'), 'Feilutbetalingen er mottregnet');
         await user.click(henleggKnapp());
     });
 
     test('Henlegger revurdering, med brev', async () => {
-        const { getByRole, getByText, getByLabelText, queryByRole, queryByText, queryAllByText } =
-            renderHenleggModal(lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }), [
-                'HENLAGT_FEILOPPRETTET_MED_BREV',
-                'HENLAGT_FEILOPPRETTET_UTEN_BREV',
-            ]);
+        renderHenleggModal(lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }), [
+            'HENLAGT_FEILOPPRETTET_MED_BREV',
+            'HENLAGT_FEILOPPRETTET_UTEN_BREV',
+        ]);
 
-        expect(queryByText('Informer søker:')).not.toBeInTheDocument();
-        expect(queryByRole('link', { name: 'Forhåndsvis brev' })).not.toBeInTheDocument();
+        expect(screen.queryByText('Informer søker:')).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Forhåndsvis brev' })).not.toBeInTheDocument();
 
         await user.click(henleggKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
-            getByLabelText('Årsak til henleggelse'),
+            screen.getByLabelText('Årsak til henleggelse'),
             'HENLAGT_FEILOPPRETTET_MED_BREV'
         );
-        await user.type(getByLabelText('Begrunnelse'), 'Revurdering er feilopprettet');
+        await user.type(screen.getByLabelText('Begrunnelse'), 'Revurdering er feilopprettet');
 
         await user.click(henleggKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.type(
-            getByRole('textbox', { name: 'Fritekst til brev' }),
+            screen.getByRole('textbox', { name: 'Fritekst til brev' }),
             'Revurdering er feilopprettet'
         );
 
-        expect(getByText('Informer søker:')).toBeInTheDocument();
-        expect(getByRole('link', { name: 'Forhåndsvis brev' })).toBeInTheDocument();
+        expect(screen.getByText('Informer søker:')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Forhåndsvis brev' })).toBeInTheDocument();
 
         await user.click(henleggKnapp());
     });
 
     test('Henlegger revurdering, uten brev', async () => {
-        const { getByLabelText, queryByText, queryByRole, queryAllByText } = renderHenleggModal(
-            lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }),
-            ['HENLAGT_FEILOPPRETTET_MED_BREV', 'HENLAGT_FEILOPPRETTET_UTEN_BREV']
-        );
+        renderHenleggModal(lagBehandling({ type: 'REVURDERING_TILBAKEKREVING' }), [
+            'HENLAGT_FEILOPPRETTET_MED_BREV',
+            'HENLAGT_FEILOPPRETTET_UTEN_BREV',
+        ]);
 
         expect(henleggTittel()).toBeInTheDocument();
 
-        expect(queryByText('Informer søker:')).not.toBeInTheDocument();
-        expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
+        expect(screen.queryByText('Informer søker:')).not.toBeInTheDocument();
+        expect(screen.queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
 
         await user.click(henleggKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
-            getByLabelText('Årsak til henleggelse'),
+            screen.getByLabelText('Årsak til henleggelse'),
             'HENLAGT_FEILOPPRETTET_UTEN_BREV'
         );
-        await user.type(getByLabelText('Begrunnelse'), 'Revurdering er feilopprettet');
+        await user.type(screen.getByLabelText('Begrunnelse'), 'Revurdering er feilopprettet');
 
-        expect(queryByText('Informer søker:')).not.toBeInTheDocument();
-        expect(queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
-        expect(queryByRole('textbox', { name: 'Fritekst til brev' })).not.toBeInTheDocument();
+        expect(screen.queryByText('Informer søker:')).not.toBeInTheDocument();
+        expect(screen.queryByText('Forhåndsvis brev')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('textbox', { name: 'Fritekst til brev' })
+        ).not.toBeInTheDocument();
 
         await user.click(henleggKnapp());
     });

--- a/src/frontend/komponenter/meny/start-på-nytt/StartPåNytt.test.tsx
+++ b/src/frontend/komponenter/meny/start-på-nytt/StartPåNytt.test.tsx
@@ -2,7 +2,7 @@ import type { StartPåNyttHook } from './useStartPåNytt';
 
 import { ActionMenu, Button } from '@navikt/ds-react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -68,9 +68,7 @@ describe('StartPåNytt', () => {
 
         expect(mockMutate).toHaveBeenCalledTimes(1);
 
-        await waitFor(() => {
-            const errorText = screen.getByText(/403 Forbidden/i);
-            expect(errorText).toBeInTheDocument();
-        });
+        const errorText = screen.getByText(/403 Forbidden/i);
+        expect(errorText).toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/modal/feil/FeilModal.test.tsx
+++ b/src/frontend/komponenter/modal/feil/FeilModal.test.tsx
@@ -168,8 +168,8 @@ describe('FeilModal', () => {
 
         renderFeilModal(mockFeil);
 
-        expect(screen.queryByText(/Fagsak ID:/)).toBeInTheDocument();
-        expect(screen.queryByText(/Behandling ID:/)).toBeInTheDocument();
+        expect(screen.getByText(/Fagsak ID:/)).toBeInTheDocument();
+        expect(screen.getByText(/Behandling ID:/)).toBeInTheDocument();
     });
 
     test('Kaller på setVisFeilModal når lukkeknappen klikkes', () => {

--- a/src/frontend/komponenter/modal/feil/FeilModal.test.tsx
+++ b/src/frontend/komponenter/modal/feil/FeilModal.test.tsx
@@ -1,5 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
-
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import { Feil } from '~/api/feil';
@@ -16,9 +14,9 @@ const renderFeilModal = (
     feil: Feil,
     behandlingId?: string,
     fagsakOverride?: ReturnType<typeof lagFagsak>
-): RenderResult => {
+): void => {
     const behandling = behandlingId ? lagBehandling({ behandlingId }) : lagBehandling();
-    return render(
+    render(
         <FagsakContext value={fagsakOverride ?? lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <FeilModal feil={feil} lukkFeilModal={mockSetVisFeilModal} />

--- a/src/frontend/komponenter/periodeinformasjon/PeriodeOppsummering.test.tsx
+++ b/src/frontend/komponenter/periodeinformasjon/PeriodeOppsummering.test.tsx
@@ -1,6 +1,6 @@
 import type { RenderResult } from '@testing-library/react';
 
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import { HendelseType } from '~/kodeverk';
 
@@ -29,9 +29,8 @@ describe('PeriodeOppsummering', () => {
             333,
             HendelseType.Annet
         );
-        await waitFor(() => {
-            expect(getByText('01.01.2021–30.04.2021')).toBeInTheDocument();
-        });
+
+        expect(getByText('01.01.2021–30.04.2021')).toBeInTheDocument();
         expect(getByText('4 måneder')).toBeInTheDocument();
         expect(getByText('333')).toBeInTheDocument();
         expect(getByText('Rettslig grunnlag: Annet')).toBeInTheDocument();

--- a/src/frontend/komponenter/periodeinformasjon/PeriodeOppsummering.test.tsx
+++ b/src/frontend/komponenter/periodeinformasjon/PeriodeOppsummering.test.tsx
@@ -1,6 +1,4 @@
-import type { RenderResult } from '@testing-library/react';
-
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { HendelseType } from '~/kodeverk';
 
@@ -11,56 +9,52 @@ const renderPeriodeOppsummering = (
     tom: string,
     beløp: number,
     hendelsestype?: HendelseType
-): RenderResult =>
+): void => {
     render(<PeriodeOppsummering hendelsetype={hendelsestype} beløp={beløp} fom={fom} tom={tom} />);
+};
 
 describe('PeriodeOppsummering', () => {
     test('Uten hendelsetype og tester 5 måneder', () => {
-        const { getByText } = renderPeriodeOppsummering('2021-01-01', '2021-05-31', 3333);
-        expect(getByText('01.01.2021–31.05.2021')).toBeInTheDocument();
-        expect(getByText('5 måneder')).toBeInTheDocument();
-        expect(getByText('3 333')).toBeInTheDocument();
+        renderPeriodeOppsummering('2021-01-01', '2021-05-31', 3333);
+        expect(screen.getByText('01.01.2021–31.05.2021')).toBeInTheDocument();
+        expect(screen.getByText('5 måneder')).toBeInTheDocument();
+        expect(screen.getByText('3 333')).toBeInTheDocument();
     });
 
     test('Med hendelsetype og tester 4 måneder', async () => {
-        const { getByText } = renderPeriodeOppsummering(
-            '2021-01-01',
-            '2021-04-30',
-            333,
-            HendelseType.Annet
-        );
+        renderPeriodeOppsummering('2021-01-01', '2021-04-30', 333, HendelseType.Annet);
 
-        expect(getByText('01.01.2021–30.04.2021')).toBeInTheDocument();
-        expect(getByText('4 måneder')).toBeInTheDocument();
-        expect(getByText('333')).toBeInTheDocument();
-        expect(getByText('Rettslig grunnlag: Annet')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2021–30.04.2021')).toBeInTheDocument();
+        expect(screen.getByText('4 måneder')).toBeInTheDocument();
+        expect(screen.getByText('333')).toBeInTheDocument();
+        expect(screen.getByText('Rettslig grunnlag: Annet')).toBeInTheDocument();
     });
 
     test('Viser dager for perioder under én måned', () => {
-        const { getByText } = renderPeriodeOppsummering('2021-01-15', '2021-01-31', 3333);
+        renderPeriodeOppsummering('2021-01-15', '2021-01-31', 3333);
 
-        expect(getByText('15.01.2021–31.01.2021')).toBeInTheDocument();
-        expect(getByText('17 dager')).toBeInTheDocument();
+        expect(screen.getByText('15.01.2021–31.01.2021')).toBeInTheDocument();
+        expect(screen.getByText('17 dager')).toBeInTheDocument();
     });
 
     test('Viser måned og dag for perioder over én måned', () => {
-        const { getByText } = renderPeriodeOppsummering('2021-01-15', '2021-02-15', 3333);
+        renderPeriodeOppsummering('2021-01-15', '2021-02-15', 3333);
 
-        expect(getByText('15.01.2021–15.02.2021')).toBeInTheDocument();
-        expect(getByText('1 måned og 1 dag')).toBeInTheDocument();
+        expect(screen.getByText('15.01.2021–15.02.2021')).toBeInTheDocument();
+        expect(screen.getByText('1 måned og 1 dag')).toBeInTheDocument();
     });
 
     test('Viser måned og dager for perioder over én måned', () => {
-        const { getByText } = renderPeriodeOppsummering('2021-01-15', '2021-03-10', 3333);
+        renderPeriodeOppsummering('2021-01-15', '2021-03-10', 3333);
 
-        expect(getByText('15.01.2021–10.03.2021')).toBeInTheDocument();
-        expect(getByText('1 måned og 24 dager')).toBeInTheDocument();
+        expect(screen.getByText('15.01.2021–10.03.2021')).toBeInTheDocument();
+        expect(screen.getByText('1 måned og 24 dager')).toBeInTheDocument();
     });
 
     test('Viser måneder og dager for perioder over én måned', () => {
-        const { getByText } = renderPeriodeOppsummering('2021-01-15', '2021-04-10', 3333);
+        renderPeriodeOppsummering('2021-01-15', '2021-04-10', 3333);
 
-        expect(getByText('15.01.2021–10.04.2021')).toBeInTheDocument();
-        expect(getByText('2 måneder og 27 dager')).toBeInTheDocument();
+        expect(screen.getByText('15.01.2021–10.04.2021')).toBeInTheDocument();
+        expect(screen.getByText('2 måneder og 27 dager')).toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/periodeinformasjon/PeriodeOppsummering.test.tsx
+++ b/src/frontend/komponenter/periodeinformasjon/PeriodeOppsummering.test.tsx
@@ -21,7 +21,7 @@ describe('PeriodeOppsummering', () => {
         expect(screen.getByText('3 333')).toBeInTheDocument();
     });
 
-    test('Med hendelsetype og tester 4 måneder', async () => {
+    test('Med hendelsetype og tester 4 måneder', () => {
         renderPeriodeOppsummering('2021-01-01', '2021-04-30', 333, HendelseType.Annet);
 
         expect(screen.getByText('01.01.2021–30.04.2021')).toBeInTheDocument();

--- a/src/frontend/komponenter/sidebar/informasjonsbokser/BrukerInformasjon.test.tsx
+++ b/src/frontend/komponenter/sidebar/informasjonsbokser/BrukerInformasjon.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { InstitusjonDto } from '~/generated';
 import type { FrontendBrukerDto } from '~/generated';
 
@@ -36,8 +35,8 @@ const baseInstitusjon = (override: Partial<InstitusjonDto> = {}): InstitusjonDto
 const renderBrukerInformasjon = (
     bruker: Partial<FrontendBrukerDto> | null = null,
     institusjon: Partial<InstitusjonDto> | null = null
-): RenderResult => {
-    return render(
+): void => {
+    render(
         <FagsakContext
             value={lagFagsak({
                 bruker: bruker ? baseBruker(bruker) : baseBruker(),

--- a/src/frontend/komponenter/sidebar/informasjonsbokser/Faktaboks.test.tsx
+++ b/src/frontend/komponenter/sidebar/informasjonsbokser/Faktaboks.test.tsx
@@ -1,5 +1,4 @@
 import type { TagProps } from '@navikt/ds-react';
-import type { RenderResult } from '@testing-library/react';
 import type {
     BehandlingDto,
     BehandlingsresultatstypeEnum,
@@ -20,9 +19,9 @@ import { Faktaboks } from './Faktaboks';
 const renderFaktaboks = (
     delvisBehandling: Partial<BehandlingDto> = {},
     ytelsestypeOverride: Ytelsetype = Ytelsetype.Barnetrygd
-): RenderResult => {
+): void => {
     const behandling = lagBehandling(delvisBehandling);
-    return render(
+    render(
         <FagsakContext value={lagFagsak({ ytelsestype: ytelsestypeOverride })}>
             <TestBehandlingProvider behandling={behandling}>
                 <Faktaboks />

--- a/src/frontend/komponenter/sidebar/sendMelding/SendMelding.test.tsx
+++ b/src/frontend/komponenter/sidebar/sendMelding/SendMelding.test.tsx
@@ -4,7 +4,7 @@ import type { DokumentApiHook } from '~/api/dokument';
 import type { BehandlingDto, SpråkkodeEnum } from '~/generated';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -71,10 +71,7 @@ describe('SendMelding', () => {
         const { getByText, getByLabelText, getByRole, queryByRole, queryByText } =
             renderSendMelding(lagBehandling({ varselSendt: false }));
 
-        await waitFor(() => {
-            expect(getByText('Brevmottaker')).toBeInTheDocument();
-        });
-
+        expect(getByText('Brevmottaker')).toBeInTheDocument();
         expect(getByLabelText('Mal')).toHaveLength(3);
         expect(queryByText('Bokmål')).not.toBeInTheDocument();
 
@@ -128,10 +125,7 @@ describe('SendMelding', () => {
             'NN'
         );
 
-        await waitFor(() => {
-            expect(getByText('Brevmottaker')).toBeInTheDocument();
-        });
-
+        expect(getByText('Brevmottaker')).toBeInTheDocument();
         expect(getByLabelText('Mal')).toHaveLength(3);
         expect(queryByText('Nynorsk')).not.toBeInTheDocument();
 
@@ -166,9 +160,7 @@ describe('SendMelding', () => {
             lagBehandling({ varselSendt: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Brevmottaker')).toBeInTheDocument();
-        });
+        expect(getByText('Brevmottaker')).toBeInTheDocument();
         expect(
             getByRole('button', {
                 name: 'Send brev',

--- a/src/frontend/komponenter/sidebar/sendMelding/SendMelding.test.tsx
+++ b/src/frontend/komponenter/sidebar/sendMelding/SendMelding.test.tsx
@@ -1,10 +1,9 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { DokumentApiHook } from '~/api/dokument';
 import type { BehandlingDto, SpråkkodeEnum } from '~/generated';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -27,9 +26,9 @@ const renderSendMelding = (
     behandling: BehandlingDto,
     språkkode: SpråkkodeEnum = 'NB',
     behandlingILesemodus: boolean = false
-): RenderResult => {
+): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak({ språkkode })}>
                 <TestBehandlingProvider
@@ -68,50 +67,49 @@ describe('SendMelding', () => {
     test('Fyller ut skjema og sender varsel', async () => {
         setupMock();
 
-        const { getByText, getByLabelText, getByRole, queryByRole, queryByText } =
-            renderSendMelding(lagBehandling({ varselSendt: false }));
+        renderSendMelding(lagBehandling({ varselSendt: false }));
 
-        expect(getByText('Brevmottaker')).toBeInTheDocument();
-        expect(getByLabelText('Mal')).toHaveLength(3);
-        expect(queryByText('Bokmål')).not.toBeInTheDocument();
+        expect(screen.getByText('Brevmottaker')).toBeInTheDocument();
+        expect(screen.getByLabelText('Mal')).toHaveLength(3);
+        expect(screen.queryByText('Bokmål')).not.toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         ).toBeDisabled();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis',
             })
         ).not.toBeInTheDocument();
 
-        await user.selectOptions(getByLabelText('Mal'), DokumentMal.Varsel);
+        await user.selectOptions(screen.getByLabelText('Mal'), DokumentMal.Varsel);
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         ).toBeDisabled();
 
-        expect(getByText('Bokmål')).toBeInTheDocument();
-        await user.type(getByRole('textbox', { name: 'Fritekst' }), 'Fritekst i varselbrev');
+        expect(screen.getByText('Bokmål')).toBeInTheDocument();
+        await user.type(screen.getByRole('textbox', { name: 'Fritekst' }), 'Fritekst i varselbrev');
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         ).toBeEnabled();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis',
             })
         ).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         );
@@ -120,34 +118,31 @@ describe('SendMelding', () => {
     test('Fyller ut skjema og sender korrigert varsel', async () => {
         setupMock();
 
-        const { getByText, getByLabelText, getByRole, queryByText } = renderSendMelding(
-            lagBehandling({ varselSendt: true }),
-            'NN'
-        );
+        renderSendMelding(lagBehandling({ varselSendt: true }), 'NN');
 
-        expect(getByText('Brevmottaker')).toBeInTheDocument();
-        expect(getByLabelText('Mal')).toHaveLength(3);
-        expect(queryByText('Nynorsk')).not.toBeInTheDocument();
+        expect(screen.getByText('Brevmottaker')).toBeInTheDocument();
+        expect(screen.getByLabelText('Mal')).toHaveLength(3);
+        expect(screen.queryByText('Nynorsk')).not.toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         ).toBeDisabled();
 
-        await user.selectOptions(getByLabelText('Mal'), DokumentMal.KorrigertVarsel);
+        await user.selectOptions(screen.getByLabelText('Mal'), DokumentMal.KorrigertVarsel);
 
-        expect(getByText('Nynorsk')).toBeInTheDocument();
-        await user.type(getByRole('textbox', { name: 'Fritekst' }), 'Fritekst i varselbrev');
+        expect(screen.getByText('Nynorsk')).toBeInTheDocument();
+        await user.type(screen.getByRole('textbox', { name: 'Fritekst' }), 'Fritekst i varselbrev');
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis',
             })
         ).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         );
@@ -156,33 +151,31 @@ describe('SendMelding', () => {
     test('Fyller ut skjema og sender innhent dokumentasjon', async () => {
         setupMock();
 
-        const { getByText, getByLabelText, getByRole } = renderSendMelding(
-            lagBehandling({ varselSendt: true })
-        );
+        renderSendMelding(lagBehandling({ varselSendt: true }));
 
-        expect(getByText('Brevmottaker')).toBeInTheDocument();
+        expect(screen.getByText('Brevmottaker')).toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         ).toBeDisabled();
 
-        await user.selectOptions(getByLabelText('Mal'), DokumentMal.InnhentDokumentasjon);
+        await user.selectOptions(screen.getByLabelText('Mal'), DokumentMal.InnhentDokumentasjon);
         await user.type(
-            getByRole('textbox', {
+            screen.getByRole('textbox', {
                 name: 'Liste over dokumenter (skriv ett dokument pr. linje)',
             }),
             'Liste over dokument'
         );
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis',
             })
         ).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         );
@@ -191,22 +184,18 @@ describe('SendMelding', () => {
     test('Lesevisning - venter på svar på manuelt brev', async () => {
         setupMock();
 
-        const { getByText, getByRole, queryByLabelText } = renderSendMelding(
-            lagBehandling({ varselSendt: false }),
-            'NB',
-            true
-        );
+        renderSendMelding(lagBehandling({ varselSendt: false }), 'NB', true);
 
-        expect(getByText('Brevmottaker')).toBeInTheDocument();
+        expect(screen.getByText('Brevmottaker')).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send brev',
             })
         ).toBeDisabled();
 
-        expect(queryByLabelText('Mal')).not.toBeInTheDocument();
-        expect(getByText('Mal')).toBeInTheDocument();
-        expect(getByText('Velg brev')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Mal')).not.toBeInTheDocument();
+        expect(screen.getByText('Mal')).toBeInTheDocument();
+        expect(screen.getByText('Velg brev')).toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/sidebar/sendMelding/SendMelding.test.tsx
+++ b/src/frontend/komponenter/sidebar/sendMelding/SendMelding.test.tsx
@@ -181,7 +181,7 @@ describe('SendMelding', () => {
         );
     });
 
-    test('Lesevisning - venter på svar på manuelt brev', async () => {
+    test('Lesevisning - venter på svar på manuelt brev', () => {
         setupMock();
 
         renderSendMelding(lagBehandling({ varselSendt: false }), 'NB', true);

--- a/src/frontend/komponenter/sidebar/totrinnskontroll/Totrinnskontroll.test.tsx
+++ b/src/frontend/komponenter/sidebar/totrinnskontroll/Totrinnskontroll.test.tsx
@@ -236,7 +236,7 @@ describe('Totrinnskontroll', () => {
 
         await user.click(godkjennKnapp());
 
-        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Fakta' })).toBeInTheDocument();
         expect(screen.getByText('Denne handlingen kan ikke angres.')).toBeInTheDocument();
         expect(
             screen.getByRole('button', {

--- a/src/frontend/komponenter/sidebar/totrinnskontroll/Totrinnskontroll.test.tsx
+++ b/src/frontend/komponenter/sidebar/totrinnskontroll/Totrinnskontroll.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { BehandlingDto } from '~/generated';
@@ -32,9 +31,9 @@ vi.mock('~/api/behandling', () => ({
 const renderTotrinnskontroll = (
     behandling: BehandlingDto,
     stateOverrides: BehandlingStateContextOverrides = {}
-): RenderResult => {
+): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider behandling={behandling} stateOverrides={stateOverrides}>
@@ -92,22 +91,20 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByText, getByTestId, getAllByRole } = renderTotrinnskontroll(
-            lagBehandling({ kanEndres: true })
-        );
+        renderTotrinnskontroll(lagBehandling({ kanEndres: true }));
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
 
-        expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
-        expect(getByText('Vedtak')).toBeInTheDocument();
-        expect(getAllByRole('link')).toHaveLength(3);
+        expect(screen.getByText('Vilkårsvurdering')).toBeInTheDocument();
+        expect(screen.getByText('Vedtak')).toBeInTheDocument();
+        expect(screen.getAllByRole('link')).toHaveLength(3);
 
         expect(godkjennKnapp()).toBeDisabled();
         expect(sendTilSaksbehandlerKnapp()).toBeDisabled();
 
-        await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_0-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_1-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_2-true'));
 
         await user.click(godkjennKnapp());
     });
@@ -121,23 +118,21 @@ describe('Totrinnskontroll', () => {
                 lagTotrinnsStegInfo('FORESLÅ_VEDTAK'),
             ],
         });
-        const { getByText, getByTestId, getAllByRole } = renderTotrinnskontroll(
-            lagBehandling({ kanEndres: true })
-        );
+        renderTotrinnskontroll(lagBehandling({ kanEndres: true }));
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
-        expect(getByText('Foreldelse')).toBeInTheDocument();
-        expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
-        expect(getByText('Vedtak')).toBeInTheDocument();
-        expect(getAllByRole('link')).toHaveLength(4);
+        expect(screen.getByText('Foreldelse')).toBeInTheDocument();
+        expect(screen.getByText('Vilkårsvurdering')).toBeInTheDocument();
+        expect(screen.getByText('Vedtak')).toBeInTheDocument();
+        expect(screen.getAllByRole('link')).toHaveLength(4);
 
         expect(godkjennKnapp()).toBeDisabled();
         expect(sendTilSaksbehandlerKnapp()).toBeDisabled();
 
-        await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_3-false'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_0-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_1-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_2-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_3-false'));
 
         await user.type(
             screen.getByRole('textbox', {
@@ -159,32 +154,31 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByText, getAllByText, getAllByRole, queryByRole } = renderTotrinnskontroll(
-            lagBehandling(),
-            { erBehandlingReturnertFraBeslutter: (): boolean => true }
-        );
+        renderTotrinnskontroll(lagBehandling(), {
+            erBehandlingReturnertFraBeslutter: (): boolean => true,
+        });
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
-        expect(getByText('Foreldelse')).toBeInTheDocument();
-        expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
-        expect(getByText('Vedtak')).toBeInTheDocument();
-        expect(getAllByRole('link')).toHaveLength(4);
+        expect(screen.getByText('Foreldelse')).toBeInTheDocument();
+        expect(screen.getByText('Vilkårsvurdering')).toBeInTheDocument();
+        expect(screen.getByText('Vedtak')).toBeInTheDocument();
+        expect(screen.getAllByRole('link')).toHaveLength(4);
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Godkjenn vedtaket',
             })
         ).not.toBeInTheDocument();
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Send til saksbehandler',
             })
         ).not.toBeInTheDocument();
 
-        expect(getAllByText('Godkjent')).toHaveLength(2);
-        expect(getAllByText('Vurder på nytt')).toHaveLength(2);
-        expect(getByText('Foreldelse må vurderes på nytt')).toBeInTheDocument();
-        expect(getByText('Vedtaket må vurderes på nytt')).toBeInTheDocument();
+        expect(screen.getAllByText('Godkjent')).toHaveLength(2);
+        expect(screen.getAllByText('Vurder på nytt')).toHaveLength(2);
+        expect(screen.getByText('Foreldelse må vurderes på nytt')).toBeInTheDocument();
+        expect(screen.getByText('Vedtaket må vurderes på nytt')).toBeInTheDocument();
     });
 
     test('Vis utfylt - foreslått på nytt - lesevisning (rolle saksbehandler)', async () => {
@@ -197,31 +191,29 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByText, getAllByText, getAllByRole, queryByRole } = renderTotrinnskontroll(
-            lagBehandling({ kanEndres: false })
-        );
+        renderTotrinnskontroll(lagBehandling({ kanEndres: false }));
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
-        expect(getByText('Foreldelse')).toBeInTheDocument();
-        expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
-        expect(getByText('Vedtak')).toBeInTheDocument();
-        expect(getAllByRole('link')).toHaveLength(4);
+        expect(screen.getByText('Foreldelse')).toBeInTheDocument();
+        expect(screen.getByText('Vilkårsvurdering')).toBeInTheDocument();
+        expect(screen.getByText('Vedtak')).toBeInTheDocument();
+        expect(screen.getAllByRole('link')).toHaveLength(4);
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Godkjenn vedtaket',
             })
         ).not.toBeInTheDocument();
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Send til saksbehandler',
             })
         ).not.toBeInTheDocument();
 
-        expect(getAllByText('Godkjent')).toHaveLength(2);
-        expect(getAllByText('Vurder på nytt')).toHaveLength(2);
-        expect(getByText('Foreldelse må vurderes på nytt')).toBeInTheDocument();
-        expect(getByText('Vedtaket må vurderes på nytt')).toBeInTheDocument();
+        expect(screen.getAllByText('Godkjent')).toHaveLength(2);
+        expect(screen.getAllByText('Vurder på nytt')).toHaveLength(2);
+        expect(screen.getByText('Foreldelse må vurderes på nytt')).toBeInTheDocument();
+        expect(screen.getByText('Vedtaket må vurderes på nytt')).toBeInTheDocument();
     });
 
     test('Viser bekreftelsesmodal når bruker klikker Godkjenn vedtaket', async () => {
@@ -233,23 +225,21 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByText, getByRole, getByTestId, queryByRole } = renderTotrinnskontroll(
-            lagBehandling({ kanEndres: true, erNyModell: true })
-        );
+        renderTotrinnskontroll(lagBehandling({ kanEndres: true, erNyModell: true }));
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
-        await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_0-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_1-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_2-true'));
 
-        expect(queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
         await user.click(godkjennKnapp());
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
-        expect(getByText('Denne handlingen kan ikke angres.')).toBeInTheDocument();
+        expect(screen.getByText('Denne handlingen kan ikke angres.')).toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Avbryt',
             })
         ).toBeInTheDocument();
@@ -264,19 +254,17 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByRole, getByTestId, queryByRole } = renderTotrinnskontroll(
-            lagBehandling({ kanEndres: true })
-        );
+        renderTotrinnskontroll(lagBehandling({ kanEndres: true }));
 
         expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
 
-        await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
-        await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_0-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_1-true'));
+        await user.click(screen.getByTestId('stegetGodkjent_idx_steg_2-true'));
 
         await user.click(godkjennKnapp());
 
-        const modal = getByRole('dialog');
+        const modal = screen.getByRole('dialog');
 
         await user.click(
             within(modal).getByRole('button', {
@@ -284,6 +272,6 @@ describe('Totrinnskontroll', () => {
             })
         );
 
-        expect(queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/sidebar/totrinnskontroll/Totrinnskontroll.test.tsx
+++ b/src/frontend/komponenter/sidebar/totrinnskontroll/Totrinnskontroll.test.tsx
@@ -6,7 +6,7 @@ import type { Ressurs } from '~/typer/ressurs';
 import type { Totrinnkontroll } from '~/typer/totrinnTyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor, within } from '@testing-library/react';
+import { render, within, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -66,6 +66,16 @@ const setupMocks = (totrinnkontroll: Totrinnkontroll): void => {
     }));
 };
 
+const godkjennKnapp = (): HTMLElement =>
+    screen.getByRole('button', {
+        name: 'Godkjenn vedtaket',
+    });
+
+const sendTilSaksbehandlerKnapp = (): HTMLElement =>
+    screen.getByRole('button', {
+        name: 'Send til saksbehandler',
+    });
+
 describe('Totrinnskontroll', () => {
     let user: UserEvent;
     beforeEach(() => {
@@ -82,47 +92,24 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByText, getByRole, getByTestId, getAllByRole } = renderTotrinnskontroll(
+        const { getByText, getByTestId, getAllByRole } = renderTotrinnskontroll(
             lagBehandling({ kanEndres: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta')).toBeInTheDocument();
-        });
-
-        expect(getAllByRole('link')).toHaveLength(3);
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
 
         expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
         expect(getByText('Vedtak')).toBeInTheDocument();
+        expect(getAllByRole('link')).toHaveLength(3);
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Godkjenn vedtaket',
-                })
-            ).toBeDisabled();
-        });
-        expect(
-            getByRole('button', {
-                name: 'Send til saksbehandler',
-            })
-        ).toBeDisabled();
+        expect(godkjennKnapp()).toBeDisabled();
+        expect(sendTilSaksbehandlerKnapp()).toBeDisabled();
 
         await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
 
-        expect(
-            getByRole('button', {
-                name: 'Godkjenn vedtaket',
-            })
-        ).toBeEnabled();
-
-        await user.click(
-            getByRole('button', {
-                name: 'Godkjenn vedtaket',
-            })
-        );
+        await user.click(godkjennKnapp());
     });
 
     test('Vis og fyll ut - sender tilbake', async () => {
@@ -134,62 +121,32 @@ describe('Totrinnskontroll', () => {
                 lagTotrinnsStegInfo('FORESLÅ_VEDTAK'),
             ],
         });
-        const { getByText, getByRole, getByTestId, getAllByRole } = renderTotrinnskontroll(
+        const { getByText, getByTestId, getAllByRole } = renderTotrinnskontroll(
             lagBehandling({ kanEndres: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta')).toBeInTheDocument();
-        });
-
-        expect(getAllByRole('link')).toHaveLength(4);
-
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
         expect(getByText('Foreldelse')).toBeInTheDocument();
         expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
         expect(getByText('Vedtak')).toBeInTheDocument();
+        expect(getAllByRole('link')).toHaveLength(4);
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Godkjenn vedtaket',
-                })
-            ).toBeDisabled();
-        });
-        expect(
-            getByRole('button', {
-                name: 'Send til saksbehandler',
-            })
-        ).toBeDisabled();
+        expect(godkjennKnapp()).toBeDisabled();
+        expect(sendTilSaksbehandlerKnapp()).toBeDisabled();
 
         await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_3-false'));
 
-        expect(
-            getByRole('button', {
-                name: 'Send til saksbehandler',
-            })
-        ).toBeDisabled();
-
         await user.type(
-            getByRole('textbox', {
+            screen.getByRole('textbox', {
                 name: 'Begrunnelse',
             }),
             'Vurder på nytt!!!!'
         );
 
-        expect(
-            getByRole('button', {
-                name: 'Send til saksbehandler',
-            })
-        ).toBeEnabled();
-
-        await user.click(
-            getByRole('button', {
-                name: 'Send til saksbehandler',
-            })
-        );
+        await user.click(sendTilSaksbehandlerKnapp());
     });
 
     test('Vis utfylt - sendt tilbake', async () => {
@@ -207,15 +164,11 @@ describe('Totrinnskontroll', () => {
             { erBehandlingReturnertFraBeslutter: (): boolean => true }
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta')).toBeInTheDocument();
-        });
-
-        expect(getAllByRole('link')).toHaveLength(4);
-
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
         expect(getByText('Foreldelse')).toBeInTheDocument();
         expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
         expect(getByText('Vedtak')).toBeInTheDocument();
+        expect(getAllByRole('link')).toHaveLength(4);
 
         expect(
             queryByRole('button', {
@@ -248,15 +201,11 @@ describe('Totrinnskontroll', () => {
             lagBehandling({ kanEndres: false })
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta')).toBeInTheDocument();
-        });
-
-        expect(getAllByRole('link')).toHaveLength(4);
-
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
         expect(getByText('Foreldelse')).toBeInTheDocument();
         expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
         expect(getByText('Vedtak')).toBeInTheDocument();
+        expect(getAllByRole('link')).toHaveLength(4);
 
         expect(
             queryByRole('button', {
@@ -288,26 +237,16 @@ describe('Totrinnskontroll', () => {
             lagBehandling({ kanEndres: true, erNyModell: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta')).toBeInTheDocument();
-        });
-
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
         await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
 
         expect(queryByRole('dialog')).not.toBeInTheDocument();
 
-        await user.click(
-            getByRole('button', {
-                name: 'Godkjenn vedtaket',
-            })
-        );
+        await user.click(godkjennKnapp());
 
-        await waitFor(() => {
-            expect(getByRole('dialog')).toBeInTheDocument();
-        });
-
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
         expect(getByText('Denne handlingen kan ikke angres.')).toBeInTheDocument();
         expect(
             getByRole('button', {
@@ -325,25 +264,19 @@ describe('Totrinnskontroll', () => {
             ],
         });
 
-        const { getByText, getByRole, getByTestId, queryByRole } = renderTotrinnskontroll(
+        const { getByRole, getByTestId, queryByRole } = renderTotrinnskontroll(
             lagBehandling({ kanEndres: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta')).toBeInTheDocument();
-        });
+        expect(await screen.findByRole('link', { name: 'Fakta' })).toBeInTheDocument();
 
         await user.click(getByTestId('stegetGodkjent_idx_steg_0-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_1-true'));
         await user.click(getByTestId('stegetGodkjent_idx_steg_2-true'));
 
-        await user.click(
-            getByRole('button', {
-                name: 'Godkjenn vedtaket',
-            })
-        );
+        await user.click(godkjennKnapp());
 
-        const modal = await waitFor(() => getByRole('dialog'));
+        const modal = getByRole('dialog');
 
         await user.click(
             within(modal).getByRole('button', {
@@ -351,8 +284,6 @@ describe('Totrinnskontroll', () => {
             })
         );
 
-        await waitFor(() => {
-            expect(queryByRole('dialog')).not.toBeInTheDocument();
-        });
+        expect(queryByRole('dialog')).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/komponenter/stegflyt/Stegflyt.test.tsx
+++ b/src/frontend/komponenter/stegflyt/Stegflyt.test.tsx
@@ -1,9 +1,8 @@
-import type { RenderResult } from '@testing-library/react';
 import type { Location } from 'react-router';
 import type { BehandlingDto } from '~/generated';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Suspense } from 'react';
 
 import { BehandlingProvider } from '~/context/BehandlingContext';
@@ -37,11 +36,11 @@ const createMockBehandling = (overrides: Record<string, unknown> = {}): Behandli
         ...overrides,
     });
 
-const renderStegflyt = (behandling: BehandlingDto = createMockBehandling()): RenderResult => {
+const renderStegflyt = (behandling: BehandlingDto = createMockBehandling()): void => {
     const queryClient = createTestQueryClient();
     setBehandlingQueryData(queryClient, '123', behandling);
 
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext
                 value={lagFagsak({
@@ -69,17 +68,17 @@ describe('Stegflyt', () => {
 
     describe('Synlighet av steg', () => {
         test('skal vise Fakta, Foreldelse, Vilkårsvurdering og Vedtak som alltid synlige', () => {
-            const { getByText } = renderStegflyt();
+            renderStegflyt();
 
-            expect(getByText('Fakta')).toBeInTheDocument();
-            expect(getByText('Foreldelse')).toBeInTheDocument();
-            expect(getByText('Vilkårsvurdering')).toBeInTheDocument();
-            expect(getByText('Vedtak')).toBeInTheDocument();
+            expect(screen.getByText('Fakta')).toBeInTheDocument();
+            expect(screen.getByText('Foreldelse')).toBeInTheDocument();
+            expect(screen.getByText('Vilkårsvurdering')).toBeInTheDocument();
+            expect(screen.getByText('Vedtak')).toBeInTheDocument();
         });
 
         test('skal ikke vise Brevmottaker når det ikke er i behandlingsstegsinfo', () => {
-            const { queryByText } = renderStegflyt();
-            expect(queryByText('Brevmottaker')).not.toBeInTheDocument();
+            renderStegflyt();
+            expect(screen.queryByText('Brevmottaker')).not.toBeInTheDocument();
         });
 
         test('skal vise Brevmottaker når det er i behandlingsstegsinfo og støttet', () => {
@@ -91,26 +90,26 @@ describe('Stegflyt', () => {
                     lagBrevmottakerSteg(),
                 ],
             });
-            const { getByText } = renderStegflyt(behandling);
+            renderStegflyt(behandling);
 
-            expect(getByText('Brevmottaker(e)')).toBeInTheDocument();
+            expect(screen.getByText('Brevmottaker(e)')).toBeInTheDocument();
         });
     });
 
     describe('Navigering', () => {
         test('skal ikke navigere til steget som allerede er aktivt', () => {
-            const { getByText } = renderStegflyt();
+            renderStegflyt();
 
-            const aktivtSteg = getByText('Fakta');
+            const aktivtSteg = screen.getByText('Fakta');
             fireEvent.click(aktivtSteg);
 
             expect(mockNavigate).not.toHaveBeenCalled();
         });
 
         test('skal kunne navigere til andre aktive steg', () => {
-            const { getByText } = renderStegflyt();
+            renderStegflyt();
 
-            const foreldelseSteg = getByText('Foreldelse');
+            const foreldelseSteg = screen.getByText('Foreldelse');
             fireEvent.click(foreldelseSteg);
 
             expect(mockNavigate).toHaveBeenCalledWith(
@@ -119,9 +118,9 @@ describe('Stegflyt', () => {
         });
 
         test('skal ikke kunne navigere til inaktive steg', () => {
-            const { getByText } = renderStegflyt();
+            renderStegflyt();
 
-            const vedtakSteg = getByText('Vedtak');
+            const vedtakSteg = screen.getByText('Vedtak');
             fireEvent.click(vedtakSteg);
 
             expect(mockNavigate).not.toHaveBeenCalled();
@@ -130,16 +129,18 @@ describe('Stegflyt', () => {
 
     describe('Aria-labels', () => {
         test('skal ha riktige aria-labels for aktive steg', () => {
-            const { getByLabelText } = renderStegflyt();
+            renderStegflyt();
 
-            expect(getByLabelText('Gå til Foreldelse')).toBeInTheDocument();
-            expect(getByLabelText('Gå til Vilkårsvurdering')).toBeInTheDocument();
+            expect(screen.getByLabelText('Gå til Foreldelse')).toBeInTheDocument();
+            expect(screen.getByLabelText('Gå til Vilkårsvurdering')).toBeInTheDocument();
         });
 
         test('skal ha riktige aria-labels for inaktive steg', () => {
-            const { getByLabelText } = renderStegflyt();
+            renderStegflyt();
 
-            expect(getByLabelText('Inaktivt steg, Vedtak, ikke klikkbar')).toBeInTheDocument();
+            expect(
+                screen.getByLabelText('Inaktivt steg, Vedtak, ikke klikkbar')
+            ).toBeInTheDocument();
         });
     });
 
@@ -149,8 +150,8 @@ describe('Stegflyt', () => {
                 pathname: '/ugyldig-side',
             });
 
-            const { container } = renderStegflyt();
-            expect(container.firstChild).toBeNull();
+            renderStegflyt();
+            expect(screen.queryByText('Fakta')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/frontend/pages/fagsak/brevmottaker/BrevmottakerFormModal.test.tsx
+++ b/src/frontend/pages/fagsak/brevmottaker/BrevmottakerFormModal.test.tsx
@@ -1,6 +1,6 @@
 import type { UserEvent } from '@testing-library/user-event';
 
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -41,8 +41,9 @@ const renderBrevmottakerFormModal = async (
             </TestBehandlingProvider>
         </FagsakContext>
     );
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
 };
+
 const adresseRadioGroup = (): HTMLElement => screen.getByRole('radiogroup', { name: /Adresse/i });
 const manuellRegistreringRadio = (): HTMLElement =>
     within(adresseRadioGroup()).getByRole('radio', { name: 'Manuell registrering' });

--- a/src/frontend/pages/fagsak/brevmottaker/Brevmottakere.test.tsx
+++ b/src/frontend/pages/fagsak/brevmottaker/Brevmottakere.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { BehandlingDto, ManuellBrevmottakerResponsDto } from '~/generated';
 
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -51,9 +50,9 @@ const createMockDødsboBrevmottaker = (): ManuellBrevmottakerResponsDto[] => [
     },
 ];
 
-const renderBrevmottakere = (behandling: BehandlingDto): RenderResult => {
+const renderBrevmottakere = (behandling: BehandlingDto): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider behandling={behandling}>

--- a/src/frontend/pages/fagsak/fakta/FaktaContainer.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/FaktaContainer.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { BehandlingDto, SchemaEnum4 } from '~/generated';
@@ -34,9 +33,9 @@ const renderFaktaContainer = (
     ytelsestype: SchemaEnum4 = 'BARNETRYGD',
     behandlet: boolean = false,
     lesemodus: boolean = false
-): RenderResult => {
+): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak({ ytelsestype })}>
                 <TestBehandlingProvider
@@ -114,70 +113,69 @@ describe('FaktaContainer', () => {
     test('Vis og fyll ut skjema', async () => {
         setupMock(lagFaktaResponse({ feilutbetaltePerioder }));
 
-        const { getByText, getByRole, getAllByRole, getByTestId, queryAllByText } =
-            renderFaktaContainer(lagBehandling(), 'BARNETRYGD');
+        renderFaktaContainer(lagBehandling(), 'BARNETRYGD');
 
         expect(
             await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
         ).toBeInTheDocument();
 
-        expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
-        expect(getByText('01.01.2020–31.10.2020')).toBeInTheDocument();
-        expect(getByText('3 999')).toBeInTheDocument();
-        expect(getByText('5 200')).toBeInTheDocument();
+        expect(screen.getByText('Periode med feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.10.2020')).toBeInTheDocument();
+        expect(screen.getByText('3 999')).toBeInTheDocument();
+        expect(screen.getByText('5 200')).toBeInTheDocument();
 
-        expect(getByText('Nye opplysninger')).toBeInTheDocument();
-        expect(getByText('05.02.2021')).toBeInTheDocument();
-        expect(getByText('Opphør av ytelsen')).toBeInTheDocument();
-        expect(getByText('Reduksjon av ytelsen, Feilutbetaling')).toBeInTheDocument();
-        expect(getByText('Opprett tilbakekreving, send varsel')).toBeInTheDocument();
+        expect(screen.getByText('Nye opplysninger')).toBeInTheDocument();
+        expect(screen.getByText('05.02.2021')).toBeInTheDocument();
+        expect(screen.getByText('Opphør av ytelsen')).toBeInTheDocument();
+        expect(screen.getByText('Reduksjon av ytelsen, Feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('Opprett tilbakekreving, send varsel')).toBeInTheDocument();
 
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
 
-        expect(getByText('01.05.2020–31.07.2020')).toBeInTheDocument();
-        expect(getByText('01.09.2020–31.10.2020')).toBeInTheDocument();
-        expect(queryAllByText('1 333')).toHaveLength(3);
+        expect(screen.getByText('01.05.2020–31.07.2020')).toBeInTheDocument();
+        expect(screen.getByText('01.09.2020–31.10.2020')).toBeInTheDocument();
+        expect(screen.queryAllByText('1 333')).toHaveLength(3);
 
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        expect(getAllByRole('combobox')).toHaveLength(3);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.getAllByRole('combobox')).toHaveLength(3);
 
-        await user.click(getByTestId('brukerHarUttaltSeg.nei'));
+        await user.click(screen.getByTestId('brukerHarUttaltSeg.nei'));
 
         await user.click(gåVidereKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(4);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(4);
 
-        await user.selectOptions(getByTestId('perioder.0.årsak'), HendelseType.BosattIRiket);
-        await user.selectOptions(getByTestId('perioder.1.årsak'), HendelseType.BorMedSøker);
-        await user.selectOptions(getByTestId('perioder.2.årsak'), HendelseType.BosattIRiket);
+        await user.selectOptions(screen.getByTestId('perioder.0.årsak'), HendelseType.BosattIRiket);
+        await user.selectOptions(screen.getByTestId('perioder.1.årsak'), HendelseType.BorMedSøker);
+        await user.selectOptions(screen.getByTestId('perioder.2.årsak'), HendelseType.BosattIRiket);
 
         await user.type(
-            getByRole('textbox', { name: 'Årsak til feilutbetalingen' }),
+            screen.getByRole('textbox', { name: 'Årsak til feilutbetalingen' }),
             'Begrunnelse'
         );
 
-        expect(getAllByRole('textbox')).toHaveLength(1);
+        expect(screen.getAllByRole('textbox')).toHaveLength(1);
 
-        expect(getAllByRole('combobox')).toHaveLength(6);
+        expect(screen.getAllByRole('combobox')).toHaveLength(6);
 
         await user.click(gåVidereKnapp());
         // BorMedSøker har kun 1 underårsak og vil derfor bli automatisk satt
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
-            getByTestId('perioder.0.underårsak'),
+            screen.getByTestId('perioder.0.underårsak'),
             HendelseUndertype.BrukerBorIkkeINorge
         );
         await user.selectOptions(
-            getByTestId('perioder.1.underårsak'),
+            screen.getByTestId('perioder.1.underårsak'),
             HendelseUndertype.BorIkkeMedBarn
         );
         await user.selectOptions(
-            getByTestId('perioder.2.underårsak'),
+            screen.getByTestId('perioder.2.underårsak'),
             HendelseUndertype.BrukerFlyttetFraNorge
         );
 
         await user.click(gåVidereKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
         expect(mockedSettIkkePersistertKomponent).toHaveBeenCalledWith('fakta');
     });
@@ -185,50 +183,49 @@ describe('FaktaContainer', () => {
     test('Vis og fyll ut skjema - behandle perioder samlet', async () => {
         setupMock(lagFaktaResponse({ feilutbetaltePerioder }));
 
-        const { getByText, getByLabelText, getByRole, getAllByRole, getByTestId, queryAllByText } =
-            renderFaktaContainer(lagBehandling(), 'BARNETRYGD');
+        renderFaktaContainer(lagBehandling(), 'BARNETRYGD');
 
         expect(
             await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
         ).toBeInTheDocument();
 
-        expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
-        expect(getByText('Opprett tilbakekreving, send varsel')).toBeInTheDocument();
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        expect(getAllByRole('combobox')).toHaveLength(3);
+        expect(screen.getByText('Periode med feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('Opprett tilbakekreving, send varsel')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.getAllByRole('combobox')).toHaveLength(3);
 
         await user.click(gåVidereKnapp());
 
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(5);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(5);
 
         await user.click(
-            getByRole('checkbox', {
+            screen.getByRole('checkbox', {
                 name: 'Velg rettslig grunnlag for periodene samlet',
             })
         );
 
-        await user.selectOptions(getByTestId('perioder.0.årsak'), HendelseType.BosattIRiket);
-        await user.type(getByLabelText('Årsak til feilutbetalingen'), 'Begrunnelse');
+        await user.selectOptions(screen.getByTestId('perioder.0.årsak'), HendelseType.BosattIRiket);
+        await user.type(screen.getByLabelText('Årsak til feilutbetalingen'), 'Begrunnelse');
 
-        expect(getAllByRole('combobox')).toHaveLength(6);
+        expect(screen.getAllByRole('combobox')).toHaveLength(6);
 
         await user.click(gåVidereKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(4);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(4);
 
         await user.selectOptions(
-            getByTestId('perioder.0.underårsak'),
+            screen.getByTestId('perioder.0.underårsak'),
             HendelseUndertype.BrukerBorIkkeINorge
         );
-        await user.click(getByTestId('brukerHarUttaltSeg.ja'));
+        await user.click(screen.getByTestId('brukerHarUttaltSeg.ja'));
         await user.type(
-            getByLabelText(
+            screen.getByLabelText(
                 'Beskriv når og hvor bruker har uttalt seg. Gi også en kort oppsummering av uttalelsen'
             ),
             'Begrunnelse'
         );
         await user.click(gåVidereKnapp());
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
         expect(mockedSettIkkePersistertKomponent).toHaveBeenCalledWith('fakta');
     });
@@ -256,28 +253,28 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText, getByLabelText, getByTestId } = renderFaktaContainer(
-            lagBehandling(),
-            'BARNETRYGD',
-            true
-        );
+        renderFaktaContainer(lagBehandling(), 'BARNETRYGD', true);
 
         expect(
             await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
         ).toBeInTheDocument();
 
-        expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByTestId('perioder.0.årsak')).toHaveValue(HendelseType.BosattIRiket);
-        expect(getByTestId('perioder.1.årsak')).toHaveValue(HendelseType.Annet);
-        expect(getByTestId('perioder.2.årsak')).toHaveValue(HendelseType.BarnsAlder);
-        expect(getByTestId('perioder.0.underårsak')).toHaveValue(
+        expect(screen.getByText('Periode med feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByTestId('perioder.0.årsak')).toHaveValue(HendelseType.BosattIRiket);
+        expect(screen.getByTestId('perioder.1.årsak')).toHaveValue(HendelseType.Annet);
+        expect(screen.getByTestId('perioder.2.årsak')).toHaveValue(HendelseType.BarnsAlder);
+        expect(screen.getByTestId('perioder.0.underårsak')).toHaveValue(
             HendelseUndertype.BrukerBorIkkeINorge
         );
-        expect(getByTestId('perioder.1.underårsak')).toHaveValue(HendelseUndertype.AnnetFritekst);
-        expect(getByTestId('perioder.2.underårsak')).toHaveValue(HendelseUndertype.BarnOver6År);
+        expect(screen.getByTestId('perioder.1.underårsak')).toHaveValue(
+            HendelseUndertype.AnnetFritekst
+        );
+        expect(screen.getByTestId('perioder.2.underårsak')).toHaveValue(
+            HendelseUndertype.BarnOver6År
+        );
 
-        expect(getByLabelText('Årsak til feilutbetalingen')).toHaveValue(
+        expect(screen.getByLabelText('Årsak til feilutbetalingen')).toHaveValue(
             'Dette er en test-begrunnelse'
         );
 
@@ -307,26 +304,26 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText, getByLabelText, getByTestId } = renderFaktaContainer(
-            lagBehandling(),
-            'OVERGANGSSTØNAD',
-            true
-        );
+        renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD', true);
 
         expect(
             await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
         ).toBeInTheDocument();
 
-        expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByTestId('perioder.0.årsak')).toHaveValue(HendelseType.EnsligForsørger);
-        expect(getByTestId('perioder.1.årsak')).toHaveValue(HendelseType.Annet);
-        expect(getByTestId('perioder.2.årsak')).toHaveValue(HendelseType.YrkesrettetAktivitet);
-        expect(getByTestId('perioder.0.underårsak')).toHaveValue(HendelseUndertype.Ugift);
-        expect(getByTestId('perioder.1.underårsak')).toHaveValue(HendelseUndertype.AnnetFritekst);
-        expect(getByTestId('perioder.2.underårsak')).toHaveValue(HendelseUndertype.Arbeid);
+        expect(screen.getByText('Periode med feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByTestId('perioder.0.årsak')).toHaveValue(HendelseType.EnsligForsørger);
+        expect(screen.getByTestId('perioder.1.årsak')).toHaveValue(HendelseType.Annet);
+        expect(screen.getByTestId('perioder.2.årsak')).toHaveValue(
+            HendelseType.YrkesrettetAktivitet
+        );
+        expect(screen.getByTestId('perioder.0.underårsak')).toHaveValue(HendelseUndertype.Ugift);
+        expect(screen.getByTestId('perioder.1.underårsak')).toHaveValue(
+            HendelseUndertype.AnnetFritekst
+        );
+        expect(screen.getByTestId('perioder.2.underårsak')).toHaveValue(HendelseUndertype.Arbeid);
 
-        expect(getByLabelText('Årsak til feilutbetalingen')).toHaveValue(
+        expect(screen.getByLabelText('Årsak til feilutbetalingen')).toHaveValue(
             'Dette er en test-begrunnelse'
         );
 
@@ -356,21 +353,21 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText } = renderFaktaContainer(lagBehandling(), 'BARNETRYGD', true, true);
+        renderFaktaContainer(lagBehandling(), 'BARNETRYGD', true, true);
 
         expect(
             await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
         ).toBeInTheDocument();
 
-        expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByText('Bosatt i riket')).toBeInTheDocument();
-        expect(getByText('Bruker bor ikke i Norge')).toBeInTheDocument();
-        expect(getByText('Annet')).toBeInTheDocument();
-        expect(getByText('Annet fritekst')).toBeInTheDocument();
-        expect(getByText('Barns alder')).toBeInTheDocument();
-        expect(getByText('Barn over 6 år')).toBeInTheDocument();
-        expect(getByText('Dette er en test-begrunnelse')).toBeInTheDocument();
+        expect(screen.getByText('Periode med feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByText('Bosatt i riket')).toBeInTheDocument();
+        expect(screen.getByText('Bruker bor ikke i Norge')).toBeInTheDocument();
+        expect(screen.getByText('Annet')).toBeInTheDocument();
+        expect(screen.getByText('Annet fritekst')).toBeInTheDocument();
+        expect(screen.getByText('Barns alder')).toBeInTheDocument();
+        expect(screen.getByText('Barn over 6 år')).toBeInTheDocument();
+        expect(screen.getByText('Dette er en test-begrunnelse')).toBeInTheDocument();
 
         expect(gåVidereKnapp()).toBeInTheDocument();
     });
@@ -398,21 +395,21 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText } = renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD', true, true);
+        renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD', true, true);
 
         expect(
             await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
         ).toBeInTheDocument();
 
-        expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByText('§15-4 Enslig forsørger')).toBeInTheDocument();
-        expect(getByText('Ugift (3. ledd)')).toBeInTheDocument();
-        expect(getByText('Annet')).toBeInTheDocument();
-        expect(getByText('Annet fritekst')).toBeInTheDocument();
-        expect(getByText('§15-6 Yrkesrettet aktivitet')).toBeInTheDocument();
-        expect(getByText('Arbeid')).toBeInTheDocument();
-        expect(getByText('Dette er en test-begrunnelse')).toBeInTheDocument();
+        expect(screen.getByText('Periode med feilutbetaling')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByText('§15-4 Enslig forsørger')).toBeInTheDocument();
+        expect(screen.getByText('Ugift (3. ledd)')).toBeInTheDocument();
+        expect(screen.getByText('Annet')).toBeInTheDocument();
+        expect(screen.getByText('Annet fritekst')).toBeInTheDocument();
+        expect(screen.getByText('§15-6 Yrkesrettet aktivitet')).toBeInTheDocument();
+        expect(screen.getByText('Arbeid')).toBeInTheDocument();
+        expect(screen.getByText('Dette er en test-begrunnelse')).toBeInTheDocument();
 
         expect(gåVidereKnapp()).toBeInTheDocument();
     });
@@ -420,14 +417,14 @@ describe('FaktaContainer', () => {
     test('Velg hendelsesundertype automatisk ved kun ett valg', async () => {
         setupMock(lagFaktaResponse({ feilutbetaltePerioder: [feilutbetaltePerioder[0]] }));
 
-        const { getAllByRole } = renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD');
+        renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD');
 
         user.selectOptions(
             await screen.findByTestId('perioder.0.årsak'),
             HendelseType.Overgangsstønad
         );
 
-        expect(getAllByRole('combobox')).toHaveLength(1);
+        expect(screen.getAllByRole('combobox')).toHaveLength(1);
 
         expect(await screen.findByTestId('perioder.0.underårsak')).toHaveValue(
             HendelseUndertype.Barn8År

--- a/src/frontend/pages/fagsak/fakta/FaktaContainer.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/FaktaContainer.test.tsx
@@ -6,7 +6,7 @@ import type { Ressurs } from '~/typer/ressurs';
 import type { FaktaResponse } from '~/typer/tilbakekrevingstyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -99,6 +99,11 @@ const setupMock = (fakta: FaktaResponse): void => {
     }));
 };
 
+const gåVidereKnapp = (): HTMLElement =>
+    screen.getByRole('button', {
+        name: 'Gå videre til foreldelsessteget',
+    });
+
 describe('FaktaContainer', () => {
     let user: UserEvent;
     beforeEach(() => {
@@ -111,9 +116,10 @@ describe('FaktaContainer', () => {
 
         const { getByText, getByRole, getAllByRole, getByTestId, queryAllByText } =
             renderFaktaContainer(lagBehandling(), 'BARNETRYGD');
-        await waitFor(() => {
-            expect(getByText('Fakta fra feilutbetalingssaken')).toBeInTheDocument();
-        });
+
+        expect(
+            await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
+        ).toBeInTheDocument();
 
         expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
         expect(getByText('01.01.2020–31.10.2020')).toBeInTheDocument();
@@ -137,14 +143,8 @@ describe('FaktaContainer', () => {
 
         await user.click(getByTestId('brukerHarUttaltSeg.nei'));
 
-        await user.click(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(4);
-        });
+        await user.click(gåVidereKnapp());
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(4);
 
         await user.selectOptions(getByTestId('perioder.0.årsak'), HendelseType.BosattIRiket);
         await user.selectOptions(getByTestId('perioder.1.årsak'), HendelseType.BorMedSøker);
@@ -159,15 +159,9 @@ describe('FaktaContainer', () => {
 
         expect(getAllByRole('combobox')).toHaveLength(6);
 
-        await user.click(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        );
+        await user.click(gåVidereKnapp());
         // BorMedSøker har kun 1 underårsak og vil derfor bli automatisk satt
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
-        });
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
             getByTestId('perioder.0.underårsak'),
@@ -182,14 +176,9 @@ describe('FaktaContainer', () => {
             HendelseUndertype.BrukerFlyttetFraNorge
         );
 
-        await user.click(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        });
+        await user.click(gåVidereKnapp());
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+
         expect(mockedSettIkkePersistertKomponent).toHaveBeenCalledWith('fakta');
     });
 
@@ -199,9 +188,9 @@ describe('FaktaContainer', () => {
         const { getByText, getByLabelText, getByRole, getAllByRole, getByTestId, queryAllByText } =
             renderFaktaContainer(lagBehandling(), 'BARNETRYGD');
 
-        await waitFor(() => {
-            expect(getByText('Fakta fra feilutbetalingssaken')).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
+        ).toBeInTheDocument();
 
         expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
         expect(getByText('Opprett tilbakekreving, send varsel')).toBeInTheDocument();
@@ -209,14 +198,9 @@ describe('FaktaContainer', () => {
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
         expect(getAllByRole('combobox')).toHaveLength(3);
 
-        await user.click(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(5);
-        });
+        await user.click(gåVidereKnapp());
+
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(5);
 
         await user.click(
             getByRole('checkbox', {
@@ -229,12 +213,7 @@ describe('FaktaContainer', () => {
 
         expect(getAllByRole('combobox')).toHaveLength(6);
 
-        await user.click(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        );
-
+        await user.click(gåVidereKnapp());
         expect(queryAllByText('Feltet må fylles ut')).toHaveLength(4);
 
         await user.selectOptions(
@@ -248,14 +227,9 @@ describe('FaktaContainer', () => {
             ),
             'Begrunnelse'
         );
-        await user.click(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        });
+        await user.click(gåVidereKnapp());
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+
         expect(mockedSettIkkePersistertKomponent).toHaveBeenCalledWith('fakta');
     });
 
@@ -282,15 +256,15 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText, getByLabelText, getByTestId, getByRole } = renderFaktaContainer(
+        const { getByText, getByLabelText, getByTestId } = renderFaktaContainer(
             lagBehandling(),
             'BARNETRYGD',
             true
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta fra feilutbetalingssaken')).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
+        ).toBeInTheDocument();
 
         expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
@@ -307,11 +281,7 @@ describe('FaktaContainer', () => {
             'Dette er en test-begrunnelse'
         );
 
-        expect(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        ).toBeInTheDocument();
+        expect(gåVidereKnapp()).toBeInTheDocument();
     });
 
     test('Vis utfylt skjema - Overgangsstønad', async () => {
@@ -337,15 +307,15 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText, getByLabelText, getByTestId, getByRole } = renderFaktaContainer(
+        const { getByText, getByLabelText, getByTestId } = renderFaktaContainer(
             lagBehandling(),
             'OVERGANGSSTØNAD',
             true
         );
 
-        await waitFor(() => {
-            expect(getByText('Fakta fra feilutbetalingssaken')).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
+        ).toBeInTheDocument();
 
         expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
@@ -360,11 +330,7 @@ describe('FaktaContainer', () => {
             'Dette er en test-begrunnelse'
         );
 
-        expect(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        ).toBeInTheDocument();
+        expect(gåVidereKnapp()).toBeInTheDocument();
     });
 
     test('Vis utfylt skjema - lesevisning - Barnetrygd', async () => {
@@ -390,16 +356,11 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText, getByRole } = renderFaktaContainer(
-            lagBehandling(),
-            'BARNETRYGD',
-            true,
-            true
-        );
+        const { getByText } = renderFaktaContainer(lagBehandling(), 'BARNETRYGD', true, true);
 
-        await waitFor(() => {
-            expect(getByText('Fakta fra feilutbetalingssaken')).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
+        ).toBeInTheDocument();
 
         expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
@@ -411,11 +372,7 @@ describe('FaktaContainer', () => {
         expect(getByText('Barn over 6 år')).toBeInTheDocument();
         expect(getByText('Dette er en test-begrunnelse')).toBeInTheDocument();
 
-        expect(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        ).toBeInTheDocument();
+        expect(gåVidereKnapp()).toBeInTheDocument();
     });
 
     test('Vis utfylt skjema - lesevisning - Overgangsstønad', async () => {
@@ -441,16 +398,11 @@ describe('FaktaContainer', () => {
         });
         setupMock(faktaResponse);
 
-        const { getByText, getByRole } = renderFaktaContainer(
-            lagBehandling(),
-            'OVERGANGSSTØNAD',
-            true,
-            true
-        );
+        const { getByText } = renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD', true, true);
 
-        await waitFor(() => {
-            expect(getByText('Fakta fra feilutbetalingssaken')).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByRole('heading', { name: 'Fakta fra feilutbetalingssaken' })
+        ).toBeInTheDocument();
 
         expect(getByText('Periode med feilutbetaling')).toBeInTheDocument();
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
@@ -462,29 +414,23 @@ describe('FaktaContainer', () => {
         expect(getByText('Arbeid')).toBeInTheDocument();
         expect(getByText('Dette er en test-begrunnelse')).toBeInTheDocument();
 
-        expect(
-            getByRole('button', {
-                name: 'Gå videre til foreldelsessteget',
-            })
-        ).toBeInTheDocument();
+        expect(gåVidereKnapp()).toBeInTheDocument();
     });
 
     test('Velg hendelsesundertype automatisk ved kun ett valg', async () => {
         setupMock(lagFaktaResponse({ feilutbetaltePerioder: [feilutbetaltePerioder[0]] }));
 
-        const { getByTestId, getAllByRole } = renderFaktaContainer(
-            lagBehandling(),
-            'OVERGANGSSTØNAD'
-        );
+        const { getAllByRole } = renderFaktaContainer(lagBehandling(), 'OVERGANGSSTØNAD');
 
-        await waitFor(() => {
-            user.selectOptions(getByTestId('perioder.0.årsak'), HendelseType.Overgangsstønad);
-        });
+        user.selectOptions(
+            await screen.findByTestId('perioder.0.årsak'),
+            HendelseType.Overgangsstønad
+        );
 
         expect(getAllByRole('combobox')).toHaveLength(1);
 
-        await waitFor(() => {
-            expect(getByTestId('perioder.0.underårsak')).toHaveValue(HendelseUndertype.Barn8År);
-        });
+        expect(await screen.findByTestId('perioder.0.underårsak')).toHaveValue(
+            HendelseUndertype.Barn8År
+        );
     });
 });

--- a/src/frontend/pages/fagsak/fakta/FaktaContainer.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/FaktaContainer.test.tsx
@@ -134,7 +134,7 @@ describe('FaktaContainer', () => {
 
         expect(screen.getByText('01.05.2020–31.07.2020')).toBeInTheDocument();
         expect(screen.getByText('01.09.2020–31.10.2020')).toBeInTheDocument();
-        expect(screen.queryAllByText('1 333')).toHaveLength(3);
+        expect(screen.getAllByText('1 333')).toHaveLength(3);
 
         expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
         expect(screen.getAllByRole('combobox')).toHaveLength(3);
@@ -142,7 +142,7 @@ describe('FaktaContainer', () => {
         await user.click(screen.getByTestId('brukerHarUttaltSeg.nei'));
 
         await user.click(gåVidereKnapp());
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(4);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(4);
 
         await user.selectOptions(screen.getByTestId('perioder.0.årsak'), HendelseType.BosattIRiket);
         await user.selectOptions(screen.getByTestId('perioder.1.årsak'), HendelseType.BorMedSøker);
@@ -159,7 +159,7 @@ describe('FaktaContainer', () => {
 
         await user.click(gåVidereKnapp());
         // BorMedSøker har kun 1 underårsak og vil derfor bli automatisk satt
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(
             screen.getByTestId('perioder.0.underårsak'),
@@ -197,7 +197,7 @@ describe('FaktaContainer', () => {
 
         await user.click(gåVidereKnapp());
 
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(5);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(5);
 
         await user.click(
             screen.getByRole('checkbox', {
@@ -211,7 +211,7 @@ describe('FaktaContainer', () => {
         expect(screen.getAllByRole('combobox')).toHaveLength(6);
 
         await user.click(gåVidereKnapp());
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(4);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(4);
 
         await user.selectOptions(
             screen.getByTestId('perioder.0.underårsak'),

--- a/src/frontend/pages/fagsak/fakta/FaktaSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/FaktaSkjema.test.tsx
@@ -3,7 +3,8 @@ import type { JSX } from 'react';
 import type { FaktaOmFeilutbetaling, BehandlingOppdaterFaktaData } from '~/generated-new';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { expect } from 'vitest';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -94,25 +95,41 @@ const renderFakta = (
     };
 };
 
+const nesteKnapp = (): HTMLElement =>
+    screen.getByRole('button', { name: 'Gå videre til forhåndsvarselsteget' });
+const oppdagetDato = (): HTMLElement =>
+    screen.getByRole('textbox', {
+        name: 'Når ble feilutbetalingen oppdaget?',
+    });
+const årsakBeskrivelse = (): HTMLElement =>
+    screen.getByRole('textbox', {
+        name: 'Årsak til feilutbetalingen',
+    });
+
 describe('Fakta om feilutbetaling', () => {
+    let user: ReturnType<typeof userEvent.setup>;
+    beforeAll(() => {
+        user = userEvent.setup({ delay: null });
+    });
+
     describe('Rettslig grunnlag', () => {
         test('Forhåndsutfylt rettslig grunnlag fra backend', async () => {
             const {
-                result: { findByRole },
+                result: { getByRole },
             } = renderFakta();
 
-            const bestemmelse = await findByRole('combobox', { name: 'Velg bestemmelse' });
+            const bestemmelse = getByRole('combobox', { name: 'Velg bestemmelse' });
             expect(bestemmelse).toHaveTextContent('Annet');
             expect(bestemmelse).toHaveValue('ANNET');
 
-            const grunnlag = await findByRole('combobox', { name: 'Velg grunnlag' });
+            const grunnlag = getByRole('combobox', { name: 'Velg grunnlag' });
             expect(grunnlag).toHaveTextContent('Annet fritekst');
             expect(grunnlag).toHaveValue('ANNET_FRITEKST');
         });
 
         test('Defaults hentes fra input objekt', async () => {
             const {
-                result: { findByRole },
+                result: { getByRole },
             } = renderFakta({
                 vurdering: {
                     årsak: 'Svindel',
@@ -124,19 +141,12 @@ describe('Fakta om feilutbetaling', () => {
                 },
             });
 
-            const årsakBeskrivelse = await findByRole('textbox', {
-                name: 'Årsak til feilutbetalingen',
-            });
-            expect(årsakBeskrivelse).toHaveValue('Svindel');
+            expect(årsakBeskrivelse()).toHaveValue('Svindel');
+            expect(oppdagetDato()).toHaveValue('20.04.2020');
 
-            const oppdagetDato = await findByRole('textbox', {
-                name: 'Når ble feilutbetalingen oppdaget?',
-            });
-            expect(oppdagetDato).toHaveValue('20.04.2020');
-
-            expect(await findByRole('radio', { name: 'Nav' })).toBeChecked();
-            expect(await findByRole('radio', { name: 'Bruker' })).not.toBeChecked();
-            const oppdagetBeskrivelse = await findByRole('textbox', {
+            expect(getByRole('radio', { name: 'Nav' })).toBeChecked();
+            expect(getByRole('radio', { name: 'Bruker' })).not.toBeChecked();
+            const oppdagetBeskrivelse = getByRole('textbox', {
                 name: 'Hvordan ble feilutbetalingen oppdaget?',
             });
             expect(oppdagetBeskrivelse).toHaveValue('Fant et dokument under bordet.');
@@ -144,49 +154,29 @@ describe('Fakta om feilutbetaling', () => {
 
         test('Submit form with all values', async () => {
             const {
-                result: { findByRole },
+                result: { getByRole },
                 mutationBody,
             } = renderFakta({});
 
-            await waitFor(async () => {
-                fireEvent.change(
-                    await findByRole('textbox', { name: 'Årsak til feilutbetalingen' }),
-                    {
-                        target: { value: 'årsak' },
-                    }
-                );
-            });
+            await user.type(årsakBeskrivelse(), 'årsak');
+            await user.type(oppdagetDato(), '20.04.2020');
 
-            const oppdagetDato = await findByRole('textbox', {
-                name: 'Når ble feilutbetalingen oppdaget?',
-            });
-            fireEvent.change(oppdagetDato, { target: { value: '20.04.2020' } });
-
-            fireEvent.click(await findByRole('radio', { name: 'Nav' }));
-            fireEvent.change(
-                await findByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' }),
-                {
-                    target: { value: 'hvordan' },
-                }
+            await user.click(getByRole('radio', { name: 'Nav' }));
+            await user.type(
+                getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' }),
+                'hvordan'
             );
-            await waitFor(async () => {
-                fireEvent.click(
-                    await findByRole('button', { name: 'Gå videre til forhåndsvarselsteget' })
-                );
-            });
+
+            await user.click(nesteKnapp());
+
             await expect(mutationBody).resolves.toEqual({
-                path: {
-                    behandlingId: 'unik',
-                },
+                path: { behandlingId: 'unik' },
                 body: {
                     perioder: [
                         {
                             id: 'unik',
                             rettsligGrunnlag: [
-                                {
-                                    bestemmelse: 'ANNET',
-                                    grunnlag: 'ANNET_FRITEKST',
-                                },
+                                { bestemmelse: 'ANNET', grunnlag: 'ANNET_FRITEKST' },
                             ],
                         },
                     ],
@@ -202,31 +192,8 @@ describe('Fakta om feilutbetaling', () => {
             });
         });
 
-        test('bytter til submit knapp når dato endres', async () => {
-            const {
-                result: { findByRole },
-            } = renderFakta({});
-
-            const nesteKnapp = await findByRole('button', {
-                name: 'Gå videre til forhåndsvarselsteget',
-            });
-            expect(nesteKnapp).toHaveAttribute('type', 'submit');
-
-            const oppdagetDato = await findByRole('textbox', {
-                name: 'Når ble feilutbetalingen oppdaget?',
-            });
-
-            fireEvent.change(oppdagetDato, { target: { value: '20.04.2020' } });
-            const submitKnapp = await findByRole('button', {
-                name: 'Gå videre til forhåndsvarselsteget',
-            });
-            expect(submitKnapp).toHaveAttribute('type', 'submit');
-        });
-
-        test('bytter til submit knapp ', async () => {
-            const {
-                result: { findByRole },
-            } = renderFakta({
+        test('Bytter til submit knapp ', async () => {
+            renderFakta({
                 vurdering: {
                     årsak: 'Toast',
                     oppdaget: {
@@ -235,27 +202,19 @@ describe('Fakta om feilutbetaling', () => {
                         beskrivelse: 'VI OPPDAGET EN FEIL!!!!',
                     },
                 },
+                ferdigvurdert: true,
             });
 
-            const nesteKnapp = await findByRole('button', {
-                name: 'Gå videre til forhåndsvarselsteget',
-            });
-            expect(nesteKnapp).toHaveAttribute('type', 'submit');
+            expect(nesteKnapp()).toHaveAttribute('type', 'button');
 
-            const oppdagetDato = await findByRole('textbox', {
-                name: 'Når ble feilutbetalingen oppdaget?',
-            });
-            fireEvent.change(oppdagetDato, { target: { value: '' } });
+            await user.clear(oppdagetDato());
 
-            const submitKnapp = await findByRole('button', {
-                name: 'Gå videre til forhåndsvarselsteget',
-            });
-            expect(submitKnapp).toHaveAttribute('type', 'submit');
+            expect(nesteKnapp()).toHaveAttribute('type', 'submit');
         });
 
         test('Bytting av bestemmelse i rettslig grunnlag', async () => {
             const {
-                result: { findByRole },
+                result: { getByRole },
             } = renderFakta({
                 muligeRettsligGrunnlag: [
                     {
@@ -282,17 +241,14 @@ describe('Fakta om feilutbetaling', () => {
                 ],
             });
 
-            expect(await findByRole('combobox', { name: 'Velg grunnlag' })).toHaveValue('G1');
-
-            fireEvent.change(await findByRole('combobox', { name: 'Velg bestemmelse' }), {
-                target: { value: 'B2' },
-            });
-            expect(await findByRole('combobox', { name: 'Velg grunnlag' })).not.toHaveValue();
+            expect(getByRole('combobox', { name: 'Velg grunnlag' })).toHaveValue('G1');
+            await user.selectOptions(getByRole('combobox', { name: 'Velg bestemmelse' }), 'B2');
+            expect(getByRole('combobox', { name: 'Velg grunnlag' })).not.toHaveValue();
         });
 
         test('Ingen forhåndsutfylt rettslig grunnlag', async () => {
             const {
-                result: { findByRole },
+                result: { getByRole, findByRole },
             } = renderFakta({
                 muligeRettsligGrunnlag: [
                     {
@@ -324,53 +280,43 @@ describe('Fakta om feilutbetaling', () => {
                 },
             });
 
-            // Tving en endring for å få opp lagre-knappen(ikke nødvendig etter backend-endring)
-            fireEvent.change(await findByRole('textbox', { name: 'Årsak til feilutbetalingen' }), {
-                target: { value: 'Ny årsak' },
-            });
+            await user.click(nesteKnapp());
 
-            fireEvent.click(
-                await findByRole('button', { name: 'Gå videre til forhåndsvarselsteget' })
-            );
-            await waitFor(async () => {
-                const bestemmelseDropdown = await findByRole('combobox', {
-                    name: 'Velg bestemmelse',
-                });
-                expect(bestemmelseDropdown).not.toHaveValue();
-                expect(bestemmelseDropdown).toBeInvalid();
-                expect(bestemmelseDropdown).toHaveAccessibleDescription('Du må fylle inn en verdi');
-            });
-
-            fireEvent.change(
+            const bestemmelseDropdown = async (): Promise<HTMLElement> =>
                 await findByRole('combobox', {
                     name: 'Velg bestemmelse',
-                }),
-                { target: { value: 'B1' } }
+                });
+            expect(await bestemmelseDropdown()).not.toHaveValue();
+            expect(await bestemmelseDropdown()).toBeInvalid();
+            expect(await bestemmelseDropdown()).toHaveAccessibleDescription(
+                'Du må fylle inn en verdi'
             );
 
-            fireEvent.click(
-                await findByRole('button', { name: 'Gå videre til forhåndsvarselsteget' })
+            await user.type(
+                getByRole('combobox', {
+                    name: 'Velg bestemmelse',
+                }),
+                'B1'
             );
-            await waitFor(async () => {
-                const grunnlagDropdown = await findByRole('combobox', { name: 'Velg grunnlag' });
-                expect(grunnlagDropdown).not.toHaveValue();
-                expect(grunnlagDropdown).toBeInvalid();
-                expect(grunnlagDropdown).toHaveAccessibleDescription('Du må fylle inn en verdi');
-            });
+
+            await user.click(nesteKnapp());
+            const grunnlagDropdown = getByRole('combobox', { name: 'Velg grunnlag' });
+            expect(grunnlagDropdown).not.toHaveValue();
+            expect(grunnlagDropdown).toBeInvalid();
+            expect(grunnlagDropdown).toHaveAccessibleDescription('Du må fylle inn en verdi');
         });
 
-        test('dato felt valideres ved unblur', async () => {
+        test('Datofelt valideres ved unblur', async () => {
             const {
                 result: { findByRole },
             } = renderFakta();
 
-            fireEvent.change(await findByRole('textbox', { name: 'Årsak til feilutbetalingen' }), {
+            fireEvent.change(årsakBeskrivelse(), {
                 target: { value: 'Ny årsak' },
             });
 
-            fireEvent.click(
-                await findByRole('button', { name: 'Gå videre til forhåndsvarselsteget' })
-            );
+            fireEvent.click(nesteKnapp());
+
             const oppdagetDato = await findByRole('textbox', {
                 name: 'Når ble feilutbetalingen oppdaget?',
             });
@@ -380,24 +326,18 @@ describe('Fakta om feilutbetaling', () => {
             );
         });
 
-        test('Viser fortsatt Neste dersom fakta ikke er ferdigvurdert, men uendret', async () => {
-            const {
-                result: { findByRole },
-            } = renderFakta({
+        test('Viser fortsatt "Neste" dersom fakta ikke er ferdigvurdert, men uendret', async () => {
+            renderFakta({
                 ferdigvurdert: false,
             });
 
-            const submitKnapp = await findByRole('button', {
-                name: 'Gå videre til forhåndsvarselsteget',
-            });
+            const submitKnapp = nesteKnapp();
             expect(submitKnapp).toHaveAttribute('type', 'submit');
             expect(submitKnapp).toHaveTextContent('Neste');
         });
 
         test('Viser nesteknapp dersom fakta er ferdigvurdert og uendret', async () => {
-            const {
-                result: { findByRole },
-            } = renderFakta({
+            renderFakta({
                 ferdigvurdert: true,
                 vurdering: {
                     årsak: 'Begrunnelse',
@@ -409,16 +349,14 @@ describe('Fakta om feilutbetaling', () => {
                 },
             });
 
-            const submitKnapp = await findByRole('button', {
-                name: 'Gå videre til forhåndsvarselsteget',
-            });
+            const submitKnapp = nesteKnapp();
             expect(submitKnapp).toHaveAttribute('type', 'button');
             expect(submitKnapp).toHaveTextContent('Neste');
         });
 
         test('Valg av dato med musepeker - skal revalidere etter valg', async () => {
             const {
-                result: { findByRole },
+                result: { getByRole, findByRole },
             } = renderFakta({
                 vurdering: {
                     årsak: 'test',
@@ -431,24 +369,22 @@ describe('Fakta om feilutbetaling', () => {
             });
 
             const datoSelector = async (): Promise<HTMLElement> =>
-                findByRole('textbox', { name: 'Når ble feilutbetalingen oppdaget?' });
+                await findByRole('textbox', { name: 'Når ble feilutbetalingen oppdaget?' });
 
             fireEvent.change(await datoSelector(), { target: { value: 'lol' } });
-            fireEvent.click(
-                await findByRole('button', { name: 'Gå videre til forhåndsvarselsteget' })
-            );
+            fireEvent.click(nesteKnapp());
             expect(await datoSelector()).toHaveAccessibleDescription(
                 'Du må skrive en dato på denne måten: dd.mm.åååå'
             );
 
-            fireEvent.click(await findByRole('button', { name: 'Åpne datovelger' }));
-            fireEvent.change(await findByRole('combobox', { name: 'År' }), {
+            fireEvent.click(getByRole('button', { name: 'Åpne datovelger' }));
+            fireEvent.change(getByRole('combobox', { name: 'År' }), {
                 target: { value: '2020' },
             });
-            fireEvent.change(await findByRole('combobox', { name: 'Måned' }), {
+            fireEvent.change(getByRole('combobox', { name: 'Måned' }), {
                 target: { value: 'januar' },
             });
-            fireEvent.click(await findByRole('button', { name: 'onsdag 1' }));
+            fireEvent.click(getByRole('button', { name: 'onsdag 1' }));
 
             expect(await datoSelector()).toHaveValue('01.01.2020');
             expect(await datoSelector()).not.toHaveAccessibleDescription();
@@ -495,34 +431,24 @@ describe('Fakta om feilutbetaling', () => {
                 </FagsakContext>
             );
 
-            const { rerender, findByRole } = render(wrapMedProviders(utfyltFakta));
+            const { rerender, getByRole } = render(wrapMedProviders(utfyltFakta));
 
-            expect(await findByRole('textbox', { name: 'Årsak til feilutbetalingen' })).toHaveValue(
-                'Svindel'
-            );
-            expect(await findByRole('radio', { name: 'Nav' })).toBeChecked();
+            expect(årsakBeskrivelse()).toHaveValue('Svindel');
+            expect(getByRole('radio', { name: 'Nav' })).toBeChecked();
+            expect(oppdagetDato()).toHaveValue('20.04.2020');
             expect(
-                await findByRole('textbox', { name: 'Når ble feilutbetalingen oppdaget?' })
-            ).toHaveValue('20.04.2020');
-            expect(
-                await findByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
+                getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
             ).toHaveValue('Fant et dokument under bordet.');
 
             // Simulerer at faktaOmFeilutbetaling oppdateres med nullstilt data, slik det gjøres ved start på nytt
             rerender(wrapMedProviders(nullstiltFakta));
 
-            await waitFor(async () => {
-                expect(
-                    await findByRole('textbox', { name: 'Årsak til feilutbetalingen' })
-                ).toHaveValue('');
-            });
-            expect(await findByRole('radio', { name: 'Nav' })).not.toBeChecked();
-            expect(await findByRole('radio', { name: 'Bruker' })).not.toBeChecked();
+            expect(årsakBeskrivelse()).toHaveValue('');
+            expect(getByRole('radio', { name: 'Nav' })).not.toBeChecked();
+            expect(getByRole('radio', { name: 'Bruker' })).not.toBeChecked();
+            expect(oppdagetDato()).toHaveValue('');
             expect(
-                await findByRole('textbox', { name: 'Når ble feilutbetalingen oppdaget?' })
-            ).toHaveValue('');
-            expect(
-                await findByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
+                getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
             ).toHaveValue('');
         });
     });

--- a/src/frontend/pages/fagsak/fakta/FaktaSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/FaktaSkjema.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { JSX } from 'react';
 import type { FaktaOmFeilutbetaling, BehandlingOppdaterFaktaData } from '~/generated-new';
 
@@ -68,7 +67,7 @@ const faktaOmFeilutbetaling = (
 
 const renderFakta = (
     overrides?: Partial<FaktaOmFeilutbetaling>
-): { result: RenderResult; mutationBody: Promise<BehandlingOppdaterFaktaData> } => {
+): Promise<BehandlingOppdaterFaktaData> => {
     const client = createTestQueryClient();
     const mutationBody = new Promise<BehandlingOppdaterFaktaData>(resolve => {
         client.setMutationDefaults(['oppdaterFakta'], {
@@ -81,18 +80,17 @@ const renderFakta = (
         });
     });
 
-    return {
-        result: render(
-            <FagsakContext value={lagFagsak()}>
-                <TestBehandlingProvider behandling={lagBehandling({ behandlingId: 'unik' })}>
-                    <QueryClientProvider client={client}>
-                        <FaktaSkjema faktaOmFeilutbetaling={faktaOmFeilutbetaling(overrides)} />
-                    </QueryClientProvider>
-                </TestBehandlingProvider>
-            </FagsakContext>
-        ),
-        mutationBody,
-    };
+    render(
+        <FagsakContext value={lagFagsak()}>
+            <TestBehandlingProvider behandling={lagBehandling({ behandlingId: 'unik' })}>
+                <QueryClientProvider client={client}>
+                    <FaktaSkjema faktaOmFeilutbetaling={faktaOmFeilutbetaling(overrides)} />
+                </QueryClientProvider>
+            </TestBehandlingProvider>
+        </FagsakContext>
+    );
+
+    return mutationBody;
 };
 
 const nesteKnapp = (): HTMLElement =>
@@ -114,23 +112,19 @@ describe('Fakta om feilutbetaling', () => {
 
     describe('Rettslig grunnlag', () => {
         test('Forhåndsutfylt rettslig grunnlag fra backend', async () => {
-            const {
-                result: { getByRole },
-            } = renderFakta();
+            renderFakta();
 
-            const bestemmelse = getByRole('combobox', { name: 'Velg bestemmelse' });
+            const bestemmelse = screen.getByRole('combobox', { name: 'Velg bestemmelse' });
             expect(bestemmelse).toHaveTextContent('Annet');
             expect(bestemmelse).toHaveValue('ANNET');
 
-            const grunnlag = getByRole('combobox', { name: 'Velg grunnlag' });
+            const grunnlag = screen.getByRole('combobox', { name: 'Velg grunnlag' });
             expect(grunnlag).toHaveTextContent('Annet fritekst');
             expect(grunnlag).toHaveValue('ANNET_FRITEKST');
         });
 
         test('Defaults hentes fra input objekt', async () => {
-            const {
-                result: { getByRole },
-            } = renderFakta({
+            renderFakta({
                 vurdering: {
                     årsak: 'Svindel',
                     oppdaget: {
@@ -144,26 +138,23 @@ describe('Fakta om feilutbetaling', () => {
             expect(årsakBeskrivelse()).toHaveValue('Svindel');
             expect(oppdagetDato()).toHaveValue('20.04.2020');
 
-            expect(getByRole('radio', { name: 'Nav' })).toBeChecked();
-            expect(getByRole('radio', { name: 'Bruker' })).not.toBeChecked();
-            const oppdagetBeskrivelse = getByRole('textbox', {
+            expect(screen.getByRole('radio', { name: 'Nav' })).toBeChecked();
+            expect(screen.getByRole('radio', { name: 'Bruker' })).not.toBeChecked();
+            const oppdagetBeskrivelse = screen.getByRole('textbox', {
                 name: 'Hvordan ble feilutbetalingen oppdaget?',
             });
             expect(oppdagetBeskrivelse).toHaveValue('Fant et dokument under bordet.');
         });
 
         test('Submit form with all values', async () => {
-            const {
-                result: { getByRole },
-                mutationBody,
-            } = renderFakta({});
+            const mutationBody = renderFakta();
 
             await user.type(årsakBeskrivelse(), 'årsak');
             await user.type(oppdagetDato(), '20.04.2020');
 
-            await user.click(getByRole('radio', { name: 'Nav' }));
+            await user.click(screen.getByRole('radio', { name: 'Nav' }));
             await user.type(
-                getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' }),
+                screen.getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' }),
                 'hvordan'
             );
 
@@ -213,9 +204,7 @@ describe('Fakta om feilutbetaling', () => {
         });
 
         test('Bytting av bestemmelse i rettslig grunnlag', async () => {
-            const {
-                result: { getByRole },
-            } = renderFakta({
+            renderFakta({
                 muligeRettsligGrunnlag: [
                     {
                         bestemmelse: { nøkkel: 'B1', beskrivelse: 'ok' },
@@ -241,15 +230,16 @@ describe('Fakta om feilutbetaling', () => {
                 ],
             });
 
-            expect(getByRole('combobox', { name: 'Velg grunnlag' })).toHaveValue('G1');
-            await user.selectOptions(getByRole('combobox', { name: 'Velg bestemmelse' }), 'B2');
-            expect(getByRole('combobox', { name: 'Velg grunnlag' })).not.toHaveValue();
+            expect(screen.getByRole('combobox', { name: 'Velg grunnlag' })).toHaveValue('G1');
+            await user.selectOptions(
+                screen.getByRole('combobox', { name: 'Velg bestemmelse' }),
+                'B2'
+            );
+            expect(screen.getByRole('combobox', { name: 'Velg grunnlag' })).not.toHaveValue();
         });
 
         test('Ingen forhåndsutfylt rettslig grunnlag', async () => {
-            const {
-                result: { getByRole, findByRole },
-            } = renderFakta({
+            renderFakta({
                 muligeRettsligGrunnlag: [
                     {
                         bestemmelse: { nøkkel: 'B1', beskrivelse: 'ok' },
@@ -283,7 +273,7 @@ describe('Fakta om feilutbetaling', () => {
             await user.click(nesteKnapp());
 
             const bestemmelseDropdown = async (): Promise<HTMLElement> =>
-                await findByRole('combobox', {
+                await screen.findByRole('combobox', {
                     name: 'Velg bestemmelse',
                 });
             expect(await bestemmelseDropdown()).not.toHaveValue();
@@ -293,23 +283,21 @@ describe('Fakta om feilutbetaling', () => {
             );
 
             await user.type(
-                getByRole('combobox', {
+                screen.getByRole('combobox', {
                     name: 'Velg bestemmelse',
                 }),
                 'B1'
             );
 
             await user.click(nesteKnapp());
-            const grunnlagDropdown = getByRole('combobox', { name: 'Velg grunnlag' });
+            const grunnlagDropdown = screen.getByRole('combobox', { name: 'Velg grunnlag' });
             expect(grunnlagDropdown).not.toHaveValue();
             expect(grunnlagDropdown).toBeInvalid();
             expect(grunnlagDropdown).toHaveAccessibleDescription('Du må fylle inn en verdi');
         });
 
         test('Datofelt valideres ved unblur', async () => {
-            const {
-                result: { findByRole },
-            } = renderFakta();
+            renderFakta();
 
             fireEvent.change(årsakBeskrivelse(), {
                 target: { value: 'Ny årsak' },
@@ -317,7 +305,7 @@ describe('Fakta om feilutbetaling', () => {
 
             fireEvent.click(nesteKnapp());
 
-            const oppdagetDato = await findByRole('textbox', {
+            const oppdagetDato = await screen.findByRole('textbox', {
                 name: 'Når ble feilutbetalingen oppdaget?',
             });
             expect(oppdagetDato).toBeInvalid();
@@ -355,9 +343,7 @@ describe('Fakta om feilutbetaling', () => {
         });
 
         test('Valg av dato med musepeker - skal revalidere etter valg', async () => {
-            const {
-                result: { getByRole, findByRole },
-            } = renderFakta({
+            renderFakta({
                 vurdering: {
                     årsak: 'test',
                     oppdaget: {
@@ -369,7 +355,7 @@ describe('Fakta om feilutbetaling', () => {
             });
 
             const datoSelector = async (): Promise<HTMLElement> =>
-                await findByRole('textbox', { name: 'Når ble feilutbetalingen oppdaget?' });
+                await screen.findByRole('textbox', { name: 'Når ble feilutbetalingen oppdaget?' });
 
             fireEvent.change(await datoSelector(), { target: { value: 'lol' } });
             fireEvent.click(nesteKnapp());
@@ -377,14 +363,14 @@ describe('Fakta om feilutbetaling', () => {
                 'Du må skrive en dato på denne måten: dd.mm.åååå'
             );
 
-            fireEvent.click(getByRole('button', { name: 'Åpne datovelger' }));
-            fireEvent.change(getByRole('combobox', { name: 'År' }), {
+            fireEvent.click(screen.getByRole('button', { name: 'Åpne datovelger' }));
+            fireEvent.change(screen.getByRole('combobox', { name: 'År' }), {
                 target: { value: '2020' },
             });
-            fireEvent.change(getByRole('combobox', { name: 'Måned' }), {
+            fireEvent.change(screen.getByRole('combobox', { name: 'Måned' }), {
                 target: { value: 'januar' },
             });
-            fireEvent.click(getByRole('button', { name: 'onsdag 1' }));
+            fireEvent.click(screen.getByRole('button', { name: 'onsdag 1' }));
 
             expect(await datoSelector()).toHaveValue('01.01.2020');
             expect(await datoSelector()).not.toHaveAccessibleDescription();
@@ -431,24 +417,24 @@ describe('Fakta om feilutbetaling', () => {
                 </FagsakContext>
             );
 
-            const { rerender, getByRole } = render(wrapMedProviders(utfyltFakta));
+            const { rerender } = render(wrapMedProviders(utfyltFakta));
 
             expect(årsakBeskrivelse()).toHaveValue('Svindel');
-            expect(getByRole('radio', { name: 'Nav' })).toBeChecked();
+            expect(screen.getByRole('radio', { name: 'Nav' })).toBeChecked();
             expect(oppdagetDato()).toHaveValue('20.04.2020');
             expect(
-                getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
+                screen.getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
             ).toHaveValue('Fant et dokument under bordet.');
 
             // Simulerer at faktaOmFeilutbetaling oppdateres med nullstilt data, slik det gjøres ved start på nytt
             rerender(wrapMedProviders(nullstiltFakta));
 
             expect(årsakBeskrivelse()).toHaveValue('');
-            expect(getByRole('radio', { name: 'Nav' })).not.toBeChecked();
-            expect(getByRole('radio', { name: 'Bruker' })).not.toBeChecked();
+            expect(screen.getByRole('radio', { name: 'Nav' })).not.toBeChecked();
+            expect(screen.getByRole('radio', { name: 'Bruker' })).not.toBeChecked();
             expect(oppdagetDato()).toHaveValue('');
             expect(
-                getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
+                screen.getByRole('textbox', { name: 'Hvordan ble feilutbetalingen oppdaget?' })
             ).toHaveValue('');
         });
     });

--- a/src/frontend/pages/fagsak/fakta/FaktaSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/FaktaSkjema.test.tsx
@@ -111,7 +111,7 @@ describe('Fakta om feilutbetaling', () => {
     });
 
     describe('Rettslig grunnlag', () => {
-        test('Forhåndsutfylt rettslig grunnlag fra backend', async () => {
+        test('Forhåndsutfylt rettslig grunnlag fra backend', () => {
             renderFakta();
 
             const bestemmelse = screen.getByRole('combobox', { name: 'Velg bestemmelse' });
@@ -123,7 +123,7 @@ describe('Fakta om feilutbetaling', () => {
             expect(grunnlag).toHaveValue('ANNET_FRITEKST');
         });
 
-        test('Defaults hentes fra input objekt', async () => {
+        test('Defaults hentes fra input objekt', () => {
             renderFakta({
                 vurdering: {
                     årsak: 'Svindel',
@@ -314,7 +314,7 @@ describe('Fakta om feilutbetaling', () => {
             );
         });
 
-        test('Viser fortsatt "Neste" dersom fakta ikke er ferdigvurdert, men uendret', async () => {
+        test('Viser fortsatt "Neste" dersom fakta ikke er ferdigvurdert, men uendret', () => {
             renderFakta({
                 ferdigvurdert: false,
             });
@@ -324,7 +324,7 @@ describe('Fakta om feilutbetaling', () => {
             expect(submitKnapp).toHaveTextContent('Neste');
         });
 
-        test('Viser nesteknapp dersom fakta er ferdigvurdert og uendret', async () => {
+        test('Viser nesteknapp dersom fakta er ferdigvurdert og uendret', () => {
             renderFakta({
                 ferdigvurdert: true,
                 vurdering: {
@@ -378,7 +378,7 @@ describe('Fakta om feilutbetaling', () => {
     });
 
     describe('Start på nytt', () => {
-        test('Skjemadata nullstilles når faktaOmFeilutbetaling oppdateres med tomme verdier', async () => {
+        test('Skjemadata nullstilles når faktaOmFeilutbetaling oppdateres med tomme verdier', () => {
             const utfyltFakta = faktaOmFeilutbetaling({
                 vurdering: {
                     årsak: 'Svindel',

--- a/src/frontend/pages/fagsak/fakta/fakta-periode/FaktaPeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/fakta-periode/FaktaPeriodeSkjema.test.tsx
@@ -4,7 +4,7 @@ import type { BehandlingApiHook } from '~/api/behandling';
 import type { Ressurs } from '~/typer/ressurs';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { FagsakContext } from '~/context/FagsakContext';
 import { HendelseUndertype, HendelseType } from '~/kodeverk';
@@ -78,11 +78,9 @@ describe('FaktaPeriodeSkjema', () => {
     test('Skal sette default verdi til HendelseType.Annet når det kun er ett element i hendelseTyper lista', async () => {
         renderComponent(mockPeriode, [HendelseType.Annet]);
 
-        await waitFor(() => {
-            const selectElement = screen.getByTestId('perioder.0.årsak');
-            expect(selectElement).toBeInTheDocument();
-            expect(screen.getByText('Annet')).toBeInTheDocument();
-        });
+        const selectElement = await screen.findByTestId('perioder.0.årsak');
+        expect(selectElement).toBeInTheDocument();
+        expect(screen.getByText('Annet')).toBeInTheDocument();
     });
 
     test('Skal sette default verdi i underårsak-select når hendelsestype er valgt og det kun er én undertype', async () => {
@@ -93,19 +91,15 @@ describe('FaktaPeriodeSkjema', () => {
         };
         renderComponent(periodeWithValue, [HendelseType.Annet]);
 
-        await waitFor(() => {
-            const underSelectElement = screen.getByTestId('perioder.0.underårsak');
-            expect(underSelectElement).toHaveValue(HendelseUndertype.AnnetFritekst);
-        });
+        const underSelectElement = await screen.findByTestId('perioder.0.underårsak');
+        expect(underSelectElement).toHaveValue(HendelseUndertype.AnnetFritekst);
     });
 
     test('Skal velge "-" som default når det er flere elementer i hendelseTyper lista', async () => {
         const multipleHendelseTyper = [HendelseType.Annet, HendelseType.Dødsfall];
         renderComponent(mockPeriode, multipleHendelseTyper);
 
-        await waitFor(() => {
-            const selectElement = screen.getByTestId('perioder.0.årsak');
-            expect(selectElement).toHaveValue('-');
-        });
+        const selectElement = await screen.findByTestId('perioder.0.årsak');
+        expect(selectElement).toHaveValue('-');
     });
 });

--- a/src/frontend/pages/fagsak/fakta/fakta-periode/FaktaPeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/fakta/fakta-periode/FaktaPeriodeSkjema.test.tsx
@@ -1,5 +1,4 @@
 import type { FaktaPeriodeSkjemaData } from '../typer/fakta';
-import type { RenderResult } from '@testing-library/react';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { Ressurs } from '~/typer/ressurs';
 
@@ -41,10 +40,10 @@ vi.mock('~/api/behandling', () => ({
 const renderComponent = (
     periode: FaktaPeriodeSkjemaData,
     hendelseTyper: HendelseType[] | undefined
-): RenderResult => {
+): void => {
     const behandling = lagBehandling();
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider behandling={behandling}>

--- a/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
@@ -6,7 +6,7 @@ import type { Ressurs } from '~/typer/ressurs';
 import type { ForeldelsePeriode, ForeldelseResponse } from '~/typer/tilbakekrevingstyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -98,13 +98,11 @@ describe('ForeldelseContainer', () => {
 
     test('Vis og fyll ut perioder og send inn', async () => {
         setupMock(lagForeldelseResponse({ foreldetPerioder: foreldelsesperioder }));
-        const { getByText, getByRole, getByLabelText, queryAllByText, queryByText } =
+        const { getByText, getAllByText, getByRole, getByLabelText, queryAllByText, queryByText } =
             renderForeldelseContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText('Foreldelse')).toBeInTheDocument();
-            expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
-        });
+        expect(getByText('Foreldelse')).toBeInTheDocument();
+        expect(await screen.findByText('Detaljer for valgt periode')).toBeInTheDocument();
 
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
         expect(getByText('3 måneder')).toBeInTheDocument();
@@ -121,9 +119,9 @@ describe('ForeldelseContainer', () => {
                 name: 'Bekreft periode',
             })
         );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
-        });
+
+        expect(getAllByText('Feltet må fylles ut')).toHaveLength(2);
+
         await user.type(getByLabelText('Begrunn valget over'), 'Begrunnelse 1');
         await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
 
@@ -132,9 +130,7 @@ describe('ForeldelseContainer', () => {
                 name: 'Bekreft periode',
             })
         );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        });
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
         expect(
             getByRole('button', {
@@ -151,9 +147,8 @@ describe('ForeldelseContainer', () => {
                 name: 'Bekreft periode',
             })
         );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
-        });
+
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.type(getByLabelText('Begrunn valget over'), 'Begrunnelse 2');
         await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
@@ -163,9 +158,7 @@ describe('ForeldelseContainer', () => {
                 name: 'Bekreft periode',
             })
         );
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        });
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
         expect(queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
         expect(
@@ -206,23 +199,19 @@ describe('ForeldelseContainer', () => {
             true
         );
 
-        await waitFor(() => {
-            expect(getByText('Foreldelse')).toBeInTheDocument();
-            expect(queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
-            expect(
-                getByRole('button', {
-                    name: 'Gå videre til vilkårsvurderingssteget',
-                })
-            ).toBeEnabled();
-        });
+        expect(getByText('Foreldelse')).toBeInTheDocument();
+        expect(queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
+        expect(
+            getByRole('button', {
+                name: 'Gå videre til vilkårsvurderingssteget',
+            })
+        ).toBeEnabled();
 
-        await waitFor(() => {
-            user.click(
-                getByRole('button', {
-                    name: 'Advarsel fra 01.01.2020 til 31.03.2020',
-                })
-            );
-        });
+        await user.click(
+            await screen.findByRole('button', {
+                name: 'Advarsel fra 01.01.2020 til 31.03.2020',
+            })
+        );
 
         expect(
             getByRole('button', {
@@ -230,9 +219,7 @@ describe('ForeldelseContainer', () => {
             })
         ).toBeEnabled();
 
-        await waitFor(() => {
-            expect(queryByText('Detaljer for valgt periode')).toBeInTheDocument();
-        });
+        expect(queryByText('Detaljer for valgt periode')).toBeInTheDocument();
 
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
         expect(getByLabelText('Begrunn valget over')).toHaveValue('Begrunnelse 1');
@@ -297,12 +284,12 @@ describe('ForeldelseContainer', () => {
             true
         );
 
-        await waitFor(() => {
-            // Tittel skal alltid være synlig
-            expect(getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
-            // Første periode sitt endringspanel skal være åpnet by default i lesevisning, sjekker at riktige verdier er satt
-            expect(getByText('Detaljer for valgt periode', { selector: 'h2' })).toBeInTheDocument();
-        });
+        expect(getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
+
+        expect(
+            await screen.findByText('Detaljer for valgt periode', { selector: 'h2' })
+        ).toBeInTheDocument();
+
         expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
         expect(getByText('Begrunnelse 1')).toBeInTheDocument();
         expect(
@@ -349,10 +336,7 @@ describe('ForeldelseContainer', () => {
             })
         );
 
-        // Tittel skal alltid være synlig
-        await waitFor(() => {
-            expect(getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
-        });
+        expect(getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
 
         // Andre periode sitt endringspanel skal nå være åpnet, sjekker at riktige verdier er satt
         expect(getByText('Detaljer for valgt periode', { selector: 'h2' })).toBeInTheDocument();
@@ -402,9 +386,7 @@ describe('ForeldelseContainer', () => {
         setupMock(lagForeldelseResponse({ foreldetPerioder: [] }));
         const { getByText } = renderForeldelseContainer(lagBehandling(), false, false, true);
 
-        await waitFor(() => {
-            expect(getByText('Foreldelse')).toBeInTheDocument();
-        });
+        expect(getByText('Foreldelse')).toBeInTheDocument();
         expect(
             getByText(
                 'Perioden blir automatisk vurdert dersom det er mer enn 6 måneder til den er foreldet.'
@@ -423,13 +405,12 @@ describe('ForeldelseContainer', () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [] }));
             const { getByRole } = renderForeldelseContainer(lagBehandling(), false, false, true);
 
-            await waitFor(() => {
-                expect(
-                    getByRole('button', {
-                        name: 'Gå videre til vilkårsvurderingssteget',
-                    })
-                ).toBeInTheDocument();
-            });
+            expect(
+                getByRole('button', {
+                    name: 'Gå videre til vilkårsvurderingssteget',
+                })
+            ).toBeInTheDocument();
+
             expect(getByRole('button', { name: 'Gå tilbake til faktasteget' })).toBeInTheDocument();
         });
 
@@ -437,9 +418,7 @@ describe('ForeldelseContainer', () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [foreldelsesperioder[0]] }));
             const { getByRole, getByLabelText } = renderForeldelseContainer(lagBehandling(), false);
 
-            await waitFor(() => {
-                expect(getByLabelText('Begrunn valget over')).toBeInTheDocument();
-            });
+            expect(await screen.findByLabelText('Begrunn valget over')).toBeInTheDocument();
 
             await user.type(getByLabelText('Begrunn valget over'), 'Begrunnelse');
             await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
@@ -457,11 +436,10 @@ describe('ForeldelseContainer', () => {
 
         test('Vurdert steg med vurdert periode uten endringer viser Neste/Forrige', async () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [ikkeForeldetPeriode] }));
-            const { getByRole, getByText } = renderForeldelseContainer(lagBehandling(), true);
+            const { getByRole } = renderForeldelseContainer(lagBehandling(), true);
 
-            await waitFor(() => {
-                expect(getByText('Foreldelse')).toBeInTheDocument();
-            });
+            expect(await screen.findByText('Foreldelse')).toBeInTheDocument();
+
             expect(
                 getByRole('button', {
                     name: 'Gå videre til vilkårsvurderingssteget',

--- a/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
@@ -214,7 +214,7 @@ describe('ForeldelseContainer', () => {
             })
         ).toBeEnabled();
 
-        expect(screen.queryByText('Detaljer for valgt periode')).toBeInTheDocument();
+        expect(screen.getByText('Detaljer for valgt periode')).toBeInTheDocument();
 
         expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
         expect(screen.getByLabelText('Begrunn valget over')).toHaveValue('Begrunnelse 1');

--- a/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { BehandlingDto } from '~/generated';
@@ -31,9 +30,9 @@ const renderForeldelseContainer = (
     behandlet: boolean = false,
     lesemodus: boolean = false,
     autoutført: boolean = false
-): RenderResult => {
+): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider
@@ -98,77 +97,76 @@ describe('ForeldelseContainer', () => {
 
     test('Vis og fyll ut perioder og send inn', async () => {
         setupMock(lagForeldelseResponse({ foreldetPerioder: foreldelsesperioder }));
-        const { getByText, getAllByText, getByRole, getByLabelText, queryAllByText, queryByText } =
-            renderForeldelseContainer(lagBehandling());
+        renderForeldelseContainer(lagBehandling());
 
-        expect(getByText('Foreldelse')).toBeInTheDocument();
+        expect(screen.getByText('Foreldelse')).toBeInTheDocument();
         expect(await screen.findByText('Detaljer for valgt periode')).toBeInTheDocument();
 
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByText('3 måneder')).toBeInTheDocument();
-        expect(getByText('1 333')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByText('3 måneder')).toBeInTheDocument();
+        expect(screen.getByText('1 333')).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vilkårsvurderingssteget',
             })
         ).toBeDisabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Bekreft periode',
             })
         );
 
-        expect(getAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.type(getByLabelText('Begrunn valget over'), 'Begrunnelse 1');
-        await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
+        await user.type(screen.getByLabelText('Begrunn valget over'), 'Begrunnelse 1');
+        await user.click(screen.getByLabelText('Nei, perioden er ikke foreldet'));
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Bekreft periode',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Lagre og gå videre til vilkårsvurderingssteget',
             })
         ).toBeDisabled();
 
-        expect(getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
-        expect(getByText('2 måneder')).toBeInTheDocument();
-        expect(getByText('1 333')).toBeInTheDocument();
+        expect(screen.getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
+        expect(screen.getByText('2 måneder')).toBeInTheDocument();
+        expect(screen.getByText('1 333')).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Bekreft periode',
             })
         );
 
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.type(getByLabelText('Begrunn valget over'), 'Begrunnelse 2');
-        await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
+        await user.type(screen.getByLabelText('Begrunn valget over'), 'Begrunnelse 2');
+        await user.click(screen.getByLabelText('Nei, perioden er ikke foreldet'));
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Bekreft periode',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
-        expect(queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
+        expect(screen.queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Lagre og gå videre til vilkårsvurderingssteget',
             })
         ).toBeEnabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Lagre og gå videre til vilkårsvurderingssteget',
             })
         );
@@ -194,15 +192,12 @@ describe('ForeldelseContainer', () => {
         });
         setupMock(foreldelseResponse);
 
-        const { getByText, getByRole, getByLabelText, queryByText } = renderForeldelseContainer(
-            lagBehandling(),
-            true
-        );
+        renderForeldelseContainer(lagBehandling(), true);
 
-        expect(getByText('Foreldelse')).toBeInTheDocument();
-        expect(queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
+        expect(screen.getByText('Foreldelse')).toBeInTheDocument();
+        expect(screen.queryByText('Detaljer for valgt periode')).not.toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vilkårsvurderingssteget',
             })
         ).toBeEnabled();
@@ -214,46 +209,48 @@ describe('ForeldelseContainer', () => {
         );
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vilkårsvurderingssteget',
             })
         ).toBeEnabled();
 
-        expect(queryByText('Detaljer for valgt periode')).toBeInTheDocument();
+        expect(screen.queryByText('Detaljer for valgt periode')).toBeInTheDocument();
 
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByLabelText('Begrunn valget over')).toHaveValue('Begrunnelse 1');
-        expect(getByLabelText('Ja, perioden er foreldet')).toBeChecked();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByLabelText('Begrunn valget over')).toHaveValue('Begrunnelse 1');
+        expect(screen.getByLabelText('Ja, perioden er foreldet')).toBeChecked();
         expect(
-            getByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             })
         ).toHaveValue('01.01.2021');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         );
 
-        expect(getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
-        expect(getByLabelText('Begrunn valget over')).toHaveValue('Begrunnelse 2');
+        expect(screen.getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
+        expect(screen.getByLabelText('Begrunn valget over')).toHaveValue('Begrunnelse 2');
         expect(
-            getByLabelText('Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder')
+            screen.getByLabelText(
+                'Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder'
+            )
         ).toBeChecked();
         expect(
-            getByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             })
         ).toHaveValue('01.01.2021');
-        expect(getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
+        expect(screen.getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
             '24.12.2020'
         );
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vilkårsvurderingssteget',
             })
         ).toBeEnabled();
@@ -278,105 +275,109 @@ describe('ForeldelseContainer', () => {
             ],
         });
 
-        const { getByText, getByRole, getByLabelText } = renderForeldelseContainer(
-            lagBehandling({ status: 'FATTER_VEDTAK' }),
-            true,
-            true
-        );
+        renderForeldelseContainer(lagBehandling({ status: 'FATTER_VEDTAK' }), true, true);
 
-        expect(getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
+        expect(screen.getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
 
         expect(
             await screen.findByText('Detaljer for valgt periode', { selector: 'h2' })
         ).toBeInTheDocument();
 
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByText('Begrunnelse 1')).toBeInTheDocument();
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByText('Begrunnelse 1')).toBeInTheDocument();
         expect(
-            getByLabelText('Perioden er foreldet', {
+            screen.getByLabelText('Perioden er foreldet', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeChecked();
         expect(
-            getByLabelText('Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder', {
-                selector: 'input',
-                exact: false,
-            })
+            screen.getByLabelText(
+                'Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder',
+                {
+                    selector: 'input',
+                    exact: false,
+                }
+            )
         ).not.toBeChecked();
-        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
+        expect(screen.getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
 
         // Alle tidslinje knappene skal alltid være synlige
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Advarsel fra 01.01.2020 til 31.03.2020',
             })
         ).toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         ).toBeInTheDocument();
 
         // Knapper for navigering mellom faner skal alltid være synlige og enabled
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå tilbake til faktasteget',
             })
         ).toBeEnabled();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vilkårsvurderingssteget',
             })
         ).toBeEnabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         );
 
-        expect(getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
+        expect(screen.getByText('Foreldelse', { selector: 'h1' })).toBeInTheDocument();
 
         // Andre periode sitt endringspanel skal nå være åpnet, sjekker at riktige verdier er satt
-        expect(getByText('Detaljer for valgt periode', { selector: 'h2' })).toBeInTheDocument();
-        expect(getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
-        expect(getByText('Begrunnelse 2')).toBeInTheDocument();
         expect(
-            getByLabelText('Perioden er foreldet', {
+            screen.getByText('Detaljer for valgt periode', { selector: 'h2' })
+        ).toBeInTheDocument();
+        expect(screen.getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
+        expect(screen.getByText('Begrunnelse 2')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('Perioden er foreldet', {
                 selector: 'input',
                 exact: false,
             })
         ).not.toBeChecked();
         expect(
-            getByLabelText('Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder', {
-                selector: 'input',
-                exact: false,
-            })
+            screen.getByLabelText(
+                'Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder',
+                {
+                    selector: 'input',
+                    exact: false,
+                }
+            )
         ).toBeChecked();
-        expect(getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
+        expect(screen.getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
             '24.12.2020'
         );
-        expect(getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
+        expect(screen.getByLabelText('Foreldelsesfrist')).toHaveValue('01.01.2021');
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Advarsel fra 01.01.2020 til 31.03.2020',
             })
         ).toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå tilbake til faktasteget',
             })
         ).toBeEnabled();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vilkårsvurderingssteget',
             })
         ).toBeEnabled();
@@ -384,11 +385,11 @@ describe('ForeldelseContainer', () => {
 
     test('Vis autoutført', async () => {
         setupMock(lagForeldelseResponse({ foreldetPerioder: [] }));
-        const { getByText } = renderForeldelseContainer(lagBehandling(), false, false, true);
+        renderForeldelseContainer(lagBehandling(), false, false, true);
 
-        expect(getByText('Foreldelse')).toBeInTheDocument();
+        expect(screen.getByText('Foreldelse')).toBeInTheDocument();
         expect(
-            getByText(
+            screen.getByText(
                 'Perioden blir automatisk vurdert dersom det er mer enn 6 måneder til den er foreldet.'
             )
         ).toBeInTheDocument();
@@ -403,49 +404,53 @@ describe('ForeldelseContainer', () => {
 
         test('Autoutført steg uten vurdering viser Neste/Forrige', async () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [] }));
-            const { getByRole } = renderForeldelseContainer(lagBehandling(), false, false, true);
+            renderForeldelseContainer(lagBehandling(), false, false, true);
 
             expect(
-                getByRole('button', {
+                screen.getByRole('button', {
                     name: 'Gå videre til vilkårsvurderingssteget',
                 })
             ).toBeInTheDocument();
 
-            expect(getByRole('button', { name: 'Gå tilbake til faktasteget' })).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Gå tilbake til faktasteget' })
+            ).toBeInTheDocument();
         });
 
         test('Uvurdert steg viser Lagre-tekst når bruker vurderer en periode', async () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [foreldelsesperioder[0]] }));
-            const { getByRole, getByLabelText } = renderForeldelseContainer(lagBehandling(), false);
+            renderForeldelseContainer(lagBehandling(), false);
 
             expect(await screen.findByLabelText('Begrunn valget over')).toBeInTheDocument();
 
-            await user.type(getByLabelText('Begrunn valget over'), 'Begrunnelse');
-            await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
-            await user.click(getByRole('button', { name: 'Bekreft periode' }));
+            await user.type(screen.getByLabelText('Begrunn valget over'), 'Begrunnelse');
+            await user.click(screen.getByLabelText('Nei, perioden er ikke foreldet'));
+            await user.click(screen.getByRole('button', { name: 'Bekreft periode' }));
 
             expect(
-                getByRole('button', {
+                screen.getByRole('button', {
                     name: 'Lagre og gå videre til vilkårsvurderingssteget',
                 })
             ).toBeInTheDocument();
             expect(
-                getByRole('button', { name: 'Lagre og gå tilbake til faktasteget' })
+                screen.getByRole('button', { name: 'Lagre og gå tilbake til faktasteget' })
             ).toBeInTheDocument();
         });
 
         test('Vurdert steg med vurdert periode uten endringer viser Neste/Forrige', async () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [ikkeForeldetPeriode] }));
-            const { getByRole } = renderForeldelseContainer(lagBehandling(), true);
+            renderForeldelseContainer(lagBehandling(), true);
 
             expect(await screen.findByText('Foreldelse')).toBeInTheDocument();
 
             expect(
-                getByRole('button', {
+                screen.getByRole('button', {
                     name: 'Gå videre til vilkårsvurderingssteget',
                 })
             ).toBeInTheDocument();
-            expect(getByRole('button', { name: 'Gå tilbake til faktasteget' })).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Gå tilbake til faktasteget' })
+            ).toBeInTheDocument();
         });
     });
 });

--- a/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/ForeldelseContainer.test.tsx
@@ -383,7 +383,7 @@ describe('ForeldelseContainer', () => {
         ).toBeEnabled();
     });
 
-    test('Vis autoutført', async () => {
+    test('Vis autoutført', () => {
         setupMock(lagForeldelseResponse({ foreldetPerioder: [] }));
         renderForeldelseContainer(lagBehandling(), false, false, true);
 
@@ -402,7 +402,7 @@ describe('ForeldelseContainer', () => {
             foreldelsesvurderingstype: 'IKKE_FORELDET',
         } satisfies ForeldelsePeriode;
 
-        test('Autoutført steg uten vurdering viser Neste/Forrige', async () => {
+        test('Autoutført steg uten vurdering viser Neste/Forrige', () => {
             setupMock(lagForeldelseResponse({ foreldetPerioder: [] }));
             renderForeldelseContainer(lagBehandling(), false, false, true);
 

--- a/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
@@ -144,7 +144,7 @@ describe('ForeldelsePeriodeSkjema', () => {
         expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
     });
 
-    test('Åpner vurdert periode med tilleggsfrist ', async () => {
+    test('Åpner vurdert periode med tilleggsfrist ', () => {
         renderForeldelsePeriodeSkjema(
             lagForeldelsePeriodeSkjemaData({
                 foreldelsesvurderingstype: 'TILLEGGSFRIST',

--- a/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
@@ -48,7 +48,7 @@ describe('ForeldelsePeriodeSkjema', () => {
         expect(screen.queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
 
         await user.click(bekreftPeriodeKnapp(screen.getByRole));
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.click(screen.getByLabelText('Nei, perioden er ikke foreldet'));
 
@@ -56,7 +56,7 @@ describe('ForeldelsePeriodeSkjema', () => {
 
         await user.click(bekreftPeriodeKnapp(screen.getByRole));
 
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.type(screen.getByLabelText('Begrunn valget over'), 'begrunnelse');
 
@@ -80,8 +80,8 @@ describe('ForeldelsePeriodeSkjema', () => {
         ).toBeInTheDocument();
 
         await user.click(bekreftPeriodeKnapp(screen.getByRole));
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
-        expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Du må velge en gyldig dato')).toHaveLength(1);
 
         await user.type(screen.getByLabelText('Begrunn valget over'), 'begrunnelse');
         await user.type(
@@ -123,8 +123,8 @@ describe('ForeldelsePeriodeSkjema', () => {
         ).toBeInTheDocument();
 
         await user.click(bekreftPeriodeKnapp(screen.getByRole));
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
-        expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Du må velge en gyldig dato')).toHaveLength(2);
 
         await user.type(screen.getByLabelText('Begrunn valget over'), 'begrunnelse');
         await user.type(

--- a/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
@@ -1,9 +1,9 @@
 import type { ForeldelsePeriodeSkjemeData } from '../typer/foreldelse';
-import type { ByRoleMatcher, ByRoleOptions, RenderResult } from '@testing-library/react';
+import type { ByRoleMatcher, ByRoleOptions } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { ForeldelseHook } from '~/pages/fagsak/foreldelse/ForeldelseContext';
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { TestBehandlingProvider } from '~/testdata/behandlingContextFactory';
@@ -19,12 +19,13 @@ vi.mock('../ForeldelseContext', () => {
     };
 });
 
-const renderForeldelsePeriodeSkjema = (periode: ForeldelsePeriodeSkjemeData): RenderResult =>
+const renderForeldelsePeriodeSkjema = (periode: ForeldelsePeriodeSkjemeData): void => {
     render(
         <TestBehandlingProvider>
             <ForeldelsePeriodeSkjema periode={periode} />
         </TestBehandlingProvider>
     );
+};
 
 describe('ForeldelsePeriodeSkjema', () => {
     let user: UserEvent;
@@ -41,106 +42,110 @@ describe('ForeldelsePeriodeSkjema', () => {
         });
 
     test('Vurderer periode ikke foreldet ', async () => {
-        const { getByRole, getByText, getByLabelText, queryAllByText, queryByLabelText } =
-            renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
+        renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
 
-        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
-        expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
+        expect(screen.getByText('Detaljer for valgt periode')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.click(getByLabelText('Nei, perioden er ikke foreldet'));
+        await user.click(screen.getByLabelText('Nei, perioden er ikke foreldet'));
 
-        expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
 
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
 
-        await user.type(getByLabelText('Begrunn valget over'), 'begrunnelse');
+        await user.type(screen.getByLabelText('Begrunn valget over'), 'begrunnelse');
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Vurderer periode foreldet ', async () => {
-        const { getByLabelText, getByRole, getByText, queryByLabelText, queryAllByText } =
-            renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
+        renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
 
-        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
-        expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
+        expect(screen.getByText('Detaljer for valgt periode')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
 
-        await user.click(getByLabelText('Ja, perioden er foreldet'));
+        await user.click(screen.getByLabelText('Ja, perioden er foreldet'));
 
         expect(
-            queryByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeInTheDocument();
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
-        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(1);
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(1);
 
-        await user.type(getByLabelText('Begrunn valget over'), 'begrunnelse');
+        await user.type(screen.getByLabelText('Begrunn valget over'), 'begrunnelse');
         await user.type(
-            getByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             }),
             '14.09.2020'
         );
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
-        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
+        expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Vurderer periode til å bruke tilleggsfrist ', async () => {
-        const { getByText, getByRole, getByLabelText, queryByLabelText, queryAllByText } =
-            renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
+        renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
 
-        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
-        expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
+        expect(screen.getByText('Detaljer for valgt periode')).toBeInTheDocument();
+        expect(screen.queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
         expect(
-            queryByLabelText('Dato for når feilutbetaling ble oppdaget')
+            screen.queryByLabelText('Dato for når feilutbetaling ble oppdaget')
         ).not.toBeInTheDocument();
 
         await user.click(
-            getByLabelText('Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder')
+            screen.getByLabelText(
+                'Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder'
+            )
         );
 
         expect(
-            queryByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeInTheDocument();
-        expect(queryByLabelText('Dato for når feilutbetaling ble oppdaget')).toBeInTheDocument();
+        expect(
+            screen.getByLabelText('Dato for når feilutbetaling ble oppdaget')
+        ).toBeInTheDocument();
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
-        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(2);
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(2);
 
-        await user.type(getByLabelText('Begrunn valget over'), 'begrunnelse');
+        await user.type(screen.getByLabelText('Begrunn valget over'), 'begrunnelse');
         await user.type(
-            getByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             }),
             '14.09.2020'
         );
-        await user.type(getByLabelText('Dato for når feilutbetaling ble oppdaget'), '14.06.2020');
+        await user.type(
+            screen.getByLabelText('Dato for når feilutbetaling ble oppdaget'),
+            '14.06.2020'
+        );
 
-        await user.click(bekreftPeriodeKnapp(getByRole));
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        expect(queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
+        await user.click(bekreftPeriodeKnapp(screen.getByRole));
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Du må velge en gyldig dato')).toHaveLength(0);
     });
 
     test('Åpner vurdert periode med tilleggsfrist ', async () => {
-        const { getByLabelText, getByText, queryByLabelText } = renderForeldelsePeriodeSkjema(
+        renderForeldelsePeriodeSkjema(
             lagForeldelsePeriodeSkjemaData({
                 foreldelsesvurderingstype: 'TILLEGGSFRIST',
                 begrunnelse: 'Vurdert',
@@ -149,26 +154,30 @@ describe('ForeldelsePeriodeSkjema', () => {
             })
         );
 
-        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
+        expect(screen.getByText('Detaljer for valgt periode')).toBeInTheDocument();
         expect(
-            queryByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeInTheDocument();
-        expect(queryByLabelText('Dato for når feilutbetaling ble oppdaget')).toBeInTheDocument();
-
-        expect(getByLabelText('Begrunn valget over')).toHaveValue('Vurdert');
         expect(
-            getByLabelText('Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder')
+            screen.getByLabelText('Dato for når feilutbetaling ble oppdaget')
+        ).toBeInTheDocument();
+
+        expect(screen.getByLabelText('Begrunn valget over')).toHaveValue('Vurdert');
+        expect(
+            screen.getByLabelText(
+                'Nei, perioden er ikke foreldet. Tilleggsfristen på 10 år gjelder'
+            )
         ).toBeChecked();
         expect(
-            getByLabelText('Foreldelsesfrist', {
+            screen.getByLabelText('Foreldelsesfrist', {
                 selector: 'input',
                 exact: false,
             })
         ).toHaveValue('04.12.2019');
-        expect(getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
+        expect(screen.getByLabelText('Dato for når feilutbetaling ble oppdaget')).toHaveValue(
             '18.09.2019'
         );
     });

--- a/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/ForeldelsePeriodeSkjema.test.tsx
@@ -3,7 +3,7 @@ import type { ByRoleMatcher, ByRoleOptions, RenderResult } from '@testing-librar
 import type { UserEvent } from '@testing-library/user-event';
 import type { ForeldelseHook } from '~/pages/fagsak/foreldelse/ForeldelseContext';
 
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { TestBehandlingProvider } from '~/testdata/behandlingContextFactory';
@@ -44,7 +44,7 @@ describe('ForeldelsePeriodeSkjema', () => {
         const { getByRole, getByText, getByLabelText, queryAllByText, queryByLabelText } =
             renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
 
-        await waitFor(() => expect(getByText('Detaljer for valgt periode')).toBeInTheDocument());
+        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
         expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
 
         await user.click(bekreftPeriodeKnapp(getByRole));
@@ -68,7 +68,7 @@ describe('ForeldelsePeriodeSkjema', () => {
         const { getByLabelText, getByRole, getByText, queryByLabelText, queryAllByText } =
             renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
 
-        await waitFor(() => expect(getByText('Detaljer for valgt periode')).toBeInTheDocument());
+        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
         expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
 
         await user.click(getByLabelText('Ja, perioden er foreldet'));
@@ -102,7 +102,7 @@ describe('ForeldelsePeriodeSkjema', () => {
         const { getByText, getByRole, getByLabelText, queryByLabelText, queryAllByText } =
             renderForeldelsePeriodeSkjema(lagForeldelsePeriodeSkjemaData());
 
-        await waitFor(() => expect(getByText('Detaljer for valgt periode')).toBeInTheDocument());
+        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
         expect(queryByLabelText('Foreldelsesfrist')).not.toBeInTheDocument();
         expect(
             queryByLabelText('Dato for når feilutbetaling ble oppdaget')
@@ -149,7 +149,7 @@ describe('ForeldelsePeriodeSkjema', () => {
             })
         );
 
-        await waitFor(() => expect(getByText('Detaljer for valgt periode')).toBeInTheDocument());
+        expect(getByText('Detaljer for valgt periode')).toBeInTheDocument();
         expect(
             queryByLabelText('Foreldelsesfrist', {
                 selector: 'input',

--- a/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/splitt-periode/SplittPeriode.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/splitt-periode/SplittPeriode.test.tsx
@@ -22,13 +22,13 @@ describe('SplittPeriode - Foreldelse', () => {
         );
 
         expect(screen.getByRole('button', { name: 'Del opp perioden' })).toBeInTheDocument();
-        expect(screen.queryAllByText('Del opp perioden')).toHaveLength(1);
+        expect(screen.getAllByText('Del opp perioden')).toHaveLength(1);
         expect(screen.queryByText('01.01.2021 - 30.04.2021')).not.toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: 'Del opp perioden' }));
 
-        expect(screen.queryAllByText('Del opp perioden')).toHaveLength(2);
-        expect(screen.queryByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
+        expect(screen.getAllByText('Del opp perioden')).toHaveLength(2);
+        expect(screen.getByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
         expect(screen.getByRole('heading', { name: 'Del opp perioden' })).toBeInTheDocument();
         expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
         expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue(

--- a/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/splitt-periode/SplittPeriode.test.tsx
+++ b/src/frontend/pages/fagsak/foreldelse/foreldelse-periode/splitt-periode/SplittPeriode.test.tsx
@@ -1,6 +1,6 @@
 import type { UserEvent } from '@testing-library/user-event';
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { TestBehandlingProvider } from '~/testdata/behandlingContextFactory';
@@ -15,22 +15,24 @@ describe('SplittPeriode - Foreldelse', () => {
     });
 
     test('Åpning av modal', async () => {
-        const { getByLabelText, getByRole, queryAllByText, queryByText } = render(
+        render(
             <TestBehandlingProvider>
                 <SplittPeriode periode={lagForeldelsePeriodeSkjemaData()} onBekreft={vi.fn()} />
             </TestBehandlingProvider>
         );
 
-        expect(getByRole('button', { name: 'Del opp perioden' })).toBeInTheDocument();
-        expect(queryAllByText('Del opp perioden')).toHaveLength(1);
-        expect(queryByText('01.01.2021 - 30.04.2021')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Del opp perioden' })).toBeInTheDocument();
+        expect(screen.queryAllByText('Del opp perioden')).toHaveLength(1);
+        expect(screen.queryByText('01.01.2021 - 30.04.2021')).not.toBeInTheDocument();
 
-        await user.click(getByRole('button', { name: 'Del opp perioden' }));
+        await user.click(screen.getByRole('button', { name: 'Del opp perioden' }));
 
-        expect(queryAllByText('Del opp perioden')).toHaveLength(2);
-        expect(queryByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
-        expect(getByRole('heading', { name: 'Del opp perioden' })).toBeInTheDocument();
-        expect(getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
-        expect(getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue('januar 2021');
+        expect(screen.queryAllByText('Del opp perioden')).toHaveLength(2);
+        expect(screen.queryByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Del opp perioden' })).toBeInTheDocument();
+        expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
+        expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue(
+            'januar 2021'
+        );
     });
 });

--- a/src/frontend/pages/fagsak/forhåndsvarsel/Forhåndsvarsel.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/Forhåndsvarsel.test.tsx
@@ -3,7 +3,7 @@ import type { RessursVarselbrevtekst } from '~/generated';
 import type { FaktaOmFeilutbetaling, ForhaandsvarselResponse } from '~/generated-new';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, type RenderResult, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Suspense } from 'react';
 
@@ -59,17 +59,14 @@ const lagFaktaOmFeilutbetaling = (vedtaksdato = '2025-01-15'): FaktaOmFeilutbeta
     ferdigvurdert: false,
 });
 
-const renderForhåndsvarsel = (
-    forhåndsvarselResponse = lagForhåndsvarselResponse()
-): RenderResult => {
+const renderForhåndsvarsel = (forhåndsvarselResponse = lagForhåndsvarselResponse()): void => {
     const queryClient = createTestQueryClient();
     const pathOptions = { path: { behandlingId: BEHANDLING_ID } };
 
     queryClient.setQueryData(behandlingForhandsvarselQueryKey(pathOptions), forhåndsvarselResponse);
     queryClient.setQueryData(hentForhåndsvarselTekstQueryKey(pathOptions), lagVarselbrevtekster());
     queryClient.setQueryData(behandlingFaktaQueryKey(pathOptions), lagFaktaOmFeilutbetaling());
-
-    return render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider>
                 <QueryClientProvider client={queryClient}>

--- a/src/frontend/pages/fagsak/forhåndsvarsel/Forhåndsvarsel.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/Forhåndsvarsel.test.tsx
@@ -142,7 +142,7 @@ describe('Forhåndsvarsel', () => {
         await user.click(nesteKnapp());
 
         expect(
-            await screen.findByText('Du må velge om det skal sendes forhåndsvarsel')
+            screen.getByText('Du må velge om det skal sendes forhåndsvarsel')
         ).toBeInTheDocument();
     });
 
@@ -168,7 +168,7 @@ describe('Forhåndsvarsel', () => {
 
         await user.click(sendKnapp());
 
-        expect(await screen.findByText('Du må fylle inn en verdi')).toBeInTheDocument();
+        expect(screen.getByText('Du må fylle inn en verdi')).toBeInTheDocument();
     });
 
     test('Viser read-only radio med Ja valgt når varsel er sendt', () => {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/Forhåndsvarsel.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/Forhåndsvarsel.test.tsx
@@ -97,9 +97,6 @@ describe('Forhåndsvarsel', () => {
     const sendKnapp = (): HTMLElement =>
         screen.getByRole('button', { name: 'Send forhåndsvarselet' });
 
-    const visBrevetKnapp = (): HTMLElement | null =>
-        screen.queryByRole('button', { name: 'Vis brevet' });
-
     test('Viser spørsmål om forhåndsvarsel', () => {
         renderForhåndsvarsel();
 
@@ -128,7 +125,7 @@ describe('Forhåndsvarsel', () => {
     test('Viser ikke "Vis brevet" før Ja er valgt', () => {
         renderForhåndsvarsel();
 
-        expect(visBrevetKnapp()).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Vis brevet' })).not.toBeInTheDocument();
     });
 
     test('Viser "Vis brevet" når Ja er valgt', async () => {
@@ -136,7 +133,7 @@ describe('Forhåndsvarsel', () => {
 
         await user.click(within(skalSendesRadioGroup()).getByRole('radio', { name: 'Ja' }));
 
-        expect(visBrevetKnapp()).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Vis brevet' })).toBeInTheDocument();
     });
 
     test('Viser feilmelding ved submit uten valg', async () => {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/Forhåndsvarsel.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/Forhåndsvarsel.test.tsx
@@ -2,7 +2,8 @@ import type { RenderResult } from '@testing-library/react';
 import type { BehandlingDto, ForhåndsvarselDto } from '~/generated';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { userEvent, type UserEvent } from '@testing-library/user-event';
 
 import { FagsakContext } from '~/context/FagsakContext';
 import { TestBehandlingProvider } from '~/testdata/behandlingContextFactory';
@@ -52,9 +53,11 @@ const renderForhåndsvarsel = (behandling: BehandlingDto = lagBehandlingDto()): 
 };
 
 describe('Forhåndsvarsel', () => {
+    let user: UserEvent;
+
     beforeEach(() => {
         vi.clearAllMocks();
-
+        user = userEvent.setup();
         vi.mocked(useForhåndsvarselQueries).mockReturnValue(lagForhåndsvarselQueries());
         vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
     });
@@ -429,11 +432,9 @@ describe('Forhåndsvarsel', () => {
             renderForhåndsvarsel();
 
             const nesteKnapp = await screen.findByRole('button', { name: 'Neste' });
-            fireEvent.click(nesteKnapp);
+            await user.click(nesteKnapp);
 
-            await waitFor(() => {
-                expect(mockMutations.navigerTilNeste).toHaveBeenCalled();
-            });
+            expect(mockMutations.navigerTilNeste).toHaveBeenCalled();
             expect(mockMutations.sendBrukeruttalelse).not.toHaveBeenCalled();
         });
 
@@ -462,14 +463,12 @@ describe('Forhåndsvarsel', () => {
             const beskrivelsesFelt = await screen.findByLabelText(
                 'Forklar hvorfor forhåndsvarselet ikke skal bli sendt'
             );
-            fireEvent.change(beskrivelsesFelt, { target: { value: 'Endret beskrivelse' } });
+            await user.type(beskrivelsesFelt, 'Endret beskrivelse');
 
             const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
-            fireEvent.click(nesteKnapp);
+            await user.click(nesteKnapp);
 
-            await waitFor(() => {
-                expect(mockMutations.sendUnntak).toHaveBeenCalled();
-            });
+            expect(mockMutations.sendUnntak).toHaveBeenCalled();
             expect(mockMutations.sendBrukeruttalelse).not.toHaveBeenCalled();
         });
 
@@ -496,14 +495,12 @@ describe('Forhåndsvarsel', () => {
             renderForhåndsvarsel();
 
             const kommentarFelt = await screen.findByLabelText('Kommentar til valget over');
-            fireEvent.change(kommentarFelt, { target: { value: 'Endret kommentar' } });
+            await user.type(kommentarFelt, 'Endret kommentar');
 
             const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
-            fireEvent.click(nesteKnapp);
+            await user.click(nesteKnapp);
 
-            await waitFor(() => {
-                expect(mockMutations.sendBrukeruttalelse).toHaveBeenCalled();
-            });
+            expect(mockMutations.sendBrukeruttalelse).toHaveBeenCalled();
             expect(mockMutations.sendUnntak).not.toHaveBeenCalled();
         });
 
@@ -633,18 +630,16 @@ describe('Forhåndsvarsel', () => {
             });
 
             const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
-            fireEvent.click(nesteKnapp);
+            await user.click(nesteKnapp);
 
             const feilmelding = await screen.findByText('Du må velge om brukeren har uttalt seg');
             expect(feilmelding).toBeInTheDocument();
 
-            fireEvent.click(within(brukeruttalelseFieldset).getByLabelText('Nei'));
+            await user.click(within(brukeruttalelseFieldset).getByLabelText('Nei'));
 
-            await waitFor(() => {
-                expect(
-                    screen.queryByText('Du må velge om brukeren har uttalt seg')
-                ).not.toBeInTheDocument();
-            });
+            expect(
+                screen.queryByText('Du må velge om brukeren har uttalt seg')
+            ).not.toBeInTheDocument();
         });
     });
 
@@ -680,9 +675,8 @@ describe('Forhåndsvarsel', () => {
             ).toBeInTheDocument();
 
             fireEvent.click(within(brukeruttalelseFieldset).getByLabelText('Nei'));
-            await waitFor(() => {
-                expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
-            });
+
+            expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
         });
 
         test('Viser "Neste" når bruker bytter skalSendeForhåndsvarsel fra Nei til Ja og tilbake til Nei', async () => {
@@ -716,9 +710,7 @@ describe('Forhåndsvarsel', () => {
             ).toBeInTheDocument();
 
             fireEvent.click(within(skalSendeFieldset).getByLabelText('Nei'));
-            await waitFor(() => {
-                expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
-            });
+            expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
         });
 
         test('Viser "Neste" når bruker bytter begrunnelseForUnntak og tilbake til opprinnelig', async () => {
@@ -752,9 +744,7 @@ describe('Forhåndsvarsel', () => {
             ).toBeInTheDocument();
 
             fireEvent.click(within(begrunnelseFieldset).getByLabelText(/forvaltningsloven §16c/i));
-            await waitFor(() => {
-                expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
-            });
+            expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
         });
     });
 

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/Forhåndsvarsel.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/Forhåndsvarsel.test.tsx
@@ -80,26 +80,26 @@ describe('Forhåndsvarsel', () => {
         expect(screen.getByLabelText('Nei')).toBeInTheDocument();
     });
 
-    test('Viser skjema for opprettelse når Ja er valgt', async () => {
+    test('Viser skjema for opprettelse når Ja er valgt', () => {
         renderForhåndsvarsel();
 
         expect(screen.queryByText(/Opprett forhåndsvarsel/)).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByLabelText('Ja'));
 
-        expect(await screen.findByText(/Opprett forhåndsvarsel/)).toBeInTheDocument();
+        expect(screen.getByText(/Opprett forhåndsvarsel/)).toBeInTheDocument();
     });
 
-    test('Viser forhåndsvisning knapp når Ja er valgt og fritekst er fyllt ut', async () => {
+    test('Viser forhåndsvisning knapp når Ja er valgt og fritekst er fyllt ut', () => {
         renderForhåndsvarsel();
 
         fireEvent.click(screen.getByLabelText('Ja'));
 
-        expect(await screen.findByText(/Opprett forhåndsvarsel/)).toBeInTheDocument();
+        expect(screen.getByText(/Opprett forhåndsvarsel/)).toBeInTheDocument();
         const fritekstFelt = screen.getByLabelText(/Legg til utdypende tekst/i);
         fireEvent.change(fritekstFelt, { target: { value: 'Dette er en fritekst' } });
 
-        expect(await screen.findByRole('button', { name: 'Vis brevet' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Vis brevet' })).toBeInTheDocument();
     });
 
     test('Viser skjema for unntak når Nei er valgt', () => {
@@ -128,7 +128,7 @@ describe('Forhåndsvarsel', () => {
         expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
     });
 
-    test('Låser valg når varsel er sendt', async () => {
+    test('Låser valg når varsel er sendt', () => {
         const mockQueries = vi.mocked(useForhåndsvarselQueries);
         mockQueries.mockReturnValue(
             lagForhåndsvarselQueries({
@@ -140,14 +140,14 @@ describe('Forhåndsvarsel', () => {
 
         renderForhåndsvarsel();
 
-        const radioGroup = await screen.findByRole('radiogroup', {
+        const radioGroup = screen.getByRole('radiogroup', {
             name: /skal det sendes forhåndsvarsel om tilbakekreving/i,
         });
         expect(radioGroup).toHaveClass('aksel-fieldset--readonly');
     });
 
     describe('Viser "nei"-valg og default values når unntak er sendt inn', () => {
-        test('IKKE_PRAKTISK_MULIG', async () => {
+        test('IKKE_PRAKTISK_MULIG', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -162,7 +162,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const forhåndsvarselRadioGroup = await screen.findByRole('radiogroup', {
+            const forhåndsvarselRadioGroup = screen.getByRole('radiogroup', {
                 name: /skal det sendes forhåndsvarsel om tilbakekreving/i,
             });
             expect(
@@ -203,27 +203,27 @@ describe('Forhåndsvarsel', () => {
     });
 
     describe('Knappetekst i ActionBar', () => {
-        test('Viser "Send forhåndsvarselet" når Ja er valgt og varsel ikke er sendt', async () => {
+        test('Viser "Send forhåndsvarselet" når Ja er valgt og varsel ikke er sendt', () => {
             renderForhåndsvarsel(lagBehandlingDto({ varselSendt: false }));
 
             fireEvent.click(screen.getByLabelText('Ja'));
 
             expect(
-                await screen.findByRole('button', { name: 'Send forhåndsvarselet' })
+                screen.getByRole('button', { name: 'Send forhåndsvarselet' })
             ).toBeInTheDocument();
         });
 
-        test('Viser "Lagre og gå til neste" når Nei er valgt (for å sende unntak)', async () => {
+        test('Viser "Lagre og gå til neste" når Nei er valgt (for å sende unntak)', () => {
             renderForhåndsvarsel(lagBehandlingDto({ varselSendt: false }));
 
             fireEvent.click(screen.getByLabelText('Nei'));
 
             expect(
-                await screen.findByRole('button', { name: 'Lagre og gå til neste' })
+                screen.getByRole('button', { name: 'Lagre og gå til neste' })
             ).toBeInTheDocument();
         });
 
-        test('Viser "Lagre og gå til neste" når kun kommentarfeltet i uttalelse endres', async () => {
+        test('Viser "Lagre og gå til neste" når kun kommentarfeltet i uttalelse endres', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -242,15 +242,15 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const kommentarFelt = await screen.findByLabelText('Kommentar til valget over');
+            const kommentarFelt = screen.getByLabelText('Kommentar til valget over');
             fireEvent.change(kommentarFelt, { target: { value: 'Endret kommentar' } });
 
             expect(
-                await screen.findByRole('button', { name: 'Lagre og gå til neste' })
+                screen.getByRole('button', { name: 'Lagre og gå til neste' })
             ).toBeInTheDocument();
         });
 
-        test('Viser "Neste" når varsel er sendt og bruker skal uttale seg', async () => {
+        test('Viser "Neste" når varsel er sendt og bruker skal uttale seg', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -262,7 +262,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            expect(await screen.findByRole('button', { name: 'Neste' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
         });
 
         test('Viser "Utsett frist"-modal når bruker klikker utsett frist-knappen', async () => {
@@ -289,14 +289,14 @@ describe('Forhåndsvarsel', () => {
     });
 
     describe('formId - riktig skjema sendes inn', () => {
-        test('Bruker opprettForm når varsel ikke er sendt og unntak ikke finnes', async () => {
+        test('Bruker opprettForm når varsel ikke er sendt og unntak ikke finnes', () => {
             renderForhåndsvarsel(lagBehandlingDto({ varselSendt: false }));
 
             const nesteKnapp = screen.getByRole('button', { name: 'Neste' });
             expect(nesteKnapp).toHaveAttribute('form', 'opprettForm');
         });
 
-        test('Bruker uttalelseForm når varsel er sendt', async () => {
+        test('Bruker uttalelseForm når varsel er sendt', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -308,26 +308,26 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Neste' });
             expect(nesteKnapp).toHaveAttribute('form', 'uttalelseForm');
         });
 
-        test('Bruker opprettForm når bruker velger Nei og ÅPENBART_UNØDVENDIG', async () => {
+        test('Bruker opprettForm når bruker velger Nei og ÅPENBART_UNØDVENDIG', () => {
             renderForhåndsvarsel();
 
             const neiRadio = screen.getByRole('radio', { name: 'Nei' });
             fireEvent.click(neiRadio);
 
-            const åpenbartUnødvendigRadio = await screen.findByRole('radio', {
+            const åpenbartUnødvendigRadio = screen.getByRole('radio', {
                 name: /Varsel anses som åpenbart unødvendig/,
             });
             fireEvent.click(åpenbartUnødvendigRadio);
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             expect(nesteKnapp).toHaveAttribute('form', 'opprettForm');
         });
 
-        test('Bruker opprettForm når unntak er lagret og bruker endrer til ÅPENBART_UNØDVENDIG', async () => {
+        test('Bruker opprettForm når unntak er lagret og bruker endrer til ÅPENBART_UNØDVENDIG', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -342,16 +342,16 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const åpenbartUnødvendigRadio = await screen.findByRole('radio', {
+            const åpenbartUnødvendigRadio = screen.getByRole('radio', {
                 name: /Varsel anses som åpenbart unødvendig/,
             });
             fireEvent.click(åpenbartUnødvendigRadio);
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             expect(nesteKnapp).toHaveAttribute('form', 'opprettForm');
         });
 
-        test('Neste-knapp har form-attributt når brukeruttalelse allerede er registrert (kan redigeres)', async () => {
+        test('Neste-knapp har form-attributt når brukeruttalelse allerede er registrert (kan redigeres)', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -373,11 +373,11 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Neste' });
             expect(nesteKnapp).toHaveAttribute('form', 'uttalelseForm');
         });
 
-        test('Neste-knapp har form-attributt når varsel er sendt og uttalelse er registrert (kan redigeres)', async () => {
+        test('Neste-knapp har form-attributt når varsel er sendt og uttalelse er registrert (kan redigeres)', () => {
             const mockQueries = vi.mocked(useForhåndsvarselQueries);
             mockQueries.mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -399,7 +399,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Neste' });
             expect(nesteKnapp).toHaveAttribute('form', 'uttalelseForm');
         });
     });
@@ -430,7 +430,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Neste' });
             await user.click(nesteKnapp);
 
             expect(mockMutations.navigerTilNeste).toHaveBeenCalled();
@@ -464,7 +464,7 @@ describe('Forhåndsvarsel', () => {
             );
             await user.type(beskrivelsesFelt, 'Endret beskrivelse');
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             await user.click(nesteKnapp);
 
             expect(mockMutations.sendUnntak).toHaveBeenCalled();
@@ -493,10 +493,10 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const kommentarFelt = await screen.findByLabelText('Kommentar til valget over');
+            const kommentarFelt = screen.getByLabelText('Kommentar til valget over');
             await user.type(kommentarFelt, 'Endret kommentar');
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             await user.click(nesteKnapp);
 
             expect(mockMutations.sendBrukeruttalelse).toHaveBeenCalled();
@@ -525,12 +525,12 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const brukeruttalelseFieldset = await screen.findByRole('radiogroup', {
+            const brukeruttalelseFieldset = screen.getByRole('radiogroup', {
                 name: /har brukeren uttalt seg/i,
             });
             fireEvent.click(within(brukeruttalelseFieldset).getByLabelText('Ja'));
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             fireEvent.click(nesteKnapp);
 
             const feilmeldinger = await screen.findAllByText('Du må fylle inn en verdi');
@@ -561,7 +561,7 @@ describe('Forhåndsvarsel', () => {
             });
             expect(brukeruttalelseFieldset).toBeInTheDocument();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             fireEvent.click(nesteKnapp);
 
             const feilmelding = await screen.findByText('Du må velge om brukeren har uttalt seg');
@@ -588,16 +588,16 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const begrunnelseFieldset = await screen.findByRole('radiogroup', {
+            const begrunnelseFieldset = screen.getByRole('radiogroup', {
                 name: /velg begrunnelse for unntak/i,
             });
             fireEvent.click(within(begrunnelseFieldset).getByLabelText(/forvaltningsloven §16c/i));
-            const brukeruttalelseFieldset = await screen.findByRole('radiogroup', {
+            const brukeruttalelseFieldset = screen.getByRole('radiogroup', {
                 name: /har brukeren uttalt seg/i,
             });
             expect(brukeruttalelseFieldset).toBeInTheDocument();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             fireEvent.click(nesteKnapp);
 
             const feilmelding = await screen.findByText('Du må velge om brukeren har uttalt seg');
@@ -624,14 +624,14 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const brukeruttalelseFieldset = await screen.findByRole('radiogroup', {
+            const brukeruttalelseFieldset = screen.getByRole('radiogroup', {
                 name: /har brukeren uttalt seg/i,
             });
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Lagre og gå til neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Lagre og gå til neste' });
             await user.click(nesteKnapp);
 
-            const feilmelding = await screen.findByText('Du må velge om brukeren har uttalt seg');
+            const feilmelding = screen.getByText('Du må velge om brukeren har uttalt seg');
             expect(feilmelding).toBeInTheDocument();
 
             await user.click(within(brukeruttalelseFieldset).getByLabelText('Nei'));
@@ -643,7 +643,7 @@ describe('Forhåndsvarsel', () => {
     });
 
     describe('Knappetekst ved endring tilbake til utgangspunkt', () => {
-        test('Viser "Neste" når bruker bytter harUttaltSeg fra Nei til Ja og tilbake til Nei', async () => {
+        test('Viser "Neste" når bruker bytter harUttaltSeg fra Nei til Ja og tilbake til Nei', () => {
             vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -662,7 +662,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const brukeruttalelseFieldset = await screen.findByRole('radiogroup', {
+            const brukeruttalelseFieldset = screen.getByRole('radiogroup', {
                 name: /har brukeren uttalt seg/i,
             });
 
@@ -678,7 +678,7 @@ describe('Forhåndsvarsel', () => {
             expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
         });
 
-        test('Viser "Neste" når bruker bytter skalSendeForhåndsvarsel fra Nei til Ja og tilbake til Nei', async () => {
+        test('Viser "Neste" når bruker bytter skalSendeForhåndsvarsel fra Nei til Ja og tilbake til Nei', () => {
             vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -697,7 +697,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const skalSendeFieldset = await screen.findByRole('radiogroup', {
+            const skalSendeFieldset = screen.getByRole('radiogroup', {
                 name: /skal det sendes forhåndsvarsel/i,
             });
 
@@ -712,7 +712,7 @@ describe('Forhåndsvarsel', () => {
             expect(screen.getByRole('button', { name: 'Neste' })).toBeInTheDocument();
         });
 
-        test('Viser "Neste" når bruker bytter begrunnelseForUnntak og tilbake til opprinnelig', async () => {
+        test('Viser "Neste" når bruker bytter begrunnelseForUnntak og tilbake til opprinnelig', () => {
             vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
@@ -731,7 +731,7 @@ describe('Forhåndsvarsel', () => {
 
             renderForhåndsvarsel();
 
-            const begrunnelseFieldset = await screen.findByRole('radiogroup', {
+            const begrunnelseFieldset = screen.getByRole('radiogroup', {
                 name: /velg begrunnelse for unntak/i,
             });
 
@@ -748,7 +748,7 @@ describe('Forhåndsvarsel', () => {
     });
 
     describe('Fristinfo', () => {
-        test('Viser fristinfo med opprinnelig frist når varsel er sendt', async () => {
+        test('Viser fristinfo med opprinnelig frist når varsel er sendt', () => {
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
                     forhåndsvarselInfo: lagForhåndsvarselInfo({
@@ -766,7 +766,7 @@ describe('Forhåndsvarsel', () => {
             expect(screen.getByText('22.01.2023')).toBeInTheDocument();
         });
 
-        test('Viser ny frist i fristinfo når frist er utsatt', async () => {
+        test('Viser ny frist i fristinfo når frist er utsatt', () => {
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
                     forhåndsvarselInfo: lagForhåndsvarselInfo({
@@ -803,7 +803,7 @@ describe('Forhåndsvarsel', () => {
             expect(screen.queryByText('Frist for uttalelse')).not.toBeInTheDocument();
         });
 
-        test('Viser utsett frist-knapp i fristinfo', async () => {
+        test('Viser utsett frist-knapp i fristinfo', () => {
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
                     forhåndsvarselInfo: lagForhåndsvarselInfo({

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/Forhåndsvarsel.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/Forhåndsvarsel.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { BehandlingDto, ForhåndsvarselDto } from '~/generated';
 
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -35,8 +34,8 @@ const lagForhåndsvarselInfo = (overrides?: Partial<ForhåndsvarselDto>): Forhå
     ...overrides,
 });
 
-const renderForhåndsvarsel = (behandling: BehandlingDto = lagBehandlingDto()): RenderResult => {
-    return render(
+const renderForhåndsvarsel = (behandling: BehandlingDto = lagBehandlingDto()): void => {
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider
                 behandling={behandling}

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { FaktaOmFeilutbetaling } from '~/generated-new';
 
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -28,9 +27,9 @@ vi.mock('../useForhåndsvarselMutations', () => ({
     mapHarBrukerUttaltSegFraApiDto: vi.fn(),
 }));
 
-const renderForhåndsvarselSkjema = (): RenderResult => {
+const renderForhåndsvarselSkjema = (): void => {
     const behandling = lagBehandlingDto();
-    const result = render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={createTestQueryClient()}>
@@ -47,15 +46,13 @@ const renderForhåndsvarselSkjema = (): RenderResult => {
     const jaRadioButton = sendForhåndsvarselFieldset.querySelector('input[value="ja"]');
     if (!jaRadioButton) throw new Error('Could not find "Ja" radio button');
     fireEvent.click(jaRadioButton);
-
-    return result;
 };
 
-const renderForhåndsvarselSkjemaSendt = (): RenderResult => {
+const renderForhåndsvarselSkjemaSendt = (): void => {
     vi.mocked(useForhåndsvarselQueries).mockReturnValue(lagForhåndsvarselQueriesSendt());
 
     const behandling = lagBehandlingDto();
-    const result = render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={createTestQueryClient()}>
@@ -72,8 +69,6 @@ const renderForhåndsvarselSkjemaSendt = (): RenderResult => {
     const jaRadioButton = sendForhåndsvarselFieldset.querySelector('input[value="ja"]');
     if (!jaRadioButton) throw new Error('Could not find "Ja" radio button');
     fireEvent.click(jaRadioButton);
-
-    return result;
 };
 
 describe('ForhåndsvarselSkjema', () => {
@@ -139,7 +134,7 @@ const lagFaktaOmFeilutbetaling = (vedtaksdato: string): FaktaOmFeilutbetaling =>
         ferdigvurdert: false,
     }) satisfies FaktaOmFeilutbetaling;
 
-const renderMedFaktaData = (vedtaksdato: string): RenderResult => {
+const renderMedFaktaData = (vedtaksdato: string): void => {
     const behandling = lagBehandlingDto();
     const queryClient = createTestQueryClient();
 
@@ -148,7 +143,7 @@ const renderMedFaktaData = (vedtaksdato: string): RenderResult => {
     });
     queryClient.setQueryData(queryKey, lagFaktaOmFeilutbetaling(vedtaksdato));
 
-    const renderForhåndsvarsel = render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={queryClient}>
@@ -165,8 +160,6 @@ const renderMedFaktaData = (vedtaksdato: string): RenderResult => {
     const jaRadioButton = fieldset.querySelector('input[value="ja"]');
     if (!jaRadioButton) throw new Error('Could not find "Ja" radio button');
     fireEvent.click(jaRadioButton);
-
-    return renderForhåndsvarsel;
 };
 
 describe('Stønadstekst', () => {
@@ -177,17 +170,17 @@ describe('Stønadstekst', () => {
     });
 
     test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', async () => {
-        const { getByRole } = renderMedFaktaData('2025-09-05');
+        renderMedFaktaData('2025-09-05');
 
-        expect(getByRole('textbox', { name: 'Legg til utdypende tekst' })).toHaveValue(
+        expect(screen.getByRole('textbox', { name: 'Legg til utdypende tekst' })).toHaveValue(
             'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
         );
     });
 
     test('Overskriver ikke fritekst som brukeren har skrevet', async () => {
-        const { getByRole } = renderMedFaktaData('2025-09-05');
+        renderMedFaktaData('2025-09-05');
 
-        const textarea = getByRole('textbox', { name: 'Legg til utdypende tekst' });
+        const textarea = screen.getByRole('textbox', { name: 'Legg til utdypende tekst' });
         expect(textarea).toHaveValue(
             'Det er gjort en endring i saken din 5. september 2025. Dette gjør at tidligere utbetalinger ikke lenger er riktige, og at du har fått utbetalt for mye.'
         );

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/SkalSendeSkjema.test.tsx
@@ -79,37 +79,37 @@ describe('ForhåndsvarselSkjema', () => {
         vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
     });
 
-    test('Viser riktig tittel når varsel ikke er sendt', async () => {
+    test('Viser riktig tittel når varsel ikke er sendt', () => {
         renderForhåndsvarselSkjema();
 
         expect(
-            await screen.findByRole('heading', {
+            screen.getByRole('heading', {
                 name: 'Opprett forhåndsvarsel',
                 level: 2,
             })
         ).toBeInTheDocument();
     });
 
-    test('Viser riktig tittel når varsel er sendt', async () => {
+    test('Viser riktig tittel når varsel er sendt', () => {
         renderForhåndsvarselSkjemaSendt();
 
         expect(
-            await screen.findByRole('heading', { name: 'Forhåndsvarsel', level: 1 })
+            screen.getByRole('heading', { name: 'Forhåndsvarsel', level: 1 })
         ).toBeInTheDocument();
     });
 
-    test('Viser brevinnhold og fritekstfelt', async () => {
+    test('Viser brevinnhold og fritekstfelt', () => {
         renderForhåndsvarselSkjema();
 
-        expect(await screen.findByText('Dette har skjedd')).toBeInTheDocument();
+        expect(screen.getByText('Dette har skjedd')).toBeInTheDocument();
         expect(screen.getByText('Legg til utdypende tekst')).toBeInTheDocument();
     });
 
-    test('Viser Brukeruttalelse når varsel er sendt', async () => {
+    test('Viser Brukeruttalelse når varsel er sendt', () => {
         renderForhåndsvarselSkjemaSendt();
 
         expect(
-            await screen.findByText('Har brukeren uttalt seg etter forhåndsvarselet ble sendt?')
+            screen.getByText('Har brukeren uttalt seg etter forhåndsvarselet ble sendt?')
         ).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Forhåndsvisning' })).not.toBeInTheDocument();
     });
@@ -169,7 +169,7 @@ describe('Stønadstekst', () => {
         vi.mocked(useForhåndsvarselMutations).mockReturnValue(lagForhåndsvarselMutations());
     });
 
-    test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', async () => {
+    test('Initialiserer fritekst med stønadstekst basert på vedtaksdato', () => {
         renderMedFaktaData('2025-09-05');
 
         expect(screen.getByRole('textbox', { name: 'Legg til utdypende tekst' })).toHaveValue(
@@ -177,7 +177,7 @@ describe('Stønadstekst', () => {
         );
     });
 
-    test('Overskriver ikke fritekst som brukeren har skrevet', async () => {
+    test('Overskriver ikke fritekst som brukeren har skrevet', () => {
         renderMedFaktaData('2025-09-05');
 
         const textarea = screen.getByRole('textbox', { name: 'Legg til utdypende tekst' });

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UnntakSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UnntakSkjema.test.tsx
@@ -79,7 +79,7 @@ describe('Unntak', () => {
         );
         expect(unntakFeilmelding).toBeInTheDocument();
 
-        const beskrivelseFeilmelding = await screen.findByText('Du må fylle inn en verdi');
+        const beskrivelseFeilmelding = screen.getByText('Du må fylle inn en verdi');
         expect(beskrivelseFeilmelding).toBeInTheDocument();
     });
 });

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UnntakSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UnntakSkjema.test.tsx
@@ -1,5 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
-
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 
@@ -25,9 +23,9 @@ vi.mock('../useForhåndsvarselMutations', () => ({
     mapHarBrukerUttaltSegFraApiDto: vi.fn(),
 }));
 
-const renderUnntak = (): RenderResult => {
+const renderUnntak = (): void => {
     const behandling = lagBehandlingDto();
-    const result = render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={createTestQueryClient()}>
@@ -38,8 +36,6 @@ const renderUnntak = (): RenderResult => {
     );
 
     fireEvent.click(screen.getByLabelText('Nei'));
-
-    return result;
 };
 
 describe('Unntak', () => {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UttalelseSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UttalelseSkjema.test.tsx
@@ -218,7 +218,7 @@ describe('Brukeruttalelse', () => {
     });
 
     describe('Fylt uttalelse', () => {
-        test('Viser utfylte verdier når brukeruttalelse er fylt ut', async () => {
+        test('Viser utfylte verdier når brukeruttalelse er fylt ut', () => {
             vi.mocked(useForhåndsvarselQueries).mockReturnValue(
                 lagForhåndsvarselQueries({
                     forhåndsvarselInfo: {

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UttalelseSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UttalelseSkjema.test.tsx
@@ -1,5 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
-
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
@@ -26,12 +24,12 @@ vi.mock('../useForhåndsvarselMutations', () => ({
     mapHarBrukerUttaltSegFraApiDto: vi.fn(),
 }));
 
-const renderBrukeruttalelse = (): RenderResult => {
+const renderBrukeruttalelse = (): void => {
     const behandling = lagBehandlingDto({
         varselSendt: true,
     });
 
-    return render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling}>
                 <QueryClientProvider client={createTestQueryClient()}>
@@ -240,17 +238,17 @@ describe('Brukeruttalelse', () => {
                 })
             );
 
-            const { findByRole } = renderBrukeruttalelse();
+            renderBrukeruttalelse();
 
-            const uttalelsesdato = await findByRole('textbox', {
+            const uttalelsesdato = await screen.findByRole('textbox', {
                 name: 'Når uttalte brukeren seg?',
             });
             expect(uttalelsesdato).toHaveValue('15.06.2023');
-            const hvordanUttalteSeg = await findByRole('textbox', {
+            const hvordanUttalteSeg = await screen.findByRole('textbox', {
                 name: 'Hvordan uttalte brukeren seg?',
             });
             expect(hvordanUttalteSeg).toHaveValue('Telefon');
-            const beskrivelse = await findByRole('textbox', {
+            const beskrivelse = await screen.findByRole('textbox', {
                 name: 'Beskriv hva brukeren har uttalt seg om',
             });
             expect(beskrivelse).toHaveValue('Brukeren forklarte situasjonen');

--- a/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UttalelseSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/forhåndsvarsel/gammel-forhåndsvarsel/skjema/UttalelseSkjema.test.tsx
@@ -71,7 +71,7 @@ describe('Brukeruttalelse', () => {
         expect(neiOptions).toHaveLength(2);
     });
 
-    test('Viser uttalelsesfelter når Ja er valgt', async () => {
+    test('Viser uttalelsesfelter når Ja er valgt', () => {
         renderBrukeruttalelse();
 
         expect(screen.queryByLabelText('Når uttalte brukeren seg?')).not.toBeInTheDocument();
@@ -86,12 +86,12 @@ describe('Brukeruttalelse', () => {
         const jaRadio = within(brukeruttalelseFieldset).getByLabelText('Ja');
         fireEvent.click(jaRadio);
 
-        expect(await screen.findByLabelText('Når uttalte brukeren seg?')).toBeInTheDocument();
+        expect(screen.getByLabelText('Når uttalte brukeren seg?')).toBeInTheDocument();
         expect(screen.getByLabelText('Hvordan uttalte brukeren seg?')).toBeInTheDocument();
         expect(screen.getByLabelText('Beskriv hva brukeren har uttalt seg om')).toBeInTheDocument();
     });
 
-    test('Viser beskrivelse for "Hvordan uttalte brukeren seg?" feltet', async () => {
+    test('Viser beskrivelse for "Hvordan uttalte brukeren seg?" feltet', () => {
         renderBrukeruttalelse();
 
         const brukeruttalelseFieldset = screen.getByRole('radiogroup', {
@@ -101,11 +101,11 @@ describe('Brukeruttalelse', () => {
         fireEvent.click(jaRadio);
 
         expect(
-            await screen.findByText('For eksempel via telefon, Gosys, Ditt Nav eller Skriv til oss')
+            screen.getByText('For eksempel via telefon, Gosys, Ditt Nav eller Skriv til oss')
         ).toBeInTheDocument();
     });
 
-    test('Viser kommentarfelt når Nei er valgt', async () => {
+    test('Viser kommentarfelt når Nei er valgt', () => {
         renderBrukeruttalelse();
 
         expect(screen.queryByLabelText('Kommentar til valget over')).not.toBeInTheDocument();
@@ -116,7 +116,7 @@ describe('Brukeruttalelse', () => {
         const neiRadio = within(brukeruttalelseFieldset).getByLabelText('Nei');
         fireEvent.click(neiRadio);
 
-        expect(await screen.findByLabelText('Kommentar til valget over')).toBeInTheDocument();
+        expect(screen.getByLabelText('Kommentar til valget over')).toBeInTheDocument();
     });
 
     test('Deaktiverer Nei-alternativet når opprinnelig frist ikke er utgått', () => {
@@ -240,15 +240,15 @@ describe('Brukeruttalelse', () => {
 
             renderBrukeruttalelse();
 
-            const uttalelsesdato = await screen.findByRole('textbox', {
+            const uttalelsesdato = screen.getByRole('textbox', {
                 name: 'Når uttalte brukeren seg?',
             });
             expect(uttalelsesdato).toHaveValue('15.06.2023');
-            const hvordanUttalteSeg = await screen.findByRole('textbox', {
+            const hvordanUttalteSeg = screen.getByRole('textbox', {
                 name: 'Hvordan uttalte brukeren seg?',
             });
             expect(hvordanUttalteSeg).toHaveValue('Telefon');
-            const beskrivelse = await screen.findByRole('textbox', {
+            const beskrivelse = screen.getByRole('textbox', {
                 name: 'Beskriv hva brukeren har uttalt seg om',
             });
             expect(beskrivelse).toHaveValue('Brukeren forklarte situasjonen');
@@ -259,7 +259,7 @@ describe('Brukeruttalelse', () => {
         test('skal vise feilmelding når ingen alternativ er valgt', async () => {
             renderBrukeruttalelse();
 
-            const nesteKnapp = await screen.findByRole('button', { name: 'Neste' });
+            const nesteKnapp = screen.getByRole('button', { name: 'Neste' });
             fireEvent.click(nesteKnapp);
 
             const brukeruttalelseFieldset = screen.getByRole('radiogroup', {
@@ -283,7 +283,7 @@ describe('Brukeruttalelse', () => {
                 const jaRadio = within(brukeruttalelseFieldset).getByLabelText('Ja');
                 fireEvent.click(jaRadio);
 
-                const nesteKnapp = await screen.findByRole('button', {
+                const nesteKnapp = screen.getByRole('button', {
                     name: 'Lagre og gå til neste',
                 });
                 fireEvent.click(nesteKnapp);
@@ -302,7 +302,7 @@ describe('Brukeruttalelse', () => {
                 const jaRadio = within(brukeruttalelseFieldset).getByLabelText('Ja');
                 fireEvent.click(jaRadio);
 
-                const datoInput = await screen.findByLabelText('Når uttalte brukeren seg?');
+                const datoInput = screen.getByLabelText('Når uttalte brukeren seg?');
                 fireEvent.blur(datoInput);
 
                 expect(
@@ -319,7 +319,7 @@ describe('Brukeruttalelse', () => {
                 const jaRadio = within(brukeruttalelseFieldset).getByLabelText('Ja');
                 fireEvent.click(jaRadio);
 
-                const nesteKnapp = await screen.findByRole('button', {
+                const nesteKnapp = screen.getByRole('button', {
                     name: 'Lagre og gå til neste',
                 });
                 fireEvent.click(nesteKnapp);
@@ -355,13 +355,13 @@ describe('Brukeruttalelse', () => {
                 const jaRadio = within(brukeruttalelseFieldset).getByLabelText('Ja');
                 await user.click(jaRadio);
 
-                await screen.findByLabelText('Når uttalte brukeren seg?');
+                screen.getByLabelText('Når uttalte brukeren seg?');
 
                 const kalenderKnapp = screen.getAllByRole('button', { name: 'Åpne datovelger' });
                 const uttalelsesKalenderKnapp = kalenderKnapp[0];
                 await user.click(uttalelsesKalenderKnapp);
 
-                const nesteMånedKnapp = await screen.findByRole('button', {
+                const nesteMånedKnapp = screen.getByRole('button', {
                     name: /gå til neste måned/i,
                 });
                 expect(nesteMånedKnapp).toBeDisabled();

--- a/src/frontend/pages/fagsak/vedtak/Vedtaksbrev.test.tsx
+++ b/src/frontend/pages/fagsak/vedtak/Vedtaksbrev.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { Avsnitt, Brevmottaker, VedtaksbrevData } from '~/generated-new';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -9,9 +8,9 @@ import { TestBehandlingProvider } from '~/testdata/behandlingContextFactory';
 
 import { Vedtaksbrev } from './Vedtaksbrev';
 
-const renderVedtaksbrev = (vedtaksbrevData: VedtaksbrevData): RenderResult => {
+const renderVedtaksbrev = (vedtaksbrevData: VedtaksbrevData): void => {
     const client = new QueryClient();
-    return render(
+    render(
         <QueryClientProvider client={client}>
             <TestBehandlingProvider>
                 <Vedtaksbrev vedtaksbrevData={vedtaksbrevData} onSubmit={vitest.fn()} />

--- a/src/frontend/pages/fagsak/vedtak/gammel-vedtak/VedtakContainer.test.tsx
+++ b/src/frontend/pages/fagsak/vedtak/gammel-vedtak/VedtakContainer.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { BehandlingDto } from '~/generated';
@@ -45,12 +44,9 @@ vi.mock('~/hooks/useSammenslåPerioder', () => ({
 
 const mockedSettIkkePersistertKomponent = vi.fn();
 
-const renderVedtakContainer = (
-    behandling: BehandlingDto,
-    lesemodus: boolean = false
-): RenderResult => {
+const renderVedtakContainer = (behandling: BehandlingDto, lesemodus: boolean = false): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider
@@ -159,76 +155,75 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByText, getAllByText, getByRole, queryByRole, queryByText } =
-            renderVedtakContainer(lagBehandling());
+        renderVedtakContainer(lagBehandling());
 
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
-            queryByText(
+            screen.queryByText(
                 'Vedtaksbrev sendes ikke ut fra denne behandlingen, men må sendes av saksbehandler fra klagebehandlingen'
             )
         ).not.toBeInTheDocument();
 
-        expect(getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
-        expect(getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
-        expect(getByText('Forsett')).toBeInTheDocument();
-        expect(getByText('Simpel uaktsomhet')).toBeInTheDocument();
-        expect(getAllByText('1 333')).toHaveLength(2);
-        expect(getByText('2 666')).toBeInTheDocument();
-        expect(getByText('90 %')).toBeInTheDocument();
-        expect(getByText('91 %')).toBeInTheDocument();
-        expect(getAllByText('1 222')).toHaveLength(2);
-        expect(getAllByText('1 222')).toHaveLength(2);
-        expect(getAllByText('2 445')).toHaveLength(2);
+        expect(screen.getByText('01.01.2020–31.03.2020')).toBeInTheDocument();
+        expect(screen.getByText('01.05.2020–30.06.2020')).toBeInTheDocument();
+        expect(screen.getByText('Forsett')).toBeInTheDocument();
+        expect(screen.getByText('Simpel uaktsomhet')).toBeInTheDocument();
+        expect(screen.getAllByText('1 333')).toHaveLength(2);
+        expect(screen.getByText('2 666')).toBeInTheDocument();
+        expect(screen.getByText('90 %')).toBeInTheDocument();
+        expect(screen.getByText('91 %')).toBeInTheDocument();
+        expect(screen.getAllByText('1 222')).toHaveLength(2);
+        expect(screen.getAllByText('1 222')).toHaveLength(2);
+        expect(screen.getAllByText('2 445')).toHaveLength(2);
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeDisabled();
 
-        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
+        expect(screen.getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
+            screen.getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
+            screen.getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
         ).toBeInTheDocument();
 
         expect(
-            getByRole('textbox', {
+            screen.getByRole('textbox', {
                 name: `Utdypende tekst`,
             })
         ).toBeInTheDocument();
 
         await user.type(
-            getByRole('textbox', {
+            screen.getByRole('textbox', {
                 name: `Utdypende tekst`,
             }),
             'Fritekst påkrevet'
         );
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeEnabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         );
@@ -260,71 +255,70 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByText, getByRole, getAllByRole, getByTestId, queryByRole, queryByText } =
-            renderVedtakContainer(
-                lagBehandling({
-                    type: 'REVURDERING_TILBAKEKREVING',
-                    behandlingsårsakstype: 'REVURDERING_OPPLYSNINGER_OM_VILKÅR',
-                })
-            );
+        renderVedtakContainer(
+            lagBehandling({
+                type: 'REVURDERING_TILBAKEKREVING',
+                behandlingsårsakstype: 'REVURDERING_OPPLYSNINGER_OM_VILKÅR',
+            })
+        );
 
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
-            queryByText(
+            screen.queryByText(
                 'Vedtaksbrev sendes ikke ut fra denne behandlingen, men må sendes av saksbehandler fra klagebehandlingen'
             )
         ).not.toBeInTheDocument();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeDisabled();
 
-        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
+        expect(screen.getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
+            screen.getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
+            screen.getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
         ).toBeInTheDocument();
 
         expect(
-            getAllByRole('textbox', {
+            screen.getAllByRole('textbox', {
                 name: `Utdypende tekst`,
             })
         ).toHaveLength(2);
 
         await user.type(
-            getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0'),
+            screen.getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0'),
             'Fritekst påkrevet'
         );
         await user.type(
-            getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0'),
+            screen.getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0'),
             'Fritekst påkrevet'
         );
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeEnabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         );
@@ -357,67 +351,68 @@ describe('VedtakContainer', () => {
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
 
-        const { getByText, getByRole, getAllByRole, getByTestId, queryByRole } =
-            renderVedtakContainer(
-                lagBehandling({
-                    type: 'REVURDERING_TILBAKEKREVING',
-                    behandlingsårsakstype: 'REVURDERING_KLAGE_KA',
-                })
-            );
+        renderVedtakContainer(
+            lagBehandling({
+                type: 'REVURDERING_TILBAKEKREVING',
+                behandlingsårsakstype: 'REVURDERING_KLAGE_KA',
+            })
+        );
 
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
-        expect(getByText('Vedtaksbrev sendes ikke ut fra denne behandlingen.')).toBeInTheDocument();
+        expect(
+            screen.getByText('Vedtaksbrev sendes ikke ut fra denne behandlingen.')
+        ).toBeInTheDocument();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).not.toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeDisabled();
 
-        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
+        expect(screen.getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
+            screen.getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
+            screen.getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
         ).toBeInTheDocument();
 
         expect(
-            getAllByRole('textbox', {
+            screen.getAllByRole('textbox', {
                 name: `Utdypende tekst`,
             })
         ).toHaveLength(2);
 
         await user.type(
-            getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0'),
+            screen.getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0'),
             'Fritekst påkrevet'
         );
         await user.type(
-            getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0'),
+            screen.getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0'),
             'Fritekst påkrevet'
         );
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).not.toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeEnabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         );
@@ -450,56 +445,55 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByText, getByRole, getAllByRole, getByTestId, queryByText, queryByRole } =
-            renderVedtakContainer(
-                lagBehandling({
-                    type: 'REVURDERING_TILBAKEKREVING',
-                    behandlingsårsakstype: 'REVURDERING_KLAGE_NFP',
-                })
-            );
+        renderVedtakContainer(
+            lagBehandling({
+                type: 'REVURDERING_TILBAKEKREVING',
+                behandlingsårsakstype: 'REVURDERING_KLAGE_NFP',
+            })
+        );
 
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
-            queryByText(
+            screen.queryByText(
                 'Vedtaksbrev sendes ikke ut fra denne behandlingen, men må sendes av saksbehandler fra klagebehandlingen'
             )
         ).not.toBeInTheDocument();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeDisabled();
 
-        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
+        expect(screen.getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
+            screen.getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
+            screen.getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
         ).toBeInTheDocument();
 
         expect(
-            getAllByRole('textbox', {
+            screen.getAllByRole('textbox', {
                 name: `Utdypende tekst`,
             })
         ).toHaveLength(1);
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Legg til utdypende tekst',
             })
         ).not.toBeInTheDocument();
 
         await user.click(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -507,42 +501,42 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
         ).toHaveAttribute('aria-expanded', 'true');
 
         expect(
-            getAllByRole('button', {
+            screen.getAllByRole('button', {
                 name: 'Legg til utdypende tekst Legg til utdypende tekst',
             })
         ).toHaveLength(2);
-        await user.click(getByTestId('legg-til-fritekst-idx_avsnitt_2-idx_underavsnitt_0'));
+        await user.click(screen.getByTestId('legg-til-fritekst-idx_avsnitt_2-idx_underavsnitt_0'));
 
         await user.type(
-            getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0'),
+            screen.getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0'),
             'Fritekst påkrevet'
         );
         await user.type(
-            getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0'),
+            screen.getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0'),
             'Fritekst ekstra'
         );
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeEnabled();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         );
@@ -572,34 +566,33 @@ describe('VedtakContainer', () => {
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
 
-        const { getByText, getByRole, getByTestId, queryByRole } =
-            renderVedtakContainer(lagBehandling());
+        renderVedtakContainer(lagBehandling());
 
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).toBeEnabled();
-        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
+        expect(screen.getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
 
         expect(
-            getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
+            screen.getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
+            screen.getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
         ).toBeInTheDocument();
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -607,7 +600,7 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -615,14 +608,14 @@ describe('VedtakContainer', () => {
 
         await user.click(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
         );
         await user.click(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -630,7 +623,7 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -638,16 +631,16 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
         ).toHaveAttribute('aria-expanded', 'true');
 
-        expect(getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0')).toHaveValue(
+        expect(screen.getByTestId('fritekst-idx_avsnitt_1-idx_underavsnitt_0')).toHaveValue(
             'Denne friteksten var påkrevet'
         );
-        expect(getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0')).toHaveValue(
+        expect(screen.getByTestId('fritekst-idx_avsnitt_2-idx_underavsnitt_0')).toHaveValue(
             'Denne friteksten var lagt til ekstra'
         );
     });
@@ -675,33 +668,33 @@ describe('VedtakContainer', () => {
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
 
-        const { getByText, getByRole, queryByRole } = renderVedtakContainer(lagBehandling(), true);
+        renderVedtakContainer(lagBehandling(), true);
 
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).not.toBeInTheDocument();
 
         expect(
-            queryByRole('button', {
+            screen.queryByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         ).not.toBeInTheDocument();
 
-        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
+        expect(screen.getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
+            screen.getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
         expect(
-            getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
+            screen.getByText('Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020')
         ).toBeInTheDocument();
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -709,7 +702,7 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -717,7 +710,7 @@ describe('VedtakContainer', () => {
 
         await user.click(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -725,7 +718,7 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -733,7 +726,7 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -741,7 +734,7 @@ describe('VedtakContainer', () => {
 
         await user.click(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -749,7 +742,7 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
@@ -757,14 +750,14 @@ describe('VedtakContainer', () => {
 
         expect(
             within(
-                getByRole('region', {
+                screen.getByRole('region', {
                     name: `Gjelder perioden fra og med 1. mai 2020 til og med 30. juni 2020`,
                 })
             ).getByRole('button', { name: 'Vis mer' })
         ).toHaveAttribute('aria-expanded', 'true');
 
-        expect(getByText('Denne friteksten var påkrevet')).toBeInTheDocument();
-        expect(getByText('Denne friteksten var lagt til ekstra')).toBeInTheDocument();
+        expect(screen.getByText('Denne friteksten var påkrevet')).toBeInTheDocument();
+        expect(screen.getByText('Denne friteksten var lagt til ekstra')).toBeInTheDocument();
     });
 
     test('Viser bekreftelsesmodal når bruker klikker Send til godkjenning', async () => {
@@ -780,24 +773,22 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByRole, queryByRole } = renderVedtakContainer(
-            lagBehandling({ kanEndres: true, erNyModell: true })
-        );
+        renderVedtakContainer(lagBehandling({ kanEndres: true, erNyModell: true }));
 
         expect(await screen.findByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
 
-        expect(queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         );
 
-        expect(getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Avbryt',
             })
         ).toBeInTheDocument();
@@ -816,19 +807,17 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByRole, queryByRole } = renderVedtakContainer(
-            lagBehandling({ kanEndres: true })
-        );
+        renderVedtakContainer(lagBehandling({ kanEndres: true }));
 
         expect(await screen.findByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Send til godkjenning hos beslutter',
             })
         );
 
-        const modal = getByRole('dialog');
+        const modal = screen.getByRole('dialog');
 
         await user.click(
             within(modal).getByRole('button', {
@@ -836,6 +825,6 @@ describe('VedtakContainer', () => {
             })
         );
 
-        expect(queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/pages/fagsak/vedtak/gammel-vedtak/VedtakContainer.test.tsx
+++ b/src/frontend/pages/fagsak/vedtak/gammel-vedtak/VedtakContainer.test.tsx
@@ -11,7 +11,7 @@ import type {
 } from '~/typer/vedtakTyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -162,9 +162,7 @@ describe('VedtakContainer', () => {
         const { getByText, getAllByText, getByRole, queryByRole, queryByText } =
             renderVedtakContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText('Vedtak')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
             queryByText(
@@ -184,21 +182,17 @@ describe('VedtakContainer', () => {
         expect(getAllByText('1 222')).toHaveLength(2);
         expect(getAllByText('2 445')).toHaveLength(2);
 
-        await waitFor(() => {
-            expect(
-                queryByRole('button', {
-                    name: 'Forhåndsvis vedtaksbrev',
-                })
-            ).toBeInTheDocument();
-        });
+        expect(
+            queryByRole('button', {
+                name: 'Forhåndsvis vedtaksbrev',
+            })
+        ).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeDisabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeDisabled();
 
         expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
@@ -274,9 +268,7 @@ describe('VedtakContainer', () => {
                 })
             );
 
-        await waitFor(() => {
-            expect(getByText('Vedtak')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
             queryByText(
@@ -284,21 +276,17 @@ describe('VedtakContainer', () => {
             )
         ).not.toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                queryByRole('button', {
-                    name: 'Forhåndsvis vedtaksbrev',
-                })
-            ).toBeInTheDocument();
-        });
+        expect(
+            queryByRole('button', {
+                name: 'Forhåndsvis vedtaksbrev',
+            })
+        ).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeDisabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeDisabled();
 
         expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
@@ -377,9 +365,7 @@ describe('VedtakContainer', () => {
                 })
             );
 
-        await waitFor(() => {
-            expect(getByText('Vedtak')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(getByText('Vedtaksbrev sendes ikke ut fra denne behandlingen.')).toBeInTheDocument();
 
@@ -389,13 +375,11 @@ describe('VedtakContainer', () => {
             })
         ).not.toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeDisabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeDisabled();
 
         expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
@@ -426,13 +410,11 @@ describe('VedtakContainer', () => {
             })
         ).not.toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeEnabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeEnabled();
 
         await user.click(
             getByRole('button', {
@@ -476,9 +458,7 @@ describe('VedtakContainer', () => {
                 })
             );
 
-        await waitFor(() => {
-            expect(getByText('Vedtak')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
             queryByText(
@@ -486,21 +466,17 @@ describe('VedtakContainer', () => {
             )
         ).not.toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                queryByRole('button', {
-                    name: 'Forhåndsvis vedtaksbrev',
-                })
-            ).toBeInTheDocument();
-        });
+        expect(
+            queryByRole('button', {
+                name: 'Forhåndsvis vedtaksbrev',
+            })
+        ).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeDisabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeDisabled();
 
         expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
@@ -559,13 +535,11 @@ describe('VedtakContainer', () => {
             })
         ).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeEnabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeEnabled();
 
         await user.click(
             getByRole('button', {
@@ -601,25 +575,19 @@ describe('VedtakContainer', () => {
         const { getByText, getByRole, getByTestId, queryByRole } =
             renderVedtakContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText('Vedtak')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                queryByRole('button', {
-                    name: 'Forhåndsvis vedtaksbrev',
-                })
-            ).toBeInTheDocument();
-        });
+        expect(
+            queryByRole('button', {
+                name: 'Forhåndsvis vedtaksbrev',
+            })
+        ).toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Send til godkjenning hos beslutter',
-                })
-            ).toBeEnabled();
-        });
+        expect(
+            getByRole('button', {
+                name: 'Send til godkjenning hos beslutter',
+            })
+        ).toBeEnabled();
         expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
 
         expect(
@@ -709,9 +677,7 @@ describe('VedtakContainer', () => {
 
         const { getByText, getByRole, queryByRole } = renderVedtakContainer(lagBehandling(), true);
 
-        await waitFor(() => {
-            expect(getByText('Vedtak')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
             queryByRole('button', {
@@ -725,9 +691,7 @@ describe('VedtakContainer', () => {
             })
         ).not.toBeInTheDocument();
 
-        await waitFor(() => {
-            expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
-        });
+        expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
         expect(
             getByText('Gjelder perioden fra og med 1. januar 2020 til og med 31. mars 2020')
         ).toBeInTheDocument();
@@ -816,13 +780,11 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByText, getByRole, queryByRole } = renderVedtakContainer(
+        const { getByRole, queryByRole } = renderVedtakContainer(
             lagBehandling({ kanEndres: true, erNyModell: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
 
         expect(queryByRole('dialog')).not.toBeInTheDocument();
 
@@ -832,9 +794,7 @@ describe('VedtakContainer', () => {
             })
         );
 
-        await waitFor(() => {
-            expect(getByRole('dialog')).toBeInTheDocument();
-        });
+        expect(getByRole('dialog')).toBeInTheDocument();
 
         expect(
             getByRole('button', {
@@ -856,13 +816,11 @@ describe('VedtakContainer', () => {
             ]),
         ];
         setupMock(vedtaksbrevAvsnitt, beregningsresultat);
-        const { getByText, getByRole, queryByRole } = renderVedtakContainer(
+        const { getByRole, queryByRole } = renderVedtakContainer(
             lagBehandling({ kanEndres: true })
         );
 
-        await waitFor(() => {
-            expect(getByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
-        });
+        expect(await screen.findByText('Du må betale tilbake barnetrygden')).toBeInTheDocument();
 
         await user.click(
             getByRole('button', {
@@ -870,7 +828,7 @@ describe('VedtakContainer', () => {
             })
         );
 
-        const modal = await waitFor(() => getByRole('dialog'));
+        const modal = getByRole('dialog');
 
         await user.click(
             within(modal).getByRole('button', {
@@ -878,8 +836,6 @@ describe('VedtakContainer', () => {
             })
         );
 
-        await waitFor(() => {
-            expect(queryByRole('dialog')).not.toBeInTheDocument();
-        });
+        expect(queryByRole('dialog')).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/pages/fagsak/vedtak/gammel-vedtak/VedtakContainer.test.tsx
+++ b/src/frontend/pages/fagsak/vedtak/gammel-vedtak/VedtakContainer.test.tsx
@@ -178,7 +178,7 @@ describe('VedtakContainer', () => {
         expect(screen.getAllByText('2 445')).toHaveLength(2);
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
@@ -211,7 +211,7 @@ describe('VedtakContainer', () => {
         );
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
@@ -271,7 +271,7 @@ describe('VedtakContainer', () => {
         ).not.toBeInTheDocument();
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
@@ -306,7 +306,7 @@ describe('VedtakContainer', () => {
         );
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
@@ -461,7 +461,7 @@ describe('VedtakContainer', () => {
         ).not.toBeInTheDocument();
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
@@ -524,7 +524,7 @@ describe('VedtakContainer', () => {
         );
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();
@@ -571,7 +571,7 @@ describe('VedtakContainer', () => {
         expect(await screen.findByText('Vedtak')).toBeInTheDocument();
 
         expect(
-            screen.queryByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forhåndsvis vedtaksbrev',
             })
         ).toBeInTheDocument();

--- a/src/frontend/pages/fagsak/verge/VergeContainer.test.tsx
+++ b/src/frontend/pages/fagsak/verge/VergeContainer.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { BehandlingDto } from '~/generated';
@@ -32,10 +31,9 @@ vi.mock('~/api/behandling', () => ({
 const renderVergeContainer = (
     behandling: BehandlingDto,
     stateOverrides: BehandlingStateContextOverrides = {}
-): RenderResult => {
+): void => {
     const client = createTestQueryClient();
-
-    return render(
+    render(
         <FagsakContext value={lagFagsak()}>
             <TestBehandlingProvider behandling={behandling} stateOverrides={stateOverrides}>
                 <QueryClientProvider client={client}>
@@ -80,87 +78,85 @@ describe('VergeContainer', () => {
     test('Fyller ut advokat', async () => {
         setupMock();
 
-        const { getByText, getByRole, getByLabelText, queryAllByText } =
-            renderVergeContainer(lagBehandling());
+        renderVergeContainer(lagBehandling());
 
-        expect(getByText('Verge')).toBeInTheDocument();
+        expect(screen.getByText('Verge')).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
 
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.selectOptions(getByLabelText('Vergetype'), Vergetype.Advokat);
+        await user.selectOptions(screen.getByLabelText('Vergetype'), Vergetype.Advokat);
 
-        await user.type(getByLabelText('Begrunn endringene'), 'Verge er advokat');
+        await user.type(screen.getByLabelText('Begrunn endringene'), 'Verge er advokat');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.type(getByLabelText('Navn'), 'Advokat Advokatesen');
-        await user.type(getByLabelText('Organisasjonsnummer'), 'DummyOrg');
+        await user.type(screen.getByLabelText('Navn'), 'Advokat Advokatesen');
+        await user.type(screen.getByLabelText('Organisasjonsnummer'), 'DummyOrg');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Fyller ut verge for barn', async () => {
         setupMock();
 
-        const { getByText, getByRole, getByLabelText, queryAllByText, queryByText } =
-            renderVergeContainer(lagBehandling());
+        renderVergeContainer(lagBehandling());
 
-        expect(getByText('Verge')).toBeInTheDocument();
+        expect(screen.getByText('Verge')).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.selectOptions(getByLabelText('Vergetype'), Vergetype.VergeForBarn);
-        await user.type(getByLabelText('Begrunn endringene'), 'Verge er advokat');
+        await user.selectOptions(screen.getByLabelText('Vergetype'), Vergetype.VergeForBarn);
+        await user.type(screen.getByLabelText('Begrunn endringene'), 'Verge er advokat');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
-        await user.type(getByLabelText('Navn'), 'Verge Vergesen');
-        await user.type(getByLabelText('Fødselsnummer'), '12sdf678901');
+        await user.type(screen.getByLabelText('Navn'), 'Verge Vergesen');
+        await user.type(screen.getByLabelText('Fødselsnummer'), '12sdf678901');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(queryByText('Du må skrive minst 3 tegn')).not.toBeInTheDocument();
-        expect(queryByText('Ugyldig fødselsnummer')).toBeInTheDocument();
+        expect(screen.queryByText('Du må skrive minst 3 tegn')).not.toBeInTheDocument();
+        expect(screen.queryByText('Ugyldig fødselsnummer')).toBeInTheDocument();
 
-        await user.clear(getByLabelText('Fødselsnummer'));
-        await user.type(getByLabelText('Fødselsnummer'), '27106903129');
+        await user.clear(screen.getByLabelText('Fødselsnummer'));
+        await user.type(screen.getByLabelText('Fødselsnummer'), '27106903129');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
-        expect(queryByText('Ugyldig fødselsnummer')).not.toBeInTheDocument();
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryByText('Ugyldig fødselsnummer')).not.toBeInTheDocument();
     });
 
     test('Vis utfylt - advokat - autoutført', async () => {
@@ -171,30 +167,27 @@ describe('VergeContainer', () => {
             begrunnelse: '',
         });
 
-        const { getByText, getByRole, getByLabelText, queryByLabelText } = renderVergeContainer(
-            lagBehandling({ harVerge: true }),
-            {
-                erStegBehandlet: (): boolean => true,
-                erStegAutoutført: (): boolean => true,
-            }
-        );
+        renderVergeContainer(lagBehandling({ harVerge: true }), {
+            erStegBehandlet: (): boolean => true,
+            erStegAutoutført: (): boolean => true,
+        });
 
-        expect(getByText('Verge')).toBeInTheDocument();
+        expect(screen.getByText('Verge')).toBeInTheDocument();
         expect(
             await screen.findByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         ).toBeEnabled();
 
-        expect(getByLabelText('Vergetype')).toHaveValue(Vergetype.Advokat);
-        expect(getByLabelText('Begrunn endringene')).toHaveValue('');
-        expect(getByLabelText('Navn')).toHaveValue('Advokat Advokatesen');
-        expect(getByLabelText('Organisasjonsnummer')).toHaveValue('DummyOrg');
-        expect(queryByLabelText('Fødselsnummer')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Vergetype')).toHaveValue(Vergetype.Advokat);
+        expect(screen.getByLabelText('Begrunn endringene')).toHaveValue('');
+        expect(screen.getByLabelText('Navn')).toHaveValue('Advokat Advokatesen');
+        expect(screen.getByLabelText('Organisasjonsnummer')).toHaveValue('DummyOrg');
+        expect(screen.queryByLabelText('Fødselsnummer')).not.toBeInTheDocument();
     });
 
     test('Vis utfylt - verge barn', async () => {
@@ -204,16 +197,13 @@ describe('VergeContainer', () => {
             ident: '27106903129',
             begrunnelse: 'Verge er opprettet',
         });
-        const { getByText, getByLabelText, queryByText, queryByLabelText } = renderVergeContainer(
-            lagBehandling({ harVerge: true }),
-            {
-                erStegBehandlet: (): boolean => true,
-            }
-        );
+        renderVergeContainer(lagBehandling({ harVerge: true }), {
+            erStegBehandlet: (): boolean => true,
+        });
 
-        expect(getByText('Verge')).toBeInTheDocument();
+        expect(screen.getByText('Verge')).toBeInTheDocument();
         expect(
-            queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
+            screen.queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
         ).not.toBeInTheDocument();
         expect(
             await screen.findByRole('button', {
@@ -221,11 +211,11 @@ describe('VergeContainer', () => {
             })
         ).toBeEnabled();
 
-        expect(getByLabelText('Vergetype')).toHaveValue(Vergetype.VergeForBarn);
-        expect(getByLabelText('Begrunn endringene')).toHaveValue('Verge er opprettet');
-        expect(getByLabelText('Navn')).toHaveValue('Verge Vergesen');
-        expect(getByLabelText('Fødselsnummer')).toHaveValue('27106903129');
-        expect(queryByLabelText('Organisasjonsnummer')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Vergetype')).toHaveValue(Vergetype.VergeForBarn);
+        expect(screen.getByLabelText('Begrunn endringene')).toHaveValue('Verge er opprettet');
+        expect(screen.getByLabelText('Navn')).toHaveValue('Verge Vergesen');
+        expect(screen.getByLabelText('Fødselsnummer')).toHaveValue('27106903129');
+        expect(screen.queryByLabelText('Organisasjonsnummer')).not.toBeInTheDocument();
     });
 
     test('Vis utfylt - advokat - lesevisning', async () => {
@@ -236,17 +226,14 @@ describe('VergeContainer', () => {
             begrunnelse: 'Bruker har engasjert advokat',
         });
 
-        const { getByText, queryByText, getByLabelText } = renderVergeContainer(
-            lagBehandling({ harVerge: true }),
-            {
-                erStegBehandlet: (): boolean => true,
-                behandlingILesemodus: true,
-            }
-        );
+        renderVergeContainer(lagBehandling({ harVerge: true }), {
+            erStegBehandlet: (): boolean => true,
+            behandlingILesemodus: true,
+        });
 
-        expect(getByText('Verge')).toBeInTheDocument();
+        expect(screen.getByText('Verge')).toBeInTheDocument();
         expect(
-            queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
+            screen.queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
         ).not.toBeInTheDocument();
         expect(
             await screen.findByRole('button', {
@@ -254,11 +241,11 @@ describe('VergeContainer', () => {
             })
         ).toBeEnabled();
 
-        expect(getByText('Advokat/advokatfullmektig')).toBeInTheDocument();
-        expect(getByText('Bruker har engasjert advokat')).toBeInTheDocument();
-        expect(getByLabelText('Navn')).toHaveValue('Advokat Advokatesen');
-        expect(getByLabelText('Organisasjonsnummer')).toHaveValue('DummyOrg');
-        expect(queryByText('Fødselsnummer')).not.toBeInTheDocument();
+        expect(screen.getByText('Advokat/advokatfullmektig')).toBeInTheDocument();
+        expect(screen.getByText('Bruker har engasjert advokat')).toBeInTheDocument();
+        expect(screen.getByLabelText('Navn')).toHaveValue('Advokat Advokatesen');
+        expect(screen.getByLabelText('Organisasjonsnummer')).toHaveValue('DummyOrg');
+        expect(screen.queryByLabelText('Fødselsnummer')).not.toBeInTheDocument();
     });
 
     test('Vis utfylt - verge barn - autoutført - lesevisning', async () => {
@@ -268,30 +255,27 @@ describe('VergeContainer', () => {
             ident: '27106903129',
             begrunnelse: '',
         });
-        const { getByText, getByRole, queryByText, getByLabelText } = renderVergeContainer(
-            lagBehandling({ harVerge: true }),
-            {
-                erStegBehandlet: (): boolean => true,
-                behandlingILesemodus: true,
-                erStegAutoutført: (): boolean => true,
-            }
-        );
+        renderVergeContainer(lagBehandling({ harVerge: true }), {
+            erStegBehandlet: (): boolean => true,
+            behandlingILesemodus: true,
+            erStegAutoutført: (): boolean => true,
+        });
 
-        expect(getByText('Verge')).toBeInTheDocument();
+        expect(screen.getByText('Verge')).toBeInTheDocument();
         expect(
             await screen.findByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
         ).toBeInTheDocument();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til faktasteget',
             })
         ).toBeEnabled();
 
-        expect(getByText('Verge for barn under 18 år')).toBeInTheDocument();
-        expect(getByLabelText('Navn')).toHaveValue('Verge Vergesen');
-        expect(getByLabelText('Begrunn endringene')).toHaveValue('');
-        expect(getByLabelText('Fødselsnummer')).toHaveValue('27106903129');
-        expect(queryByText('Organisasjonsnummer')).not.toBeInTheDocument();
+        expect(screen.getByText('Verge for barn under 18 år')).toBeInTheDocument();
+        expect(screen.getByLabelText('Navn')).toHaveValue('Verge Vergesen');
+        expect(screen.getByLabelText('Begrunn endringene')).toHaveValue('');
+        expect(screen.getByLabelText('Fødselsnummer')).toHaveValue('27106903129');
+        expect(screen.queryByText('Organisasjonsnummer')).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/pages/fagsak/verge/VergeContainer.test.tsx
+++ b/src/frontend/pages/fagsak/verge/VergeContainer.test.tsx
@@ -88,7 +88,7 @@ describe('VergeContainer', () => {
             })
         );
 
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(screen.getByLabelText('Vergetype'), Vergetype.Advokat);
 
@@ -99,7 +99,7 @@ describe('VergeContainer', () => {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.type(screen.getByLabelText('Navn'), 'Advokat Advokatesen');
         await user.type(screen.getByLabelText('Organisasjonsnummer'), 'DummyOrg');
@@ -124,7 +124,7 @@ describe('VergeContainer', () => {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.selectOptions(screen.getByLabelText('Vergetype'), Vergetype.VergeForBarn);
         await user.type(screen.getByLabelText('Begrunn endringene'), 'Verge er advokat');
@@ -134,7 +134,7 @@ describe('VergeContainer', () => {
                 name: 'Gå videre til faktasteget',
             })
         );
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.type(screen.getByLabelText('Navn'), 'Verge Vergesen');
         await user.type(screen.getByLabelText('Fødselsnummer'), '12sdf678901');
@@ -145,7 +145,7 @@ describe('VergeContainer', () => {
             })
         );
         expect(screen.queryByText('Du må skrive minst 3 tegn')).not.toBeInTheDocument();
-        expect(screen.queryByText('Ugyldig fødselsnummer')).toBeInTheDocument();
+        expect(screen.getByText('Ugyldig fødselsnummer')).toBeInTheDocument();
 
         await user.clear(screen.getByLabelText('Fødselsnummer'));
         await user.type(screen.getByLabelText('Fødselsnummer'), '27106903129');

--- a/src/frontend/pages/fagsak/verge/VergeContainer.test.tsx
+++ b/src/frontend/pages/fagsak/verge/VergeContainer.test.tsx
@@ -6,7 +6,7 @@ import type { VergeDto } from '~/typer/api';
 import type { Ressurs } from '~/typer/ressurs';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -83,9 +83,7 @@ describe('VergeContainer', () => {
         const { getByText, getByRole, getByLabelText, queryAllByText } =
             renderVergeContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText('Verge')).toBeInTheDocument();
-        });
+        expect(getByText('Verge')).toBeInTheDocument();
 
         await user.click(
             getByRole('button', {
@@ -123,9 +121,7 @@ describe('VergeContainer', () => {
         const { getByText, getByRole, getByLabelText, queryAllByText, queryByText } =
             renderVergeContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText('Verge')).toBeInTheDocument();
-        });
+        expect(getByText('Verge')).toBeInTheDocument();
 
         await user.click(
             getByRole('button', {
@@ -183,12 +179,10 @@ describe('VergeContainer', () => {
             }
         );
 
-        await waitFor(() => {
-            expect(getByText('Verge')).toBeInTheDocument();
-            expect(
-                getByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
-            ).toBeInTheDocument();
-        });
+        expect(getByText('Verge')).toBeInTheDocument();
+        expect(
+            await screen.findByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
+        ).toBeInTheDocument();
 
         expect(
             getByRole('button', {
@@ -210,22 +204,22 @@ describe('VergeContainer', () => {
             ident: '27106903129',
             begrunnelse: 'Verge er opprettet',
         });
-        const { getByText, getByRole, getByLabelText, queryByText, queryByLabelText } =
-            renderVergeContainer(lagBehandling({ harVerge: true }), {
+        const { getByText, getByLabelText, queryByText, queryByLabelText } = renderVergeContainer(
+            lagBehandling({ harVerge: true }),
+            {
                 erStegBehandlet: (): boolean => true,
-            });
+            }
+        );
 
-        await waitFor(() => {
-            expect(getByText('Verge')).toBeInTheDocument();
-            expect(
-                queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
-            ).not.toBeInTheDocument();
-            expect(
-                getByRole('button', {
-                    name: 'Gå videre til faktasteget',
-                })
-            ).toBeEnabled();
-        });
+        expect(getByText('Verge')).toBeInTheDocument();
+        expect(
+            queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
+        ).not.toBeInTheDocument();
+        expect(
+            await screen.findByRole('button', {
+                name: 'Gå videre til faktasteget',
+            })
+        ).toBeEnabled();
 
         expect(getByLabelText('Vergetype')).toHaveValue(Vergetype.VergeForBarn);
         expect(getByLabelText('Begrunn endringene')).toHaveValue('Verge er opprettet');
@@ -242,7 +236,7 @@ describe('VergeContainer', () => {
             begrunnelse: 'Bruker har engasjert advokat',
         });
 
-        const { getByText, getByRole, queryByText, getByLabelText } = renderVergeContainer(
+        const { getByText, queryByText, getByLabelText } = renderVergeContainer(
             lagBehandling({ harVerge: true }),
             {
                 erStegBehandlet: (): boolean => true,
@@ -250,17 +244,15 @@ describe('VergeContainer', () => {
             }
         );
 
-        await waitFor(() => {
-            expect(getByText('Verge')).toBeInTheDocument();
-            expect(
-                queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
-            ).not.toBeInTheDocument();
-            expect(
-                getByRole('button', {
-                    name: 'Gå videre til faktasteget',
-                })
-            ).toBeEnabled();
-        });
+        expect(getByText('Verge')).toBeInTheDocument();
+        expect(
+            queryByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
+        ).not.toBeInTheDocument();
+        expect(
+            await screen.findByRole('button', {
+                name: 'Gå videre til faktasteget',
+            })
+        ).toBeEnabled();
 
         expect(getByText('Advokat/advokatfullmektig')).toBeInTheDocument();
         expect(getByText('Bruker har engasjert advokat')).toBeInTheDocument();
@@ -285,12 +277,10 @@ describe('VergeContainer', () => {
             }
         );
 
-        await waitFor(() => {
-            expect(getByText('Verge')).toBeInTheDocument();
-            expect(
-                getByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
-            ).toBeInTheDocument();
-        });
+        expect(getByText('Verge')).toBeInTheDocument();
+        expect(
+            await screen.findByText('Automatisk vurdert. Verge er kopiert fra fagsystemet.')
+        ).toBeInTheDocument();
 
         expect(
             getByRole('button', {

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainer.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainer.test.tsx
@@ -125,7 +125,7 @@ describe('VilkårsvurderingContainer', () => {
             })
         );
 
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(
             screen.getByLabelText(
@@ -142,7 +142,7 @@ describe('VilkårsvurderingContainer', () => {
                 name: 'Neste periode',
             })
         );
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.type(
             screen.getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor'),
@@ -166,7 +166,7 @@ describe('VilkårsvurderingContainer', () => {
                 name: 'Neste periode',
             })
         );
-        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(
             screen.getByRole('radio', {
@@ -239,7 +239,7 @@ describe('VilkårsvurderingContainer', () => {
         );
         expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
         expect(
-            screen.queryByText(
+            screen.getByText(
                 'Totalbeløpet kan være under 4 rettsgebyr. Dersom 6.ledd skal anvendes for å frafalle tilbakekrevingen, må denne anvendes likt på alle periodene.'
             )
         ).toBeInTheDocument();

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainer.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainer.test.tsx
@@ -1,4 +1,3 @@
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { BehandlingDto } from '~/generated';
@@ -77,9 +76,9 @@ const setupUseBehandlingApiMock = (vilkårsvurdering: VilkårsvurderingResponse)
     }));
 };
 
-const renderVilkårsvurderingContainer = (behandling: BehandlingDto): RenderResult => {
+const renderVilkårsvurderingContainer = (behandling: BehandlingDto): void => {
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak({ ytelsestype: 'BARNETRYGD' })}>
                 <TestBehandlingProvider
@@ -111,26 +110,25 @@ describe('VilkårsvurderingContainer', () => {
             })
         );
 
-        const { getByText, getByRole, getByLabelText, getByTestId, queryAllByText, queryByText } =
-            renderVilkårsvurderingContainer(lagBehandling());
+        renderVilkårsvurderingContainer(lagBehandling());
 
         expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
         await user.type(
-            getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
+            screen.getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
             'Begrunnelse vilkårene 1'
         );
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Neste periode',
             })
         );
 
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker forsto eller burde forstått at utbetalingen skyldtes en feil',
                 {
                     selector: 'input',
@@ -140,60 +138,60 @@ describe('VilkårsvurderingContainer', () => {
         );
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Neste periode',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(2);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.type(
-            getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor'),
+            screen.getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor'),
             'Begrunnelse aktsomhet 1'
         );
         await user.click(
-            getByLabelText('Mottaker burde forstått at utbetalingen skyldtes en feil')
+            screen.getByLabelText('Mottaker burde forstått at utbetalingen skyldtes en feil')
         );
 
         expect(
-            getByText(
+            screen.getByText(
                 'Totalbeløpet kan være under 4 ganger rettsgebyret (6. ledd). Skal det tilbakekreves?'
             )
         ).toBeInTheDocument();
         expect(
-            queryByText('Når 6. ledd anvendes må alle perioder behandles likt')
+            screen.queryByText('Når 6. ledd anvendes må alle perioder behandles likt')
         ).not.toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Neste periode',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(
-            getByRole('radio', {
+            screen.getByRole('radio', {
                 name: 'Nei',
             })
         );
 
         expect(
-            queryByText('Når 6. ledd anvendes må alle perioder behandles likt')
+            screen.getByText('Når 6. ledd anvendes må alle perioder behandles likt')
         ).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Neste periode',
             })
         );
 
-        expect(getByText(andrePeriode, { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText(andrePeriode, { selector: 'p' })).toBeInTheDocument();
 
         await user.type(
-            getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
+            screen.getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
             'Begrunnelse vilkårene 2'
         );
         await user.click(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker forsto eller burde forstått at utbetalingen skyldtes en feil',
                 {
                     selector: 'input',
@@ -202,46 +200,46 @@ describe('VilkårsvurderingContainer', () => {
             )
         );
         await user.type(
-            getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor'),
+            screen.getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor'),
             'Begrunnelse aktsomhet 2'
         );
         await user.click(
-            getByLabelText('Mottaker burde forstått at utbetalingen skyldtes en feil')
+            screen.getByLabelText('Mottaker burde forstått at utbetalingen skyldtes en feil')
         );
         expect(
-            getByText(
+            screen.getByText(
                 'Totalbeløpet kan være under 4 ganger rettsgebyret (6. ledd). Skal det tilbakekreves?'
             )
         ).toBeInTheDocument();
         await user.click(
-            getByRole('radio', {
+            screen.getByRole('radio', {
                 name: 'Ja',
             })
         );
 
-        expect(getByText('Begrunn resultatet av vurderingen ovenfor')).toBeInTheDocument();
+        expect(screen.getByText('Begrunn resultatet av vurderingen ovenfor')).toBeInTheDocument();
 
         await user.type(
-            getByLabelText('Begrunn resultatet av vurderingen ovenfor'),
+            screen.getByLabelText('Begrunn resultatet av vurderingen ovenfor'),
             'Begrunnelse særlige grunner 2'
         );
         await user.click(
-            getByLabelText('Graden av uaktsomhet hos den som kravet retter seg mot', {
+            screen.getByLabelText('Graden av uaktsomhet hos den som kravet retter seg mot', {
                 selector: 'input',
             })
         );
-        await user.click(getByTestId('harGrunnerTilReduksjon_Nei'));
+        await user.click(screen.getByTestId('harGrunnerTilReduksjon_Nei'));
 
-        expect(getByText('100%')).toBeInTheDocument();
+        expect(screen.getByText('100%')).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vedtakssteget',
             })
         );
-        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
         expect(
-            queryByText(
+            screen.queryByText(
                 'Totalbeløpet kan være under 4 rettsgebyr. Dersom 6.ledd skal anvendes for å frafalle tilbakekrevingen, må denne anvendes likt på alle periodene.'
             )
         ).toBeInTheDocument();
@@ -249,65 +247,67 @@ describe('VilkårsvurderingContainer', () => {
 
     test('Vis og fyll ut perioder og send inn - god tro - bruker kopiering', async () => {
         setupUseBehandlingApiMock(lagVilkårsvurderingResponse({ perioder }));
-        const { getByText, getByRole, getByLabelText } =
-            renderVilkårsvurderingContainer(lagBehandling());
+        renderVilkårsvurderingContainer(lagBehandling());
 
         expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
         await user.type(
-            getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
+            screen.getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
             'Begrunnelse1'
         );
         await user.click(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })
         );
         await user.click(
-            getByRole('radio', {
+            screen.getByRole('radio', {
                 name: 'Nei',
             })
         );
-        await user.type(getByLabelText('Begrunn hvorfor beløpet ikke er i behold'), 'Begrunnelse2');
+        await user.type(
+            screen.getByLabelText('Begrunn hvorfor beløpet ikke er i behold'),
+            'Begrunnelse2'
+        );
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Neste periode',
             })
         );
 
-        expect(getByText(andrePeriode)).toBeInTheDocument();
+        expect(screen.getByText(andrePeriode)).toBeInTheDocument();
         await user.selectOptions(
-            getByRole('combobox', {
+            screen.getByRole('combobox', {
                 name: 'Kopier vilkårsvurdering fra',
             }),
             førstePeriode
         );
-        expect(getByText('Er beløpet i behold?')).toBeInTheDocument();
-        expect(getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
+        expect(screen.getByText('Er beløpet i behold?')).toBeInTheDocument();
+        expect(screen.getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
             `${perioder[0].begrunnelse}Begrunnelse1`
         );
         expect(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeChecked();
         expect(
-            getByRole('radio', {
+            screen.getByRole('radio', {
                 name: 'Nei',
             })
         ).toBeChecked();
-        expect(getByLabelText('Begrunn hvorfor beløpet ikke er i behold')).toHaveValue(
+        expect(screen.getByLabelText('Begrunn hvorfor beløpet ikke er i behold')).toHaveValue(
             'Begrunnelse2'
         );
 
-        const tilbakekrevdBeløp = getByLabelText('Beløp som skal tilbakekreves');
+        const tilbakekrevdBeløp = screen.getByLabelText('Beløp som skal tilbakekreves');
         expect(tilbakekrevdBeløp).toHaveValue('0');
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Gå videre til vedtakssteget',
             })
         );
@@ -341,16 +341,15 @@ describe('VilkårsvurderingContainer', () => {
             ],
         });
         setupUseBehandlingApiMock(vilkårsvurderingResponse);
-        const { getByText, getByRole, getByLabelText, getByTestId } =
-            renderVilkårsvurderingContainer(lagBehandling());
+        renderVilkårsvurderingContainer(lagBehandling());
 
         expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
-        expect(getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
+        expect(screen.getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
             'Begrunnelse vilkår 1'
         );
         expect(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker forsto eller burde forstått at utbetalingen skyldtes en feil',
                 {
                     selector: 'input',
@@ -358,42 +357,44 @@ describe('VilkårsvurderingContainer', () => {
                 }
             )
         ).toBeChecked();
-        expect(getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor')).toHaveTextContent(
-            'Begrunnelse aktsomhet 1'
-        );
-        expect(getByLabelText('Mottaker forsto at utbetalingen skyldtes en feil')).toBeChecked();
+        expect(
+            screen.getByLabelText('Begrunn hvorfor du valgte alternativet ovenfor')
+        ).toHaveTextContent('Begrunnelse aktsomhet 1');
+        expect(
+            screen.getByLabelText('Mottaker forsto at utbetalingen skyldtes en feil')
+        ).toBeChecked();
 
-        expect(getByTestId('skalDetTilleggesRenter_Nei')).toBeChecked();
+        expect(screen.getByTestId('skalDetTilleggesRenter_Nei')).toBeChecked();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         );
 
         expect(
-            getByText(andrePeriode, {
+            screen.getByText(andrePeriode, {
                 selector: 'p',
             })
         ).toBeInTheDocument();
 
-        expect(getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
+        expect(screen.getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
             'Begrunnelse vilkår 2'
         );
         expect(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeChecked();
-        expect(getByLabelText('Begrunn hvorfor beløpet ikke er i behold')).toHaveTextContent(
+        expect(screen.getByLabelText('Begrunn hvorfor beløpet ikke er i behold')).toHaveTextContent(
             'Begrunnelse god tro 2'
         );
-        expect(getByLabelText('Nei')).toBeChecked();
-        const tilbakekrevdBeløp = getByLabelText('Beløp som skal tilbakekreves');
+        expect(screen.getByLabelText('Nei')).toBeChecked();
+        const tilbakekrevdBeløp = screen.getByLabelText('Beløp som skal tilbakekreves');
         expect(tilbakekrevdBeløp).toHaveValue('0');
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Forrige periode',
             })
         );
@@ -429,14 +430,13 @@ describe('VilkårsvurderingContainer', () => {
             })
         );
 
-        const { getByText, getByRole, getByLabelText } =
-            renderVilkårsvurderingContainer(lagBehandling());
+        renderVilkårsvurderingContainer(lagBehandling());
 
         expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
-        expect(getByText('Begrunnelse vilkår 1')).toBeInTheDocument();
+        expect(screen.getByText('Begrunnelse vilkår 1')).toBeInTheDocument();
         expect(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker forsto eller burde forstått at utbetalingen skyldtes en feil',
                 {
                     selector: 'input',
@@ -445,52 +445,52 @@ describe('VilkårsvurderingContainer', () => {
             )
         ).toBeChecked();
         expect(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })
         ).not.toBeChecked();
 
-        expect(getByText('Begrunnelse aktsomhet 1')).toBeInTheDocument();
+        expect(screen.getByText('Begrunnelse aktsomhet 1')).toBeInTheDocument();
         expect(
-            getByLabelText('Mottaker forsto at utbetalingen skyldtes en feil', {
+            screen.getByLabelText('Mottaker forsto at utbetalingen skyldtes en feil', {
                 selector: 'input',
             })
         ).toBeChecked();
         expect(
-            getByLabelText('Mottaker må ha forstått at utbetalingen skyldtes en feil', {
+            screen.getByLabelText('Mottaker må ha forstått at utbetalingen skyldtes en feil', {
                 selector: 'input',
                 exact: false,
             })
         ).not.toBeChecked();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.01.2020 til 31.03.2020',
             })
         ).toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         ).toBeInTheDocument();
 
         await user.click(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         );
 
-        expect(getByText(andrePeriode, { selector: 'p' })).toBeInTheDocument();
-        expect(getByText('Begrunnelse vilkår 2')).toBeInTheDocument();
+        expect(screen.getByText(andrePeriode, { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText('Begrunnelse vilkår 2')).toBeInTheDocument();
         expect(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })
         ).toBeChecked();
         expect(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker forsto eller burde forstått at utbetalingen skyldtes en feil',
                 {
                     selector: 'input',
@@ -498,27 +498,27 @@ describe('VilkårsvurderingContainer', () => {
                 }
             )
         ).not.toBeChecked();
-        expect(getByText('Begrunnelse god tro 2')).toBeInTheDocument();
+        expect(screen.getByText('Begrunnelse god tro 2')).toBeInTheDocument();
         expect(
-            getByLabelText('Nei', {
+            screen.getByLabelText('Nei', {
                 selector: 'input',
                 exact: true,
             })
         ).toBeChecked();
         expect(
-            getByLabelText('Ja', {
+            screen.getByLabelText('Ja', {
                 selector: 'input',
                 exact: true,
             })
         ).not.toBeChecked();
 
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         ).toBeInTheDocument();
         expect(
-            getByRole('button', {
+            screen.getByRole('button', {
                 name: 'Suksess fra 01.05.2020 til 30.06.2020',
             })
         ).toBeInTheDocument();
@@ -536,7 +536,7 @@ describe('VilkårsvurderingContainer', () => {
             ],
         });
         setupUseBehandlingApiMock(vilkårsvurderingResponse);
-        const { getByText, getByLabelText } = renderVilkårsvurderingContainer(lagBehandling());
+        renderVilkårsvurderingContainer(lagBehandling());
 
         expect(
             await screen.findByRole('button', {
@@ -544,9 +544,9 @@ describe('VilkårsvurderingContainer', () => {
             })
         ).toBeInTheDocument();
 
-        expect(getByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
         expect(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker forsto eller burde forstått at utbetalingen skyldtes en feil',
                 {
                     selector: 'input',
@@ -555,7 +555,7 @@ describe('VilkårsvurderingContainer', () => {
             )
         ).not.toBeChecked();
         expect(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker har forårsaket feilutbetalingen ved forsett eller uaktsomt gitt feilaktige opplysninger',
                 {
                     selector: 'input',
@@ -564,7 +564,7 @@ describe('VilkårsvurderingContainer', () => {
             )
         ).not.toBeChecked();
         expect(
-            getByLabelText(
+            screen.getByLabelText(
                 'Mottaker har forårsaket feilutbetalingen ved forsett eller uaktsomt gitt mangelfulle opplysninger',
                 {
                     selector: 'input',
@@ -573,7 +573,7 @@ describe('VilkårsvurderingContainer', () => {
             )
         ).not.toBeChecked();
         expect(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainer.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainer.test.tsx
@@ -9,7 +9,7 @@ import type {
 } from '~/typer/tilbakekrevingstyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -114,9 +114,7 @@ describe('VilkårsvurderingContainer', () => {
         const { getByText, getByRole, getByLabelText, getByTestId, queryAllByText, queryByText } =
             renderVilkårsvurderingContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
-        });
+        expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
         await user.type(
             getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
@@ -129,9 +127,7 @@ describe('VilkårsvurderingContainer', () => {
             })
         );
 
-        await waitFor(() => {
-            expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
-        });
+        expect(queryAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(
             getByLabelText(
@@ -256,9 +252,7 @@ describe('VilkårsvurderingContainer', () => {
         const { getByText, getByRole, getByLabelText } =
             renderVilkårsvurderingContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText(førstePeriode)).toBeInTheDocument();
-        });
+        expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
         await user.type(
             getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor'),
@@ -350,9 +344,7 @@ describe('VilkårsvurderingContainer', () => {
         const { getByText, getByRole, getByLabelText, getByTestId } =
             renderVilkårsvurderingContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
-        });
+        expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
         expect(getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor')).toHaveValue(
             'Begrunnelse vilkår 1'
@@ -440,9 +432,7 @@ describe('VilkårsvurderingContainer', () => {
         const { getByText, getByRole, getByLabelText } =
             renderVilkårsvurderingContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(getByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
-        });
+        expect(await screen.findByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
 
         expect(getByText('Begrunnelse vilkår 1')).toBeInTheDocument();
         expect(
@@ -546,16 +536,13 @@ describe('VilkårsvurderingContainer', () => {
             ],
         });
         setupUseBehandlingApiMock(vilkårsvurderingResponse);
-        const { getByText, getByRole, getByLabelText } =
-            renderVilkårsvurderingContainer(lagBehandling());
+        const { getByText, getByLabelText } = renderVilkårsvurderingContainer(lagBehandling());
 
-        await waitFor(() => {
-            expect(
-                getByRole('button', {
-                    name: 'Nøytral fra 01.01.2020 til 31.03.2020',
-                })
-            ).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByRole('button', {
+                name: 'Nøytral fra 01.01.2020 til 31.03.2020',
+            })
+        ).toBeInTheDocument();
 
         expect(getByText(førstePeriode, { selector: 'p' })).toBeInTheDocument();
         expect(

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainerAutoutført.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContainerAutoutført.test.tsx
@@ -3,7 +3,7 @@ import type { Ressurs } from '~/typer/ressurs';
 import type { VilkårsvurderingResponse } from '~/typer/tilbakekrevingstyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { FagsakContext } from '~/context/FagsakContext';
@@ -48,7 +48,7 @@ describe('VilkårsvurderingContainer', () => {
         setupMock();
         const behandling = lagBehandling();
 
-        const { getByText } = render(
+        render(
             <FagsakContext value={lagFagsak()}>
                 <QueryClientProvider client={queryClient}>
                     <TestBehandlingProvider
@@ -65,8 +65,8 @@ describe('VilkårsvurderingContainer', () => {
             </FagsakContext>
         );
 
-        await waitFor(() => {
-            expect(getByText('Automatisk vurdert. Alle perioder er foreldet.')).toBeInTheDocument();
-        });
+        expect(
+            await screen.findByText('Automatisk vurdert. Alle perioder er foreldet.')
+        ).toBeInTheDocument();
     });
 });

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingPerioder.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingPerioder.test.tsx
@@ -1,4 +1,4 @@
-import type { ByRoleMatcher, ByRoleOptions, RenderResult } from '@testing-library/react';
+import type { ByRoleMatcher, ByRoleOptions } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingApiHook } from '~/api/behandling';
 import type { Ressurs } from '~/typer/ressurs';
@@ -8,7 +8,7 @@ import type {
 } from '~/typer/tilbakekrevingstyper';
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -71,14 +71,14 @@ const setupMocks = (): void => {
     }));
 };
 
-const renderVilkårsvurderingPerioder = (): RenderResult => {
+const renderVilkårsvurderingPerioder = (): void => {
     const skjemaData = perioder.map((periode, index) => ({
         index: `idx_fpsd_${index}`,
         ...periode,
     }));
     const behandling = lagBehandling();
     const queryClient = createTestQueryClient();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider
@@ -125,9 +125,9 @@ describe('VilkårsvurderingPerioder', () => {
     });
 
     test('Skal bytte periode når det ikke er ulagrede endringer', async () => {
-        const { getAllByRole } = renderVilkårsvurderingPerioder();
+        renderVilkårsvurderingPerioder();
 
-        const andrePeriodeButton = findPeriodButton(getAllByRole, '01.05.2020');
+        const andrePeriodeButton = findPeriodButton(screen.getAllByRole, '01.05.2020');
         if (!andrePeriodeButton) {
             throw new Error('Andre periode button ikke funnet');
         }
@@ -137,88 +137,95 @@ describe('VilkårsvurderingPerioder', () => {
     });
 
     test('Skal vise modal ved bytte av periode med ulagrede endringer', async () => {
-        const { getByText, getAllByRole, getByLabelText } = renderVilkårsvurderingPerioder();
+        renderVilkårsvurderingPerioder();
 
-        const begrunnelseInput = getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor');
+        const begrunnelseInput = screen.getByLabelText(
+            'Begrunn hvorfor du valgte vilkåret ovenfor'
+        );
         await user.type(begrunnelseInput, 'Test begrunnelse som ikke er lagret');
 
-        const andrePeriodeButton = findPeriodButton(getAllByRole, '01.05.2020');
+        const andrePeriodeButton = findPeriodButton(screen.getAllByRole, '01.05.2020');
         if (!andrePeriodeButton) {
             throw new Error('Andre periode button ikke funnet');
         }
 
         await user.click(andrePeriodeButton);
 
-        expect(getByText(modalTekst)).toBeInTheDocument();
+        expect(screen.getByText(modalTekst)).toBeInTheDocument();
     });
 
     test('Skal bytte uten å lagre når "Fortsett uten å lagre" klikkes', async () => {
-        const { getByText, getByRole, getAllByRole, getByLabelText, queryByText } =
-            renderVilkårsvurderingPerioder();
+        renderVilkårsvurderingPerioder();
 
-        const begrunnelseInput = getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor');
+        const begrunnelseInput = screen.getByLabelText(
+            'Begrunn hvorfor du valgte vilkåret ovenfor'
+        );
         await user.type(begrunnelseInput, 'Test begrunnelse som ikke er lagret');
 
-        const andrePeriodeButton = findPeriodButton(getAllByRole, '01.05.2020');
+        const andrePeriodeButton = findPeriodButton(screen.getAllByRole, '01.05.2020');
         if (andrePeriodeButton) {
             await user.click(andrePeriodeButton);
         }
 
-        expect(getByText(modalTekst)).toBeInTheDocument();
-        await user.click(getByRole('button', { name: 'Fortsett uten å lagre' }));
+        expect(screen.getByText(modalTekst)).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Fortsett uten å lagre' }));
 
         expect(andrePeriodeButton).toHaveAttribute('aria-current', 'true');
-        expect(queryByText(modalTekst)).not.toBeInTheDocument();
+        expect(screen.queryByText(modalTekst)).not.toBeInTheDocument();
     });
 
     test('Skal lagre og bytte når "Lagre og bytt periode" klikkes', async () => {
-        const { getByText, getByRole, getAllByRole, getByLabelText, queryByText } =
-            renderVilkårsvurderingPerioder();
+        renderVilkårsvurderingPerioder();
 
-        const begrunnelseInput = getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor');
+        const begrunnelseInput = screen.getByLabelText(
+            'Begrunn hvorfor du valgte vilkåret ovenfor'
+        );
         await user.type(begrunnelseInput, 'Gyldig begrunnelse');
 
         await user.click(
-            getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
+            screen.getByLabelText('Mottaker har mottatt beløpet i aktsom god tro', {
                 selector: 'input',
                 exact: false,
             })
         );
 
-        await user.click(getByRole('radio', { name: 'Nei' }));
-        const godTroBegrunnelseInput = getByLabelText('Begrunn hvorfor beløpet ikke er i behold');
+        await user.click(screen.getByRole('radio', { name: 'Nei' }));
+        const godTroBegrunnelseInput = screen.getByLabelText(
+            'Begrunn hvorfor beløpet ikke er i behold'
+        );
         await user.type(godTroBegrunnelseInput, 'Beløp vurdering');
 
-        const andrePeriodeButton = findPeriodButton(getAllByRole, '01.05.2020');
+        const andrePeriodeButton = findPeriodButton(screen.getAllByRole, '01.05.2020');
         if (andrePeriodeButton) {
             await user.click(andrePeriodeButton);
         }
 
-        expect(getByText(modalTekst)).toBeInTheDocument();
-        await user.click(getByRole('button', { name: 'Lagre og bytt periode' }));
+        expect(screen.getByText(modalTekst)).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Lagre og bytt periode' }));
 
         expect(andrePeriodeButton).toHaveAttribute('aria-current', 'true');
-        expect(queryByText(modalTekst)).not.toBeInTheDocument();
+        expect(screen.queryByText(modalTekst)).not.toBeInTheDocument();
     });
 
     test('Skal lukke modal og forbli på nåværende periode når "Lukk" klikkes', async () => {
-        const { getByText, getByRole, getAllByRole, getByLabelText, queryByText } =
-            renderVilkårsvurderingPerioder();
+        renderVilkårsvurderingPerioder();
 
-        const begrunnelseInput = getByLabelText('Begrunn hvorfor du valgte vilkåret ovenfor');
+        const begrunnelseInput = screen.getByLabelText(
+            'Begrunn hvorfor du valgte vilkåret ovenfor'
+        );
         await user.type(begrunnelseInput, 'Test begrunnelse');
 
-        const førstePeriodeButton = findPeriodButton(getAllByRole, '01.01.2020');
-        const andrePeriodeButton = findPeriodButton(getAllByRole, '01.05.2020');
+        const førstePeriodeButton = findPeriodButton(screen.getAllByRole, '01.01.2020');
+        const andrePeriodeButton = findPeriodButton(screen.getAllByRole, '01.05.2020');
         if (andrePeriodeButton) {
             await user.click(andrePeriodeButton);
         }
 
-        expect(getByText(modalTekst)).toBeInTheDocument();
-        await user.click(getByRole('button', { name: 'Lukk' }));
+        expect(screen.getByText(modalTekst)).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: 'Lukk' }));
 
         expect(førstePeriodeButton).toHaveAttribute('aria-current', 'true');
-        expect(queryByText(modalTekst)).not.toBeInTheDocument();
+        expect(screen.queryByText(modalTekst)).not.toBeInTheDocument();
         expect(begrunnelseInput).toHaveValue('Test begrunnelse');
     });
 });

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.test.tsx
@@ -1,5 +1,4 @@
 import type { VilkårsvurderingPeriodeSkjemaData } from '../typer/vilkårsvurdering';
-import type { RenderResult } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { BehandlingDto } from '~/generated';
 import type { VilkårsvurderingHook } from '~/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/VilkårsvurderingContext';
@@ -52,10 +51,10 @@ const renderVilkårsvurderingPeriodeSkjema = ({
     behandletPerioder?: VilkårsvurderingPeriodeSkjemaData[];
     behandling?: BehandlingDto;
     perioder?: VilkårsvurderingPeriodeSkjemaData[];
-}): RenderResult => {
+}): void => {
     const queryClient = createTestQueryClient();
     const defaultPeriode = periode ?? lagVilkårsvurderingPeriodeSkjemaData();
-    return render(
+    render(
         <QueryClientProvider client={queryClient}>
             <FagsakContext value={lagFagsak()}>
                 <TestBehandlingProvider behandling={behandling}>
@@ -250,16 +249,16 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
                 },
             ],
         });
-        const { getByText } = renderVilkårsvurderingPeriodeSkjema({
+        renderVilkårsvurderingPeriodeSkjema({
             periode: vilkårsvurderingPeriode,
             erTotalbeløpUnder4Rettsgebyr: false,
             behandletPerioder: [lagVilkårsvurderingPeriodeSkjemaData()],
         });
 
-        expect(getByText('Aktivitet 1')).toBeInTheDocument();
-        expect(getByText('1 333')).toBeInTheDocument();
-        expect(getByText('Aktivitet 2')).toBeInTheDocument();
-        expect(getByText('1 000')).toBeInTheDocument();
+        expect(screen.getByText('Aktivitet 1')).toBeInTheDocument();
+        expect(screen.getByText('1 333')).toBeInTheDocument();
+        expect(screen.getByText('Aktivitet 2')).toBeInTheDocument();
+        expect(screen.getByText('1 000')).toBeInTheDocument();
 
         await user.click(godTroValg());
         await user.type(begrunnVilkår(), 'begrunnelse');
@@ -589,7 +588,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
     });
 
     test('Mangelfulle - uaktsomt - under 4 rettsgebyr - ingen grunn til reduksjon', async () => {
-        const { getByText } = renderVilkårsvurderingPeriodeSkjema({
+        renderVilkårsvurderingPeriodeSkjema({
             erTotalbeløpUnder4Rettsgebyr: true,
         });
 
@@ -615,8 +614,8 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
 
         await user.type(begrunnResultat(), 'begrunnelse');
 
-        expect(getByText('Andel som skal tilbakekreves')).toBeInTheDocument();
-        expect(getByText('100%')).toBeInTheDocument();
+        expect(screen.getByText('Andel som skal tilbakekreves')).toBeInTheDocument();
+        expect(screen.getByText('100%')).toBeInTheDocument();
         expect(queryRentetilleggGruppe()).not.toBeInTheDocument();
 
         await user.click(gåVidereKnapp());
@@ -718,7 +717,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
                 },
             },
         });
-        const { getByTestId } = renderVilkårsvurderingPeriodeSkjema({
+        renderVilkårsvurderingPeriodeSkjema({
             periode: periode,
             erTotalbeløpUnder4Rettsgebyr: true,
         });
@@ -740,7 +739,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
 
         expect(under4RettsgebyrJa()).toBeChecked();
 
-        expect(getByTestId('andelSomTilbakekrevesManuell')).toHaveValue('33');
+        expect(screen.getByTestId('andelSomTilbakekrevesManuell')).toHaveValue('33');
     });
 
     test('Viser særlige grunner og for over 4 rettsgebyr alternativ - uaktsomt', async () => {
@@ -766,14 +765,14 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
                 },
             },
         });
-        const { getByTestId } = renderVilkårsvurderingPeriodeSkjema({
+        renderVilkårsvurderingPeriodeSkjema({
             periode: periode,
             behandling: lagBehandling({ erNyModell: true }),
             erTotalbeløpUnder4Rettsgebyr: true,
         });
         under4RettsgebyrGruppe();
         expect(
-            getByTestId('tilbakekrevSelvOmBeloepErUnder4Rettsgebyr_Over4Rettsgebyr')
+            screen.getByTestId('tilbakekrevSelvOmBeloepErUnder4Rettsgebyr_Over4Rettsgebyr')
         ).toBeChecked();
         særligeGrunnerGruppe();
     });
@@ -801,13 +800,13 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
                 },
             },
         });
-        const { queryByTestId } = renderVilkårsvurderingPeriodeSkjema({
+        renderVilkårsvurderingPeriodeSkjema({
             periode: periode,
             erTotalbeløpUnder4Rettsgebyr: true,
         });
         under4RettsgebyrGruppe();
         expect(
-            queryByTestId('tilbakekrevSelvOmBeloepErUnder4Rettsgebyr_Over4Rettsgebyr')
+            screen.queryByTestId('tilbakekrevSelvOmBeloepErUnder4Rettsgebyr_Over4Rettsgebyr')
         ).not.toBeInTheDocument();
     });
 });

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.test.tsx
@@ -211,7 +211,6 @@ const gåVidereKnapp = (): HTMLElement =>
     screen.getByRole('button', { name: 'Gå videre til vedtakssteget' });
 
 // Feilmeldinger
-const antallFeiledeFelter = (): HTMLElement[] => screen.queryAllByText('Feltet må fylles ut');
 const særligGrunnFeil = (): HTMLElement[] =>
     screen.queryAllByText('Du må velge minst en særlig grunn');
 
@@ -264,7 +263,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnVilkår(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(beløpIBeholdNei());
         await user.type(begrunnBeløpIkkeIBehold(), 'begrunnelse');
@@ -273,7 +272,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(tilbakekrevdBeløp).toHaveValue('0');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('God tro - beløp i behold', async () => {
@@ -286,12 +285,12 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnBeløpIBehold(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.type(angiBeløpTilbakekreves(), '2000');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Forsto/burde forstått - forsto', async () => {
@@ -301,7 +300,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnVilkår(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.click(mottakerForstoValg());
         await user.type(begrunnAlternativ(), 'begrunnelse');
@@ -309,7 +308,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(rentetilleggNei()).toBeChecked();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Forsto/burde forstått - må ha forstått - ingen grunn til reduksjon', async () => {
@@ -322,7 +321,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnAlternativ(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
         expect(særligGrunnFeil()).toHaveLength(1);
 
         await user.click(gradAvUaktsomhetValg());
@@ -335,12 +334,12 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(rentetilleggNei()).toBeChecked();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.type(begrunnAnnet(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Feilaktig - forsto', async () => {
@@ -350,7 +349,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnVilkår(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.click(forsettligValg());
         await user.type(begrunnAktsomhetsgrad(), 'begrunnelse');
@@ -358,7 +357,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(rentetilleggJa()).toBeChecked();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('BAKS - Feilaktig - forsto', async () => {
@@ -370,7 +369,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnVilkår(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.click(forsettligValg());
         await user.type(begrunnAktsomhetsgrad(), 'begrunnelse');
@@ -378,7 +377,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(rentetilleggNei()).toBeChecked();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Feilaktige - grovt uaktsomt - ingen grunn til reduksjon', async () => {
@@ -391,7 +390,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnAktsomhetsgrad(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
         expect(særligGrunnFeil()).toHaveLength(1);
 
         await user.click(gradAvUaktsomhetValg());
@@ -403,7 +402,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.click(gåVidereKnapp());
 
         expect(særligGrunnFeil()).toHaveLength(0);
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('BAKS - Feilaktige - grovt uaktsomt - ingen grunn til reduksjon', async () => {
@@ -418,7 +417,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnAktsomhetsgrad(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
         expect(særligGrunnFeil()).toHaveLength(1);
 
         await user.click(gradAvUaktsomhetValg());
@@ -430,7 +429,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.click(gåVidereKnapp());
 
         expect(særligGrunnFeil()).toHaveLength(0);
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Feilaktige - grovt uaktsomt - grunn til reduksjon', async () => {
@@ -444,7 +443,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
 
         await user.click(gåVidereKnapp());
         expect(særligGrunnFeil()).toHaveLength(1);
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
 
         await user.click(gradAvUaktsomhetValg());
 
@@ -453,14 +452,14 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnResultat(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.selectOptions(andelTilbakekrevesSelect(), '30');
 
         expect(rentetilleggJa()).toBeChecked();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('nyModell - Feilaktige - grovt uaktsomt - låst ja rentetillegg', async () => {
@@ -515,18 +514,18 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
 
         const andelAvBeløp = andelTilbakekrevesSelect();
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.selectOptions(andelAvBeløp, 'Egendefinert');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         const andelAvBeløpFritekst = andelTilbakekrevesFritekst();
         await user.type(andelAvBeløpFritekst, '22');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Mangelfulle - grovt uaktsomt - ingen grunn til reduksjon - ileggRenter er true', async () => {
@@ -543,7 +542,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnResultat(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
 
         const oppdatertPeriode = mockOppdaterPeriode.mock.calls[0][0];
         expect(oppdatertPeriode.vilkårsvurderingsresultatInfo.aktsomhet.ileggRenter).toBe(true);
@@ -561,12 +560,12 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnAktsomhetsgrad(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(under4RettsgebyrJa());
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
         expect(særligGrunnFeil()).toHaveLength(1);
 
         await user.click(gradAvUaktsomhetValg());
@@ -579,12 +578,12 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         andelTilbakekrevesSelect();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.selectOptions(andelTilbakekrevesSelect(), '30');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Mangelfulle - uaktsomt - under 4 rettsgebyr - ingen grunn til reduksjon', async () => {
@@ -599,13 +598,13 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         await user.type(begrunnAktsomhetsgrad(), 'begrunnelse');
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(under4RettsgebyrJa());
         expect(sjetteLeddInfoTekst()).not.toBeInTheDocument();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(2);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(2);
         expect(særligGrunnFeil()).toHaveLength(1);
 
         await user.click(gradAvUaktsomhetValg());
@@ -619,7 +618,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(queryRentetilleggGruppe()).not.toBeInTheDocument();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Mangelfulle - uaktsomt - under 4 rettsgebyr - ikke tilbakekreves - én periode viser ikke 6. ledd-advarsel', async () => {
@@ -636,14 +635,14 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(sjetteLeddInfoTekst()).not.toBeInTheDocument();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(1);
+        expect(screen.getAllByText('Feltet må fylles ut')).toHaveLength(1);
 
         await user.click(under4RettsgebyrNei());
 
         expect(sjetteLeddInfoTekst()).not.toBeInTheDocument();
 
         await user.click(gåVidereKnapp());
-        expect(antallFeiledeFelter()).toHaveLength(0);
+        expect(screen.queryAllByText('Feltet må fylles ut')).toHaveLength(0);
     });
 
     test('Mangelfulle - uaktsomt - under 4 rettsgebyr - ikke tilbakekreves - flere perioder viser 6. ledd-advarsel', async () => {

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.test.tsx
@@ -670,7 +670,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(sjetteLeddInfoTekst()).toBeInTheDocument();
     });
 
-    test('Åpner vurdert periode - god tro - beløp i behold', async () => {
+    test('Åpner vurdert periode - god tro - beløp i behold', () => {
         const periode = lagVilkårsvurderingPeriodeSkjemaData({
             begrunnelse: 'Gitt i god tro',
             vilkårsvurderingsresultatInfo: {
@@ -693,7 +693,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(angiBeløpTilbakekreves()).toHaveValue('699');
     });
 
-    test('Åpner vurdert periode - mangelfulle - uaktsomt - under 4 rettsgebyr', async () => {
+    test('Åpner vurdert periode - mangelfulle - uaktsomt - under 4 rettsgebyr', () => {
         const periode = lagVilkårsvurderingPeriodeSkjemaData({
             begrunnelse: 'Gitt mangelfulle opplysninger',
             vilkårsvurderingsresultatInfo: {
@@ -741,7 +741,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         expect(screen.getByTestId('andelSomTilbakekrevesManuell')).toHaveValue('33');
     });
 
-    test('Viser særlige grunner og for over 4 rettsgebyr alternativ - uaktsomt', async () => {
+    test('Viser særlige grunner og for over 4 rettsgebyr alternativ - uaktsomt', () => {
         const periode = lagVilkårsvurderingPeriodeSkjemaData({
             begrunnelse: 'Gitt mangelfulle opplysninger',
             vilkårsvurderingsresultatInfo: {
@@ -776,7 +776,7 @@ describe('VilkårsvurderingPeriodeSkjema', () => {
         særligeGrunnerGruppe();
     });
 
-    test('Viser ikke over 4 rettsgebyr alternativ for gammel modell', async () => {
+    test('Viser ikke over 4 rettsgebyr alternativ for gammel modell', () => {
         const periode = lagVilkårsvurderingPeriodeSkjemaData({
             begrunnelse: 'Gitt mangelfulle opplysninger',
             vilkårsvurderingsresultatInfo: {

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/splitt-periode/SplittPeriode.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/splitt-periode/SplittPeriode.test.tsx
@@ -1,6 +1,6 @@
 import type { UserEvent } from '@testing-library/user-event';
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -20,7 +20,7 @@ describe('SplittPeriode - Vilkårsvurdering', () => {
 
     test('Åpning av modal', async () => {
         const behandling = lagBehandling();
-        const { getByLabelText, getByRole, queryAllByText, queryByText } = render(
+        render(
             <HttpProvider>
                 <TestBehandlingProvider behandling={behandling}>
                     <SplittPeriode
@@ -31,15 +31,17 @@ describe('SplittPeriode - Vilkårsvurdering', () => {
             </HttpProvider>
         );
 
-        expect(getByRole('button', { name: 'Del opp perioden' })).toBeInTheDocument();
-        expect(queryByText('01.01.2021 - 30.04.2021')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Del opp perioden' })).toBeInTheDocument();
+        expect(screen.queryByText('01.01.2021 - 30.04.2021')).not.toBeInTheDocument();
 
-        await user.click(getByRole('button', { name: 'Del opp perioden' }));
+        await user.click(screen.getByRole('button', { name: 'Del opp perioden' }));
 
-        expect(queryAllByText('Del opp perioden')).toHaveLength(2);
-        expect(queryByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
-        expect(getByRole('heading', { name: 'Del opp perioden' })).toBeInTheDocument();
-        expect(getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
-        expect(getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue('januar 2021');
+        expect(screen.queryAllByText('Del opp perioden')).toHaveLength(2);
+        expect(screen.queryByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Del opp perioden' })).toBeInTheDocument();
+        expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
+        expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue(
+            'januar 2021'
+        );
     });
 });

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/splitt-periode/SplittPeriode.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/splitt-periode/SplittPeriode.test.tsx
@@ -36,8 +36,8 @@ describe('SplittPeriode - Vilkårsvurdering', () => {
 
         await user.click(screen.getByRole('button', { name: 'Del opp perioden' }));
 
-        expect(screen.queryAllByText('Del opp perioden')).toHaveLength(2);
-        expect(screen.queryByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
+        expect(screen.getAllByText('Del opp perioden')).toHaveLength(2);
+        expect(screen.getByText('01.01.2021 - 30.04.2021')).toBeInTheDocument();
         expect(screen.getByRole('heading', { name: 'Del opp perioden' })).toBeInTheDocument();
         expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toBeInTheDocument();
         expect(screen.getByLabelText('Angi t.o.m. måned for første periode')).toHaveValue(


### PR DESCRIPTION
- Fjernet unødvendig bruk av `waitFor` og erstattet det med `findByRole`. Lettere å lese og kan være raskere.
- Byttet bruk av `fireEvent` med `userEvent` noen steder.
- Bruker `screen` fremfor å destructe render funksjonen
- Retter på bruken av `screen.query*` ved å kunsøke etter noe som ikke er der
- Bytter unødvendige `find*` med `get*`
- Fjerner unødvendig `async` på tester som er synkrone