### PR TITLE
Fjerner ts-node og HMR-portkonflikt ved oppstart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY package.json .
 
 EXPOSE 8000
 ENV NODE_ENV=production
-CMD [ "--import=./node_dist/backend/register.js", "--es-module-specifier-resolution=node", "node_dist/backend/server.js" ]
+CMD [ "--import=./node_dist/backend/register.js", "node_dist/backend/server.js" ]

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "start": "NODE_ENV=production node --loader ts-node/esm --es-module-specifier-resolution=node node_dist/backend/server.js",
-    "start:dev": "tsc && NODE_ENV=development node --loader ts-node/esm --es-module-specifier-resolution=node node_dist/backend/server.js",
+    "start": "NODE_ENV=production node --import=./node_dist/backend/register.js node_dist/backend/server.js",
+    "start:dev": "tsc && NODE_ENV=development node --import=./node_dist/backend/register.js node_dist/backend/server.js",
     "build": "pnpm check && pnpm build:prod",
     "build:client": "vite build --config src/frontend/vite.config.js",
     "build:server": "tsc --project tsconfig.json",
@@ -82,7 +82,6 @@
     "husky": "9.1.7",
     "jsdom": "29.1.1",
     "lint-staged": "17.0.7",
-    "ts-node": "10.9.2",
     "typescript": "6.0.3",
     "vite": "8.0.16",
     "vite-plugin-compression": "0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ importers:
       lint-staged:
         specifier: 17.0.7
         version: 17.0.7
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@types/node@25.9.3)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -349,10 +346,6 @@ packages:
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
-
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
@@ -485,9 +478,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
@@ -964,18 +954,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1098,15 +1076,6 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1138,9 +1107,6 @@ packages:
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1362,9 +1328,6 @@ packages:
   countries-list@3.3.0:
     resolution: {integrity: sha512-XRUjS+dcZuNh/fg3+mka3bXgcg4TbQZ1gaK5IJqO6qulerBANl1bmrd20P2dgmPkBpP+5FnejiSF1gd7bgAg+g==}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1454,10 +1417,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -1992,9 +1951,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2524,20 +2480,6 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2581,9 +2523,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -2765,10 +2704,6 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2967,10 +2902,6 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
-
   '@csstools/color-helpers@6.0.2': {}
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
@@ -3127,11 +3058,6 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3539,14 +3465,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -3686,12 +3604,6 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-
-  acorn@8.16.0: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -3715,8 +3627,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
-
-  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -3940,8 +3850,6 @@ snapshots:
 
   countries-list@3.3.0: {}
 
-  create-require@1.1.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4031,8 +3939,6 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
-
-  diff@4.0.4: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -4582,8 +4488,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-error@1.3.6: {}
-
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
@@ -5101,24 +5005,6 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
-  ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.9.3
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tslib@2.8.1: {}
 
   type-is@2.0.1:
@@ -5150,8 +5036,6 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
-
-  v8-compile-cache-lib@3.0.1: {}
 
   vary@1.1.2: {}
 
@@ -5320,8 +5204,6 @@ snapshots:
 
   yaml@2.9.0:
     optional: true
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/backend/esm-resolve-hooks.ts
+++ b/src/backend/esm-resolve-hooks.ts
@@ -1,0 +1,42 @@
+import type { ResolveFnOutput, ResolveHook, ResolveHookContext } from 'node:module';
+
+// Node sin ESM-resolver krever eksplisitt filendelse og støtter ikke mappe-importer
+// (f.eks. `import backend from './backend'`). tsc med moduleResolution 'bundler'
+// genererer slike importer i den kompilerte koden. Denne resolve-hooken legger til
+// `.js`/`/index.js` ved behov, slik at vi slipper ts-node (som trigger DEP0180
+// fs.Stats-deprecation).
+export const resolve: ResolveHook = async (
+    specifier: string,
+    context: ResolveHookContext,
+    nextResolve: (
+        specifier: string,
+        context?: ResolveHookContext
+    ) => ResolveFnOutput | Promise<ResolveFnOutput>
+) => {
+    try {
+        return await nextResolve(specifier, context);
+    } catch (error) {
+        const kanReddes =
+            error instanceof Error &&
+            'code' in error &&
+            (error.code === 'ERR_MODULE_NOT_FOUND' ||
+                error.code === 'ERR_UNSUPPORTED_DIR_IMPORT') &&
+            (specifier.startsWith('./') ||
+                specifier.startsWith('../') ||
+                specifier.startsWith('/'));
+
+        if (!kanReddes) {
+            throw error;
+        }
+
+        for (const kandidat of [`${specifier}.js`, `${specifier}/index.js`]) {
+            try {
+                return await nextResolve(kandidat, context);
+            } catch {
+                // Prøv neste kandidat
+            }
+        }
+
+        throw error;
+    }
+};

