### PR TITLE
Biome: oppdaterer schema i settings og ignorerer den store filen dokumenter.svg

### DIFF
--- a/biome.generated.json
+++ b/biome.generated.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
 	"extends": ["./biome.json"],
 	"files": {
 		"includes": ["**"]

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"files": {
 		"ignoreUnknown": true,
@@ -10,7 +10,8 @@
 			"!**/node_dist/**",
 			"!**/node_modules/**",
 			"!src/frontend/generated/**",
-			"!src/frontend/generated-new/**"
+			"!src/frontend/generated-new/**",
+			"!src/frontend/images/dokumenter.svg"
 		]
 	},
 	"formatter": {
@@ -37,7 +38,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": false,
+			"preset": "none",
 			"a11y": {
 				"noAccessKey": "error",
 				"noAriaUnsupportedElements": "error",


### PR DESCRIPTION
- Recommended deprecated
- Samme versjon i schema som vi bruker
- Ignorerer dokumenter som var for stor til default-sjekken til biome (trenger heller ikke sjekk på en statisk fil)