### PR TITLE
Opprydning i vilkårsvurdering

### DIFF
--- a/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import type { Vilkaarsperiode } from '@/generated-new';
 import type { Vilkårsperiode } from './typer';
 
-import { Box, Heading, HStack } from '@navikt/ds-react';
+import { Heading, HStack } from '@navikt/ds-react';
 
 import { DelPeriode } from './del-periode/DelPeriode';
 import { VilkårsvurderingSkjema } from './skjema/VilkårsvurderingSkjema';
@@ -24,42 +24,40 @@ export const VilkårsvurderingDetaljer: FC<Props> = ({
         ({ vilkårsvurdering: { id } }) => id === valgtPeriode.id
     );
     return (
-        <section className="flex-2 min-h-0">
-            <Box className="border border-ax-default rounded-xl border-ax-border-neutral-subtle h-full flex flex-col">
-                <HStack
-                    justify="space-between"
-                    className="border-b py-3 px-4 border-ax-border-neutral-subtle shrink-0"
-                >
-                    <Heading size="small" level="2">
-                        {`${valgtPeriode.fom}–${valgtPeriode.tom}`}
-                    </Heading>
-                    <HStack>
-                        {valgtVilkårsperiode &&
-                            valgtVilkårsperiode.vilkårsvurdering.delbarePerioder.length > 1 && (
-                                <DelPeriode
-                                    key={`${valgtVilkårsperiode.vilkårsvurdering.periode.fom}-${valgtVilkårsperiode.vilkårsvurdering.periode.tom}`}
-                                    periode={valgtVilkårsperiode.vilkårsvurdering.periode}
-                                    delbarePerioder={
-                                        valgtVilkårsperiode.vilkårsvurdering.delbarePerioder
-                                    }
-                                    erVurdert={erPeriodeVurdert(valgtPeriode.vurdering)}
-                                    hentVilkårsvurdering={hentVilkårsvurdering}
-                                />
-                            )}
-                        <SlåSammen
-                            valgtPeriodeId={valgtPeriode.id}
-                            vilkårsperioder={vilkårsperioder.map(({ vilkårsvurdering }) => ({
-                                periodeId: vilkårsvurdering.id,
-                                periode: vilkårsvurdering.periode,
-                                delbarePerioder: vilkårsvurdering.delbarePerioder,
-                            }))}
-                            hentVilkårsvurdering={hentVilkårsvurdering}
-                        />
-                    </HStack>
+        <section className="flex-2 min-h-0 border border-ax-default rounded-xl border-ax-border-neutral-subtle flex flex-col">
+            <HStack
+                justify="space-between"
+                className="border-b py-3 px-4 border-ax-border-neutral-subtle shrink-0"
+            >
+                <Heading size="small" level="2">
+                    {`${valgtPeriode.fom}–${valgtPeriode.tom}`}
+                </Heading>
+                <HStack>
+                    {valgtVilkårsperiode &&
+                        valgtVilkårsperiode.vilkårsvurdering.delbarePerioder.length > 1 && (
+                            <DelPeriode
+                                key={`${valgtVilkårsperiode.vilkårsvurdering.periode.fom}-${valgtVilkårsperiode.vilkårsvurdering.periode.tom}`}
+                                periode={valgtVilkårsperiode.vilkårsvurdering.periode}
+                                delbarePerioder={
+                                    valgtVilkårsperiode.vilkårsvurdering.delbarePerioder
+                                }
+                                erVurdert={erPeriodeVurdert(valgtPeriode.vurdering)}
+                                hentVilkårsvurdering={hentVilkårsvurdering}
+                            />
+                        )}
+                    <SlåSammen
+                        valgtPeriodeId={valgtPeriode.id}
+                        vilkårsperioder={vilkårsperioder.map(({ vilkårsvurdering }) => ({
+                            periodeId: vilkårsvurdering.id,
+                            periode: vilkårsvurdering.periode,
+                            delbarePerioder: vilkårsvurdering.delbarePerioder,
+                        }))}
+                        hentVilkårsvurdering={hentVilkårsvurdering}
+                    />
                 </HStack>
+            </HStack>
 
-                <VilkårsvurderingSkjema />
-            </Box>
+            <VilkårsvurderingSkjema />
         </section>
     );
 };

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/DelPeriode.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/DelPeriode.test.tsx
@@ -45,9 +45,9 @@ const renderDelPeriode = ({
     );
 };
 