--- a/src/backend/register.ts
+++ b/src/backend/register.ts
@@ -1,6 +1,7 @@
-// Fjerner warningen: 'ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`'
+// Registrerer en custom ESM-resolve-hook som håndterer mappe- og extensionless-importer
+// i den kompilerte koden. Dette erstatter ts-node/esm, som både trigget
+// ExperimentalWarning for '--experimental-loader' og DEP0180 (fs.Stats deprecation).
 
 import { register } from 'node:module';
-import { pathToFileURL } from 'node:url';
 
-register('ts-node/esm', pathToFileURL('./'));
+register('./esm-resolve-hooks.js', import.meta.url);

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, Router } from 'express';
+import type { Server } from 'http';
 import type { ViteDevServer } from 'vite';
 import type { TexasClient } from './backend/auth/texas';
 
@@ -15,6 +16,10 @@ import { prometheusTellere } from './metrikker';
 let vite: ViteDevServer;
 const isProd = process.env.NODE_ENV === 'production';
 
+export const lukkVite = async (): Promise<void> => {
+    await vite?.close();
+};
+
 const getHtmlInnholdProd = (): string => {
     return fs.readFileSync(path.join(process.cwd(), buildPath, 'index.html'), 'utf-8');
 };
@@ -29,7 +34,11 @@ const getHtmlInnholdDev = async (url: string): Promise<string> => {
     return htmlInnhold;
 };
 
-export default async (texasClient: TexasClient, router: Router): Promise<Router> => {
+export default async (
+    texasClient: TexasClient,
+    router: Router,
+    httpServer: Server
+): Promise<Router> => {
     router.get('/version', (_: Request, res: Response) => {
         res.status(200).send({ status: 'SUKSESS', data: appConfig.version }).end();
     });
@@ -48,7 +57,9 @@ export default async (texasClient: TexasClient, router: Router): Promise<Router>
     if (!isProd) {
         vite = await createViteServer({
             root: path.join(process.cwd(), 'src/frontend'),
-            server: { middlewareMode: true },
+            // Kjør HMR-WebSocket over BFF-ens egen HTTP-server i stedet for en
+            // separat port (24678). Da kan vi aldri få "Port 24678 already in use".
+            server: { middlewareMode: true, hmr: { server: httpServer } },
             appType: 'custom',
         });
         router.use(vite.middlewares);

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -3,6 +3,7 @@ import type { NextFunction, Request, Response } from 'express';
 import cookieParser from 'cookie-parser';
 import { json, urlencoded } from 'express';
 import expressStaticGzip from 'express-static-gzip';
+import { createServer } from 'http';
 import path from 'path';
 
 import backend from './backend';
@@ -12,12 +13,15 @@ import { appConfig, proxyUrl, sessionConfig, texasConfig } from './config';
 import { logInfo } from './logging/logging';
 import { prometheusTellere } from './metrikker';
 import { attachToken, doProxy, doRedirectProxy } from './proxy';
-import setupRouter from './router';
+import setupRouter, { lukkVite } from './router';
 
 (async (): Promise<void> => {
     const port = 8000;
 
     const { app, texasClient, router } = backend(texasConfig, prometheusTellere);
+
+    // Opprett HTTP-serveren eksplisitt slik at Vites HMR kan dele den (se router.ts).
+    const server = createServer(app);
 
     if (process.env.NODE_ENV === 'production') {
         app.use('/assets', expressStaticGzip(path.join(process.cwd(), 'dist/assets'), {}));
@@ -43,14 +47,15 @@ import setupRouter from './router';
     // Sett opp express og router etter proxy. Spesielt viktig med tanke på større payloads
     app.use(json({ limit: '200mb' }));
     app.use(urlencoded({ limit: '200mb', extended: true }));
-    app.use('/', await setupRouter(texasClient, router));
+    app.use('/', await setupRouter(texasClient, router, server));
 
-    const server = app.listen(port, '0.0.0.0', () => {
+    server.listen(port, '0.0.0.0', () => {
         logInfo(`Server startet på port ${port}. Build version: ${appConfig.version}.`);
     });
 
     process.on('SIGTERM', () => {
         logInfo('SIGTERM signal received: closing HTTP server');
+        void lukkVite();
         server.close(() => {
             logInfo('HTTP server closed');
         });


### PR DESCRIPTION
Fjerner oppstarts-warnings og «Port 24678 already in use».

Erstatter ts-node/esm-loaderen med en liten native ESM-resolve-hook, og kjører Vites HMR over BFF-ens egen HTTP-server i stedet for en separat port.

Tidligere:
<img width="813" height="226" alt="Skjermbilde 2026-06-16 kl  21 26 14" src="https://github.com/user-attachments/assets/5b4b8e5d-2479-46e5-a7a4-5a3dc8a87fda" />

Nå:
<img width="815" height="105" alt="Skjermbilde 2026-06-16 kl  21 19 07" src="https://github.com/user-attachments/assets/cc2b3a1e-6230-43eb-bea2-11eef2002477" />