-const delOppKnapp = (): HTMLElement => screen.getByRole('button', { name: 'Del opp perioden' });
+const delOppKnapp = (): HTMLElement => screen.getByRole('button', { name: 'Del opp' });
 const delOppPeriodenKnapp = (): HTMLElement =>
-    within(screen.getByRole('dialog')).getByRole('button', { name: 'Del opp perioden' });
+    within(screen.getByRole('dialog')).getByRole('button', { name: 'Del opp' });
 const velgDatoTekst = 'Velg fra og med dato for periode 2';
 const velgDatoDatePicker = (): HTMLElement => screen.getByLabelText(velgDatoTekst);
 
@@ -119,41 +119,6 @@ describe('DelPeriode', () => {
 
         expect(valgbareDager).toHaveLength(1);
         expect(valgbareDager[0]).toHaveTextContent('15');
-    });
-
-    test('Skal filtrere vilkårsperioder som ligger utenfor perioden', async () => {
-        const user = userEvent.setup();
-        const periode = {
-            fom: '2024-01-10',
-            tom: '2024-01-25',
-        };
-
-        const vilkårsperioderMedPerioderUtenfor = [
-            { periodeId: '1', periode: { fom: '2024-01-01', tom: '2024-01-09' } }, // Før perioden
-            { periodeId: '2', periode: { fom: '2024-01-10', tom: '2024-01-17' } }, // Innenfor
-            { periodeId: '3', periode: { fom: '2024-01-18', tom: '2024-01-25' } }, // Innenfor
-            { periodeId: '4', periode: { fom: '2024-01-26', tom: '2024-01-31' } }, // Etter perioden
-        ] satisfies PeriodeInfo[];
-
-        renderDelPeriode({
-            periodeProp: periode,
-            vilkårsperioderProp: vilkårsperioderMedPerioderUtenfor,
-        });
-
-        await user.click(delOppKnapp());
-
-        // Skal bare vise de to periodene innenfor
-        expect(screen.getByText('Periode 1')).toBeInTheDocument();
-        expect(screen.getByText('10.01.2024–17.01.2024')).toBeInTheDocument();
-        expect(screen.getByText('Periode 2')).toBeInTheDocument();
-        expect(screen.getByText('18.01.2024–25.01.2024')).toBeInTheDocument();
-
-        // Skal ikke inneholde periodene utenfor
-        expect(screen.queryByText('01.01.2024–09.01.2024')).not.toBeInTheDocument();
-        expect(screen.queryByText('26.01.2024–31.01.2024')).not.toBeInTheDocument();
-
-        // standardSplittDato skal være den andre filtrerte perioden
-        expect(velgDatoDatePicker()).toHaveValue('18.01.2024');
     });
 
     test('Skal vise "Vurdert" i popover for periode 1 når perioden er vurdert', async () => {

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/DelPeriode.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/DelPeriode.tsx
@@ -1,5 +1,6 @@
+import type { AxiosError } from 'axios';
 import type { Periode } from '@/generated';
-import type { PeriodeInfo, SplittPeriode } from '@/generated-new';
+import type { Error as KontraktError, PeriodeInfo, SplittPeriode } from '@/generated-new';
 
 import { CalendarFillIcon } from '@navikt/aksel-icons';
 import {
@@ -21,7 +22,6 @@ import { useBehandling } from '@/context/BehandlingContext';
 import { behandlingSplittPeriodeMutation } from '@/generated-new/@tanstack/react-query.gen';
 import { MODAL_BREDDE } from '@/komponenter/meny/utils';
 import { useVisGlobalAlert } from '@/stores/globalAlertStore';
-import { hentFeilmeldingFraError } from '@/typer/ressurs';
 import { formatterDatostring } from '@/utils';
 
 import { hentSplittedePerioder } from './utils';
@@ -117,11 +117,11 @@ export const DelPeriode: FC<Props> = ({
             });
             delPeriodeRef.current?.close();
         },
-        // biome-ignore lint/nursery/useExplicitType: Klarer ikke finne typen på error her, da den kommer fra useMutation og ikke er eksplisitt definert i api-kallet.
-        onError: error => {
+        onError: (error: AxiosError<KontraktError>) => {
             visGlobalAlert({
-                title: 'Kunne ikke dele opp perioden',
-                message: hentFeilmeldingFraError(error),
+                title: error.response?.data.tittel ?? 'Kunne ikke dele opp perioden',
+                message:
+                    error.response?.data.melding ?? 'En feil har oppstått ved deling av perioden.',
                 status: 'error',
             });
         },

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/DelPeriode.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/DelPeriode.tsx
@@ -15,7 +15,7 @@ import {
 } from '@navikt/ds-react';
 import { useMutation } from '@tanstack/react-query';
 import { format, isValid, parseISO } from 'date-fns';
-import { type FC, useMemo, useRef, useState } from 'react';
+import { type FC, useRef, useState } from 'react';
 
 import { useBehandling } from '@/context/BehandlingContext';
 import { behandlingSplittPeriodeMutation } from '@/generated-new/@tanstack/react-query.gen';
@@ -43,31 +43,18 @@ export const DelPeriode: FC<Props> = ({
     const { behandlingId } = useBehandling();
     const visGlobalAlert = useVisGlobalAlert();
 
-    const perioderInnenforPeriode = useMemo(
-        () =>
-            delbarePerioder.filter(
-                ({ periode: { fom, tom } }) => fom >= periode.fom && tom <= periode.tom
-            ),
-        [delbarePerioder, periode]
-    );
-    const valgbareSplittDatoer = perioderInnenforPeriode
-        .slice(1)
-        .map(({ periode: { fom } }) => fom);
-    const standardSplittDato = perioderInnenforPeriode[1]?.periode.fom;
+    const valgbareSplittDatoer = delbarePerioder.slice(1).map(({ periode: { fom } }) => fom);
+
+    const standardSplittDato = delbarePerioder[1]?.periode.fom;
 
     const [valgtDato, setValgtDato] = useState<Date | undefined>(
         standardSplittDato ? parseISO(standardSplittDato) : undefined
     );
     const [feilmelding, setFeilmelding] = useState<string | undefined>(undefined);
 
-    const splittedePerioder = useMemo(
-        () =>
-            hentSplittedePerioder(
-                periode,
-                perioderInnenforPeriode.map(({ periode }) => periode),
-                valgtDato
-            ),
-        [periode, perioderInnenforPeriode, valgtDato]
+    const splittedePerioder = hentSplittedePerioder(
+        delbarePerioder.map(({ periode }) => periode),
+        valgtDato
     );
     const førsteSplittetPeriode = splittedePerioder[0];
     const andreSplittetPeriode = splittedePerioder[1];
@@ -145,7 +132,7 @@ export const DelPeriode: FC<Props> = ({
             setFeilmelding('Du må velge en dato');
             return;
         }
-        const valgtPeriodeId = perioderInnenforPeriode.find(
+        const valgtPeriodeId = delbarePerioder.find(
             ({ periode }) => periode.fom === format(valgtDato, 'yyyy-MM-dd')
         )?.periodeId;
         if (!valgtPeriodeId) {
@@ -167,12 +154,12 @@ export const DelPeriode: FC<Props> = ({
                 size="xsmall"
                 variant="tertiary"
             >
-                Del opp perioden
+                Del opp
             </Button>
 
             <Modal
                 ref={delPeriodeRef}
-                header={{ heading: 'Del opp perioden' }}
+                header={{ heading: 'Del opp' }}
                 className={MODAL_BREDDE}
                 closeOnBackdropClick
             >
@@ -230,7 +217,7 @@ export const DelPeriode: FC<Props> = ({
                         loading={splittPeriode.isPending}
                         disabled={splittPeriode.isPending}
                     >
-                        Del opp perioden
+                        Del opp
                     </Button>
                     <Button
                         variant="secondary"

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/utils.test.ts
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/utils.test.ts
@@ -1,97 +1,18 @@
 import type { Periode } from '@/generated';
 
-import { hentSplittedePerioder, kanSplitte } from './utils';
+import { hentSplittedePerioder } from './utils';
 
 describe('Vilkårsvurdering - utils', () => {
-    describe('kanSplitte', () => {
-        describe('kan splitte når', () => {
-            test('to vilkårsperioder er innenfor periode', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-06-28',
-                } satisfies Periode;
-
-                const vilkårsperioder = [
-                    {
-                        fom: '2026-06-01',
-                        tom: '2026-06-14',
-                    },
-                    {
-                        fom: '2026-06-15',
-                        tom: '2026-06-28',
-                    },
-                ] satisfies Periode[];
-
-                expect(kanSplitte(periode, vilkårsperioder)).toBe(true);
-            });
-
-            test('det er 3 eller mer vilkårsperioder innenfor', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-08-31',
-                } satisfies Periode;
-                const perioder = [
-                    { fom: '2026-06-01', tom: '2026-06-30' },
-                    { fom: '2026-07-01', tom: '2026-07-31' },
-                    { fom: '2026-08-01', tom: '2026-08-31' },
-                ];
-
-                expect(kanSplitte(periode, perioder)).toBe(true);
-            });
-        });
-
-        describe('false', () => {
-            test('kan ikke splitte når vilkårsperioder er tom', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-06-30',
-                } satisfies Periode;
-                const vilkårsperioder: Periode[] = [];
-
-                expect(kanSplitte(periode, vilkårsperioder)).toBe(false);
-            });
-
-            test('kan ikke splitte når det bare er 1 vilkårsperiode innenfor', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-06-30',
-                } satisfies Periode;
-                const vilkårsperioder = [
-                    { fom: '2026-06-01', tom: '2026-06-30' } satisfies Periode,
-                ];
-
-                expect(kanSplitte(periode, vilkårsperioder)).toBe(false);
-            });
-
-            test('kan ikke splitte når vilkårsperiode ligger helt utenfor periode', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-06-14',
-                } satisfies Periode;
-                const vilkårsperioder = [
-                    { fom: '2026-06-01', tom: '2026-06-14' } satisfies Periode,
-                    { fom: '2026-06-15', tom: '2026-06-28' } satisfies Periode,
-                ];
-
-                expect(kanSplitte(periode, vilkårsperioder)).toBe(false);
-            });
-        });
-    });
-
     describe('hentSplittedePerioder', () => {
         describe('returnerer splittede perioder når', () => {
             test('splittDato er gyldig', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-07-31',
-                } satisfies Periode;
                 const vilkårsperioder = [
                     { fom: '2026-06-01', tom: '2026-06-30' } satisfies Periode,
                     { fom: '2026-07-01', tom: '2026-07-31' } satisfies Periode,
                 ];
                 const splittDato = new Date('2026-07-01');
 
-                const resultat = hentSplittedePerioder(periode, vilkårsperioder, splittDato);
+                const resultat = hentSplittedePerioder(vilkårsperioder, splittDato);
 
                 expect(resultat).toHaveLength(2);
                 expect(resultat[0]).toEqual(vilkårsperioder[0]);
@@ -99,10 +20,6 @@ describe('Vilkårsvurdering - utils', () => {
             });
 
             test('splittDato er fom av tredje periode', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-08-31',
-                } satisfies Periode;
                 const vilkårsperioder = [
                     { fom: '2026-06-01', tom: '2026-06-30' } satisfies Periode,
                     { fom: '2026-07-01', tom: '2026-07-31' } satisfies Periode,
@@ -110,7 +27,7 @@ describe('Vilkårsvurdering - utils', () => {
                 ];
                 const splittDato = new Date('2026-08-01');
 
-                const resultat = hentSplittedePerioder(periode, vilkårsperioder, splittDato);
+                const resultat = hentSplittedePerioder(vilkårsperioder, splittDato);
 
                 expect(resultat).toHaveLength(2);
                 expect(resultat[0].tom).toBe('2026-07-31');
@@ -118,10 +35,6 @@ describe('Vilkårsvurdering - utils', () => {
             });
 
             test('splittDato på andre fom gir tredje periodes tom i andre resultatsperiode', () => {
-                const periode = {
-                    fom: '2026-03-02',
-                    tom: '2026-05-29',
-                } satisfies Periode;
                 const vilkårsperioder = [
                     { fom: '2026-03-02', tom: '2026-03-13' } satisfies Periode,
                     { fom: '2026-05-04', tom: '2026-05-15' } satisfies Periode,
@@ -129,7 +42,7 @@ describe('Vilkårsvurdering - utils', () => {
                 ];
                 const splittDato = new Date('2026-05-04');
 
-                const resultat = hentSplittedePerioder(periode, vilkårsperioder, splittDato);
+                const resultat = hentSplittedePerioder(vilkårsperioder, splittDato);
 
                 expect(resultat).toHaveLength(2);
                 expect(resultat[0].fom).toBe('2026-03-02');
@@ -141,44 +54,33 @@ describe('Vilkårsvurdering - utils', () => {
 
         describe('returnerer tom array når', () => {
             test('splittDato er undefined', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-07-31',
-                } satisfies Periode;
                 const vilkårsperioder = [
                     { fom: '2026-06-01', tom: '2026-06-30' } satisfies Periode,
                     { fom: '2026-07-01', tom: '2026-07-31' } satisfies Periode,
                 ];
 
-                const resultat = hentSplittedePerioder(periode, vilkårsperioder, undefined);
+                const resultat = hentSplittedePerioder(vilkårsperioder, undefined);
 
                 expect(resultat).toEqual([]);
             });
 
             test('splittDato ligger før noen vilkårsperiode', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-07-31',
-                } satisfies Periode;
                 const vilkårsperioder = [
                     { fom: '2026-06-15', tom: '2026-06-30' } satisfies Periode,
                     { fom: '2026-07-01', tom: '2026-07-31' } satisfies Periode,
                 ];
                 const splittDato = new Date('2026-06-01');
 
-                const resultat = hentSplittedePerioder(periode, vilkårsperioder, splittDato);
+                const resultat = hentSplittedePerioder(vilkårsperioder, splittDato);
 
                 expect(resultat).toEqual([]);
             });
 
             test('vilkårsperioder er tom array', () => {
-                const periode = {
-                    fom: '2026-06-01',
-                    tom: '2026-07-31',
-                } satisfies Periode;
+                const vilkårsperioder: Periode[] = [];
                 const splittDato = new Date('2026-07-01');
 
-                const resultat = hentSplittedePerioder(periode, [], splittDato);
+                const resultat = hentSplittedePerioder(vilkårsperioder, splittDato);
 
                 expect(resultat).toEqual([]);
             });

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/utils.ts
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/del-periode/utils.ts
@@ -3,66 +3,38 @@ import type { Periode } from '@/generated';
 import { format } from 'date-fns';
 
 /**
- * Sjekker om en periode kan splittes basert på antall vilkårsperioder innenfor.
- * Krever minst 2 vilkårsperioder som ligger helt innenfor perioden.
- * Sammenligner datostrenger direkte (ISO-format) for optimal ytelse.
- *
- * @param periode Perioden som skal splittes
- * @param vilkårsperioder Alle vilkårsperiodene for hele behandlingen
- * @returns true hvis periode kan splittes (2+ vilkårsperioder innenfor)
- */
-export const kanSplitte = (periode: Periode, vilkårsperioder: Periode[] | undefined): boolean => {
-    if (!vilkårsperioder || vilkårsperioder.length < 2) return false;
-
-    const antallPerioderInnenfor = vilkårsperioder.filter(
-        ({ fom, tom }) => fom >= periode.fom && tom <= periode.tom
-    ).length;
-
-    return antallPerioderInnenfor >= 2;
-};
-
-/**
  * Returnerer de to periodene som dannes ved å splitte en periode på en gitt dato.
- * Splittdatoen må være fom-datoen for en av vilkårsperiodene innenfor periode.
+ * Splittdatoen må være fom-datoen for en av vilkårsperiodene innenfor perioden.
  *
- * @param periode Perioden som skal splittes
- * @param vilkårsperioder Alle vilkårsperiodene i en behandling
+ * @param delbarePerioder Alle de delbare periodene i perioden det skal splittes på
  * @param splittDato Datoen å splitte på (må være Date objekt, ikke string)
  * @returns Array med to perioder [før, etter] eller tom array hvis splitting ikke er mulig
  */
 export const hentSplittedePerioder = (
-    periode: Periode,
-    vilkårsperioder: Periode[],
+    delbarePerioder: Periode[],
     splittDato: Date | undefined
 ): Periode[] => {
-    if (!splittDato || vilkårsperioder.length < 2) {
+    if (!splittDato || delbarePerioder.length < 2) {
         return [];
     }
 
     const splittDatoString = format(splittDato, 'yyyy-MM-dd');
 
-    const vilkårsperioderInnenfor = vilkårsperioder.filter(
-        ({ fom, tom }) => fom >= periode.fom && tom <= periode.tom
-    );
+    const delbarePerioderFør = delbarePerioder.filter(({ tom }) => tom < splittDatoString);
+    const delbarePerioderEtter = delbarePerioder.filter(({ fom }) => fom >= splittDatoString);
 
-    const vilkårsperioderFør = vilkårsperioderInnenfor.filter(({ tom }) => tom < splittDatoString);
-
-    const vilkårsperioderEtter = vilkårsperioderInnenfor.filter(
-        ({ fom }) => fom >= splittDatoString
-    );
-
-    if (vilkårsperioderFør.length === 0 || vilkårsperioderEtter.length === 0) {
+    if (delbarePerioderFør.length === 0 || delbarePerioderEtter.length === 0) {
         return [];
     }
 
     const førPeriode = {
-        fom: vilkårsperioderFør[0].fom,
-        tom: vilkårsperioderFør[vilkårsperioderFør.length - 1].tom,
+        fom: delbarePerioderFør[0].fom,
+        tom: delbarePerioderFør[delbarePerioderFør.length - 1].tom,
     } satisfies Periode;
 
     const etterPeriode = {
-        fom: vilkårsperioderEtter[0].fom,
-        tom: vilkårsperioderEtter[vilkårsperioderEtter.length - 1].tom,
+        fom: delbarePerioderEtter[0].fom,
+        tom: delbarePerioderEtter[delbarePerioderEtter.length - 1].tom,
     } satisfies Periode;
 
     return [førPeriode, etterPeriode];

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/gammel-vilkårsvurdering/vilkaarsvurdering-periode/VilkårsvurderingPeriodeSkjema.tsx
@@ -33,7 +33,6 @@ import { useVilkårsvurdering } from '@/pages/fagsak/vilkaarsvurdering/gammel-vi
 import { formatterDatostring, isEmpty } from '@/utils';
 
 import { DelPeriode } from '../../del-periode/DelPeriode';
-import { kanSplitte } from '../../del-periode/utils';
 import { PeriodeHandling } from '../typer/periodeHandling';
 import { AktsomhetsvurderingSkjema } from './aktsomhetsvurdering/AktsomhetsvurderingSkjema';
 import { GodTroSkjema } from './GodTroSkjema';
@@ -287,14 +286,14 @@ export const VilkårsvurderingPeriodeSkjema: FC<Props> = ({
         !periode.foreldet &&
         differenceInMonths(parseISO(periode.periode.tom), parseISO(periode.periode.fom)) >= 1;
 
+    const delbarePerioder = vilkårsvurderingsperioder?.filter(
+        ({ periode: { fom, tom } }) => fom >= periode.periode.fom && tom <= periode.periode.tom
+    );
+
+    const finnesFlereDelbarePerioder = delbarePerioder && delbarePerioder.length > 1;
+
     const kanSplitteINyModell =
-        erNyModell &&
-        !erLesevisning &&
-        !periode.foreldet &&
-        kanSplitte(
-            periode.periode,
-            vilkårsvurderingsperioder?.map(({ periode }) => periode)
-        );
+        erNyModell && !erLesevisning && !periode.foreldet && finnesFlereDelbarePerioder;
 
     const erSistePeriode = periode.index === perioder[perioder.length - 1].index;
 
@@ -308,6 +307,11 @@ export const VilkårsvurderingPeriodeSkjema: FC<Props> = ({
         onNeste: () => handleNavigering(PeriodeHandling.GåTilNesteSteg),
         disableNeste: (!erAllePerioderBehandlet && !erSistePeriode) || periode.foreldet,
     });
+
+    const erPeriodenVurdert =
+        !!periode.vilkårsvurderingsresultatInfo?.vilkårsvurderingsresultat &&
+        periode.vilkårsvurderingsresultatInfo.vilkårsvurderingsresultat !==
+            Vilkårsresultat.Udefinert;
 
     if (sendInnSkjemaMutation.isPending) {
         return (
@@ -329,14 +333,8 @@ export const VilkårsvurderingPeriodeSkjema: FC<Props> = ({
                     {kanSplitteINyModell && (
                         <DelPeriode
                             periode={periode.periode}
-                            // Vil aldri være undefined siden kanSplitteINyModell vil returnere false hvis vilkårsvurderingsperioder er undefined
-                            delbarePerioder={vilkårsvurderingsperioder ?? []}
-                            erVurdert={
-                                !!periode.vilkårsvurderingsresultatInfo
-                                    ?.vilkårsvurderingsresultat &&
-                                periode.vilkårsvurderingsresultatInfo.vilkårsvurderingsresultat !==
-                                    Vilkårsresultat.Udefinert
-                            }
+                            delbarePerioder={delbarePerioder}
+                            erVurdert={erPeriodenVurdert}
                             hentVilkårsvurdering={hentVilkårsvurdering}
                         />
                     )}

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/slå-sammen-periode/SlåSammen.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/slå-sammen-periode/SlåSammen.tsx
@@ -10,7 +10,6 @@ import { useBehandling } from '@/context/BehandlingContext';
 import { behandlingSlaaSammenPerioderMutation } from '@/generated-new/@tanstack/react-query.gen';
 import { MODAL_BREDDE } from '@/komponenter/meny/utils';
 import { useVisGlobalAlert } from '@/stores/globalAlertStore';
-import { hentFeilmeldingFraError } from '@/typer/ressurs';
 import { formatterDatostring } from '@/utils';
 
 import { finnSammenslåingsforslag } from './utils';
@@ -47,7 +46,9 @@ export const SlåSammen: FC<Props> = ({
         onError: (error: AxiosError<KontraktError>) => {
             visGlobalAlert({
                 title: error.response?.data.tittel ?? 'Kunne ikke slå sammen periodene',
-                message: error.response?.data.melding ?? hentFeilmeldingFraError(error),
+                message:
+                    error.response?.data.melding ??
+                    'En feil har oppstått ved sammenslåing av periodene.',
                 status: 'error',
             });
         },


### PR DESCRIPTION
- Bruker `Error`-objektet for nye endepunkter laget med Typespec
- Fjerner `Box` som et unødvendig html-ledd
- `Del opp periode` -> `Del opp` | likt som Sammenslå
- Fjerner `kanSplitte` med tester som erstattes av enkel filtreringslogikk i gamle modell da vi får disse periodene ferdig filtrert fra backenden 
- Renamet til `delbarePerioder`