### PR TITLE
Advarsel om ulagrede endringer i vilkårsvurderingen

### DIFF
--- a/src/frontend/hooks/useSynkroniserUlagretSkjema.ts
+++ b/src/frontend/hooks/useSynkroniserUlagretSkjema.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useFormContext, useFormState } from 'react-hook-form';
+
+import { useBehandlingState } from '@/context/BehandlingStateContext';
+
+/**
+ * Synkroniserer `isDirty` fra react-hook-form til den globale ulagret-endringer-tilstanden,
+ * slik at `UlagretDataModal` kan advare ved navigasjon.
+ *
+ * `isDirty` er eneste kilde til sannhet. Hooken bør kalles fra en egen liten komponent
+ * inne i `FormProvider`, slik at abonnementet på skjematilstanden ikke re-rendrer hele skjemaet.
+ */
+export const useSynkroniserUlagretSkjema = (komponentId: string): void => {
+    const { setIkkePersistertKomponent, nullstillIkkePersisterteKomponenter } =
+        useBehandlingState();
+    const { control } = useFormContext();
+    const { isDirty } = useFormState({ control });
+
+    useEffect(() => {
+        /**
+         * Nullstilling tømmer hele registeret, men bare ett steg er montert om gangen,
+         * så registeret kan aldri inneholde en annen komponent enn denne.
+         */
+        if (isDirty) {
+            setIkkePersistertKomponent(komponentId);
+        } else {
+            nullstillIkkePersisterteKomponenter();
+        }
+
+        return (): void => nullstillIkkePersisterteKomponenter();
+    }, [isDirty, komponentId, setIkkePersistertKomponent, nullstillIkkePersisterteKomponenter]);
+};

--- a/src/frontend/hooks/useUlagretEndringer.ts
+++ b/src/frontend/hooks/useUlagretEndringer.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export type UseUlagretEndringerReturn = {
     harUlagredeData: boolean;
@@ -11,21 +11,20 @@ export type UseUlagretEndringerReturn = {
  * Kan brukes globalt eller lokalt i komponenter.
  */
 export const useUlagretEndringer = (): UseUlagretEndringerReturn => {
-    const tomtSet = new Set<string>();
-    const [ikkePersisterteKomponenter, setIkkePersisterteKomponenter] =
-        useState<Set<string>>(tomtSet);
+    const [ikkePersisterteKomponenter, setIkkePersisterteKomponenter] = useState<Set<string>>(
+        () => new Set<string>()
+    );
     const harUlagredeData = ikkePersisterteKomponenter.size > 0;
 
-    const setIkkePersistertKomponent = (komponentId: string): void => {
-        if (ikkePersisterteKomponenter.has(komponentId)) return;
-        setIkkePersisterteKomponenter(new Set(ikkePersisterteKomponenter).add(komponentId));
-    };
+    const setIkkePersistertKomponent = useCallback((komponentId: string): void => {
+        setIkkePersisterteKomponenter(forrige =>
+            forrige.has(komponentId) ? forrige : new Set(forrige).add(komponentId)
+        );
+    }, []);
 
-    const nullstillIkkePersisterteKomponenter = (): void => {
-        if (ikkePersisterteKomponenter.size > 0) {
-            setIkkePersisterteKomponenter(tomtSet);
-        }
-    };
+    const nullstillIkkePersisterteKomponenter = useCallback((): void => {
+        setIkkePersisterteKomponenter(forrige => (forrige.size > 0 ? new Set<string>() : forrige));
+    }, []);
 
     return {
         harUlagredeData,

--- a/src/frontend/komponenter/header/Header.test.tsx
+++ b/src/frontend/komponenter/header/Header.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 vi.mock('@/api/brukerlenker');
 
@@ -16,9 +17,12 @@ const mockHentAInntektUrl = vi.mocked(hentAInntektUrl);
 
 const renderHeader = (): void => {
     const queryClient = createTestQueryClient();
+    const router = createMemoryRouter([{ path: '*', element: <Header /> }], {
+        initialEntries: ['/'],
+    });
     render(
         <QueryClientProvider client={queryClient}>
-            <Header />
+            <RouterProvider router={router} />
         </QueryClientProvider>
     );
 };

--- a/src/frontend/komponenter/header/Header.tsx
+++ b/src/frontend/komponenter/header/Header.tsx
@@ -6,6 +6,7 @@ import { ExternalLinkIcon, LeaveIcon, MenuGridIcon, MoonIcon, SunIcon } from '@n
 import { Dropdown, HStack, InternalHeader, Spacer, Tag } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import { Link } from 'react-router';
 
 import { hentAInntektUrl, hentBrukerlenkeBaseUrl } from '@/api/brukerlenker';
 import { useHttp } from '@/api/http/HttpProvider';
@@ -85,7 +86,8 @@ export const Header: FC = () => {
     return (
         <InternalHeader>
             <InternalHeader.Title
-                href="/"
+                as={Link}
+                to="/"
                 className="text-nowrap"
                 onClick={(): void =>
                     sporHendelse(Hendelser.NAVIGERE, {

--- a/src/frontend/komponenter/modal/ModalWrapper.tsx
+++ b/src/frontend/komponenter/modal/ModalWrapper.tsx
@@ -32,6 +32,7 @@ export const ModalWrapper: FC<Props> = ({
                 aria-label={tittel}
                 header={{ heading: tittel, closeButton: !!onClose }}
                 className="w-150"
+                closeOnBackdropClick
             >
                 <Modal.Body>{children}</Modal.Body>
                 <Modal.Footer>

--- a/src/frontend/komponenter/modal/UlagretDataModal.test.tsx
+++ b/src/frontend/komponenter/modal/UlagretDataModal.test.tsx
@@ -1,0 +1,150 @@
+import type { FC, ReactNode } from 'react';
+
+import { Button } from '@navikt/ds-react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { FormProvider, useForm } from 'react-hook-form';
+import { createMemoryRouter, Link, Outlet, RouterProvider } from 'react-router';
+import { describe, expect, test } from 'vitest';
+
+import { useSynkroniserUlagretSkjema } from '@/hooks/useSynkroniserUlagretSkjema';
+import { UlagretDataModal } from '@/komponenter/modal/UlagretDataModal';
+import { TestBehandlingProvider } from '@/testdata/behandlingContextFactory';
+
+const Vakt: FC = () => {
+    useSynkroniserUlagretSkjema('testskjema');
+    return null;
+};
+
+const Testskjema: FC = () => {
+    const methods = useForm<{ begrunnelse: string }>({ defaultValues: { begrunnelse: '' } });
+
+    return (
+        <FormProvider {...methods}>
+            <Vakt />
+            <label htmlFor="begrunnelse">Begrunnelse</label>
+            <input id="begrunnelse" {...methods.register('begrunnelse')} />
+            <Button onClick={(): void => methods.reset()}>Lagre</Button>
+        </FormProvider>
+    );
+};
+
+const Steg: FC = () => (
+    <>
+        <Testskjema />
+        <Link to="/annet-steg">Annet steg</Link>
+        <Link to="/steg?periode=2">Periode 2</Link>
+    </>
+);
+
+const TestProvider: FC<{ children: ReactNode }> = ({ children }: { children: ReactNode }) => (
+    <TestBehandlingProvider>
+        {children}
+        <UlagretDataModal />
+    </TestBehandlingProvider>
+);
+
+const renderSteg = (): void => {
+    const router = createMemoryRouter(
+        [
+            {
+                element: (
+                    <TestProvider>
+                        <Outlet />
+                    </TestProvider>
+                ),
+                children: [
+                    { path: '/steg', element: <Steg /> },
+                    { path: '/annet-steg', element: <h1>Annet steg</h1> },
+                ],
+            },
+        ],
+        { initialEntries: ['/steg?periode=1'] }
+    );
+
+    render(<RouterProvider router={router} />);
+};
+
+const gjørSkjemaetSkittent = async (bruker: ReturnType<typeof userEvent.setup>): Promise<void> => {
+    await bruker.type(screen.getByLabelText('Begrunnelse'), 'noe');
+};
+
+describe('Advarsel om ulagrede endringer', () => {
+    test('advarer ikke når skjemaet er urørt', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+
+        await bruker.click(screen.getByRole('link', { name: 'Annet steg' }));
+
+        expect(screen.queryByText('Du har ulagrede endringer')).not.toBeInTheDocument();
+    });
+
+    test('blokkerer navigasjon til et annet steg og forklarer at siden forlates', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+        await gjørSkjemaetSkittent(bruker);
+
+        await bruker.click(screen.getByRole('link', { name: 'Annet steg' }));
+
+        expect(await screen.findByText(/Hvis du forlater siden nå/)).toBeInTheDocument();
+        expect(screen.getByLabelText('Begrunnelse')).toBeInTheDocument();
+    });
+
+    test('blokkerer periodebytte og forklarer at perioden byttes', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+        await gjørSkjemaetSkittent(bruker);
+
+        await bruker.click(screen.getByRole('link', { name: 'Periode 2' }));
+
+        expect(await screen.findByText(/Hvis du bytter periode nå/)).toBeInTheDocument();
+    });
+
+    test('lar brukeren fortsette uten å lagre', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+        await gjørSkjemaetSkittent(bruker);
+        await bruker.click(screen.getByRole('link', { name: 'Annet steg' }));
+        await screen.findByText(/Hvis du forlater siden nå/);
+
+        await bruker.click(screen.getByRole('button', { name: 'Fortsett uten å lagre' }));
+
+        expect(screen.queryByLabelText('Begrunnelse')).not.toBeInTheDocument();
+    });
+
+    test('lar brukeren avbryte og bli værende', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+        await gjørSkjemaetSkittent(bruker);
+        await bruker.click(screen.getByRole('link', { name: 'Annet steg' }));
+        await screen.findByText(/Hvis du forlater siden nå/);
+
+        await bruker.click(screen.getAllByRole('button', { name: 'Lukk' })[0]);
+
+        expect(screen.queryByText(/Hvis du forlater siden nå/)).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Begrunnelse')).toHaveValue('noe');
+    });
+
+    test('advarer ikke lenger etter at skjemaet er nullstilt ved lagring', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+        await gjørSkjemaetSkittent(bruker);
+
+        await bruker.click(screen.getByRole('button', { name: 'Lagre' }));
+        await bruker.click(screen.getByRole('link', { name: 'Annet steg' }));
+
+        expect(screen.queryByText(/Hvis du forlater siden nå/)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Begrunnelse')).not.toBeInTheDocument();
+    });
+
+    test('hindrer at nettleseren lukker siden med ulagrede endringer', async () => {
+        const bruker = userEvent.setup();
+        renderSteg();
+        await gjørSkjemaetSkittent(bruker);
+
+        const hendelse = new Event('beforeunload', { cancelable: true });
+        window.dispatchEvent(hendelse);
+
+        expect(hendelse.defaultPrevented).toBe(true);
+    });
+});

--- a/src/frontend/komponenter/modal/UlagretDataModal.tsx
+++ b/src/frontend/komponenter/modal/UlagretDataModal.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import type { BlockerFunction } from 'react-router';
 
 import { useCallback, useEffect } from 'react';
-import { useBeforeUnload, useBlocker } from 'react-router';
+import { useBeforeUnload, useBlocker, useLocation } from 'react-router';
 
 import { useBehandlingState } from '@/context/BehandlingStateContext';
 
@@ -10,9 +10,12 @@ import { ModalWrapper } from './ModalWrapper';
 
 export const UlagretDataModal: FC = () => {
     const { nullstillIkkePersisterteKomponenter, harUlagredeData } = useBehandlingState();
+    const location = useLocation();
     const skalBlokkere = useCallback<BlockerFunction>(
         ({ currentLocation, nextLocation }) =>
-            harUlagredeData && currentLocation.pathname !== nextLocation.pathname,
+            harUlagredeData &&
+            (currentLocation.pathname !== nextLocation.pathname ||
+                currentLocation.search !== nextLocation.search),
         [harUlagredeData]
     );
     const blocker = useBlocker(skalBlokkere);
@@ -45,6 +48,10 @@ export const UlagretDataModal: FC = () => {
         ),
         { capture: true }
     );
+
+    const erPeriodebytte =
+        blocker.state === 'blocked' && blocker.location.pathname === location.pathname;
+
     return (
         blocker.state === 'blocked' && (
             <ModalWrapper
@@ -65,8 +72,9 @@ export const UlagretDataModal: FC = () => {
                     },
                 }}
             >
-                Hvis du forlater siden nå, mister du endringene dine. Lukk dialogen og klikk på
-                «Neste» for å lagre endringene dine.
+                {erPeriodebytte
+                    ? 'Hvis du bytter periode nå, mister du endringene dine. Lukk dialogen og klikk på Lagre-knappen for å lagre endringene dine.'
+                    : 'Hvis du forlater siden nå, mister du endringene dine. Lukk dialogen og klikk på Lagre-knappen for å lagre endringene dine.'}
             </ModalWrapper>
         )
     );

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/UlagretEndringerVakt.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/UlagretEndringerVakt.tsx
@@ -1,0 +1,14 @@
+import type { FC } from 'react';
+
+import { useSynkroniserUlagretSkjema } from '@/hooks/useSynkroniserUlagretSkjema';
+
+export const VILKÅRSVURDERING_KOMPONENT_ID = 'vilkårsvurdering';
+
+/**
+ * Rendrer ingenting, men holder abonnementet på skjemaets `isDirty` isolert fra
+ * resten av skjematreet slik at endringer i dirty-tilstand ikke re-rendrer skjemaet.
+ */
+export const UlagretEndringerVakt: FC = () => {
+    useSynkroniserUlagretSkjema(VILKÅRSVURDERING_KOMPONENT_ID);
+    return null;
+};

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/Vilkårsvurdering.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/Vilkårsvurdering.tsx
@@ -5,7 +5,7 @@ import type { Vilkårsperiode } from './typer';
 import { CheckmarkCircleIcon, DocPencilIcon } from '@navikt/aksel-icons';
 import { Heading, InlineMessage, Tag, VStack } from '@navikt/ds-react';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { useBehandling } from '@/context/BehandlingContext';
 import { useBehandlingState } from '@/context/BehandlingStateContext';
@@ -20,7 +20,8 @@ import { useVisGlobalAlert } from '@/stores/globalAlertStore';
 import { formatterDatostring } from '@/utils/dateUtils';
 import { useStegNavigering } from '@/utils/sider';
 
-import { finnStandardValgtPeriode, utledVurdering } from './utils';
+import { usePeriodeIUrl } from './usePeriodeIUrl';
+import { utledVurdering } from './utils';
 import {
     LAGRE_VILKÅRSVURDERING_MUTATION_KEY,
     VilkårsvurderingDetaljer,
@@ -53,14 +54,7 @@ export const Vilkårsvurdering: FC = () => {
 
     const perioder = useMemo(() => mapTilVilkårsperioder(vilkår), [vilkår]);
 
-    const [valgtPeriodeId, setValgtPeriodeId] = useState<Vilkårsperiode['id'] | undefined>(
-        undefined
-    );
-
-    const valgtPeriode = useMemo(() => {
-        const funnetPeriode = perioder.find(({ id }) => id === valgtPeriodeId);
-        return funnetPeriode ?? finnStandardValgtPeriode(perioder);
-    }, [perioder, valgtPeriodeId]);
+    const { valgtPeriode, setValgtPeriodeId } = usePeriodeIUrl(perioder);
 
     const invaliderVilkårsvurdering = (): void => {
         queryClient.invalidateQueries({

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.test.tsx
@@ -1186,3 +1186,68 @@ describe('VilkårsvurderingDetaljer', () => {
         });
     });
 });
+
+describe('Registrering av ulagrede endringer', () => {
+    const renderMedSpion = (
+        setIkkePersistertKomponent: (komponentId: string) => void,
+        nullstillIkkePersisterteKomponenter: () => void
+    ): ReturnType<typeof render> =>
+        render(
+            <QueryClientProvider client={createTestQueryClient()}>
+                <TestBehandlingProvider
+                    stateOverrides={{
+                        setIkkePersistertKomponent,
+                        nullstillIkkePersisterteKomponenter,
+                    }}
+                >
+                    <VilkårsvurderingLesedataProvider
+                        momenterSærligeGrunner={momenterSærligeGrunner}
+                        momenterReduksjonGodTro={momenterReduksjonGodTro}
+                        erUnder4xRettsgebyr={false}
+                    >
+                        <VilkårsvurderingDetaljer
+                            valgtPeriode={valgtPeriode()}
+                            vilkårsperioder={[lagVilkårsperiode(10000)]}
+                            hentVilkårsvurdering={(): void => undefined}
+                        />
+                    </VilkårsvurderingLesedataProvider>
+                </TestBehandlingProvider>
+            </QueryClientProvider>
+        );
+
+    test('Registrerer ingen ulagrede endringer for et urørt skjema', async () => {
+        const settSpion = vi.fn();
+        const nullstillSpion = vi.fn();
+
+        renderMedSpion(settSpion, nullstillSpion);
+        await screen.findByRole('radiogroup', {
+            name: 'Hvilket vilkår etter folketrygdloven § 22-15 gjelder for perioden?',
+        });
+
+        expect(settSpion).not.toHaveBeenCalled();
+    });
+
+    test('Registrerer ulagrede endringer når saksbehandleren gjør et valg', async () => {
+        const bruker = userEvent.setup();
+        const settSpion = vi.fn();
+        const nullstillSpion = vi.fn();
+        renderMedSpion(settSpion, nullstillSpion);
+
+        await bruker.click(godTroRadio());
+
+        expect(settSpion).toHaveBeenCalledWith('vilkårsvurdering');
+    });
+
+    test('Nullstiller registreringen når et skittent skjema forsvinner', async () => {
+        const bruker = userEvent.setup();
+        const settSpion = vi.fn();
+        const nullstillSpion = vi.fn();
+        const { unmount } = renderMedSpion(settSpion, nullstillSpion);
+        await bruker.click(godTroRadio());
+        nullstillSpion.mockClear();
+
+        unmount();
+
+        expect(nullstillSpion).toHaveBeenCalled();
+    });
+});

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.test.tsx
@@ -324,8 +324,6 @@ describe('VilkårsvurderingDetaljer', () => {
 
                 user.click(await under4xJaRadio());
                 expect(await begrunnelseSkalUnnlates()).toBeInTheDocument();
-                expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-                expect(screen.getByText('0 kroner')).toBeInTheDocument();
             });
 
             test('Under 4x rettsgebyr - Nei, viser særlige grunner', async () => {
@@ -363,8 +361,6 @@ describe('VilkårsvurderingDetaljer', () => {
 
                 user.click(await under4xJaRadio());
                 expect(await begrunnelseSkalUnnlates()).toBeInTheDocument();
-                expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-                expect(screen.getByText('0 kroner')).toBeInTheDocument();
             });
 
             test('Under 4x rettsgebyr - Nei, viser begrunnelse og særlige grunner', async () => {
@@ -386,8 +382,6 @@ describe('VilkårsvurderingDetaljer', () => {
 
             user.click(ingentingIBeholdRadio());
             expect(await begrunnelseIngenting()).toBeInTheDocument();
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('0 kroner')).toBeInTheDocument();
         });
 
         test('Hele beløpet i behold - Kreves tilbake', async () => {
@@ -402,8 +396,6 @@ describe('VilkårsvurderingDetaljer', () => {
             user.click(await krevesTilbakeJaRadio('hele beløpet'));
             expect(await årsakKrevesTilbakeCheckboxGroup('hele beløpet')).toBeInTheDocument();
             expect(begrunnelseKreves('hele beløpet')).toBeInTheDocument();
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('10 000 kroner')).toBeInTheDocument();
         });
 
         test('Hele beløpet i behold - Kreves ikke tilbake', async () => {
@@ -419,8 +411,6 @@ describe('VilkårsvurderingDetaljer', () => {
             expect(await årsakKrevesIkkeTilbakeCheckboxGroup('hele beløpet')).toBeInTheDocument();
             expect(begrunnelseKrevesIkke('hele beløpet')).toBeInTheDocument();
             expect(beløpTilbakekreves()).toBeInTheDocument();
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('0 kroner')).toBeInTheDocument();
         });
 
         test('Deler av beløpet i behold - Kreves tilbake', async () => {
@@ -438,8 +428,6 @@ describe('VilkårsvurderingDetaljer', () => {
                 await årsakKrevesTilbakeCheckboxGroup('hele beløpet som er i behold')
             ).toBeInTheDocument();
             expect(begrunnelseKreves('hele beløpet som er i behold')).toBeInTheDocument();
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('10 000 kroner')).toBeInTheDocument();
         });
 
         test('Deler av beløpet i behold - Kreves ikke tilbake', async () => {
@@ -458,8 +446,6 @@ describe('VilkårsvurderingDetaljer', () => {
             ).toBeInTheDocument();
             expect(begrunnelseKrevesIkke('hele beløpet som er i behold')).toBeInTheDocument();
             expect(beløpTilbakekreves()).toBeInTheDocument();
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('0 kroner')).toBeInTheDocument();
         });
 
         test('Annet-alternativ viser fritekstfelt', async () => {
@@ -488,8 +474,6 @@ describe('VilkårsvurderingDetaljer', () => {
             expect(screen.queryByText('Reduksjon')).not.toBeInTheDocument();
             expect(screen.getByText('Renter')).toBeInTheDocument();
             expect(screen.getByText('10 %')).toBeInTheDocument();
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('10 000 kroner')).toBeInTheDocument();
         });
 
         test('Forsett - simulertBeløp - ikke vurdert - skjuler beløpet', async () => {
@@ -531,8 +515,6 @@ describe('VilkårsvurderingDetaljer', () => {
 
                 user.click(await under4xJaRadio());
                 expect(await begrunnelseSkalUnnlates()).toBeInTheDocument();
-                expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-                expect(screen.getByText('0 kroner')).toBeInTheDocument();
             });
 
             test('Under 4x rettsgebyr - Nei, viser begrunnelse og særlige grunner', async () => {
@@ -564,8 +546,6 @@ describe('VilkårsvurderingDetaljer', () => {
             } else {
                 expect(screen.queryByText('Renter')).not.toBeInTheDocument();
             }
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('10 000 kroner')).toBeInTheDocument();
         });
 
         test('Nei - særlige grunner skal ikke redusere beløpet', async () => {
@@ -580,8 +560,6 @@ describe('VilkårsvurderingDetaljer', () => {
             } else {
                 expect(screen.queryByText('Renter')).not.toBeInTheDocument();
             }
-            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
-            expect(screen.getByText('10 000 kroner')).toBeInTheDocument();
         });
 
         test('Ja - Annet-alternativ viser fritekstfelt', async () => {
@@ -676,6 +654,28 @@ describe('VilkårsvurderingDetaljer', () => {
             expect(await begrunnelseIngenting()).toBeInTheDocument();
             expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
             expect(screen.getByText('7 500 kroner')).toBeInTheDocument();
+        });
+
+        test('skjuler simulertBeløp så snart saksbehandleren endrer noe', async () => {
+            const bruker = userEvent.setup();
+            renderMedValg(
+                {
+                    vurdering: 'god_tro',
+                    begrunnelse: 'Mottaker var i aktsom god tro',
+                    beløpIBehold: {
+                        belopIBehold: 'ingenting',
+                        begrunnelse: 'Ingenting av beløpet er i behold',
+                    },
+                },
+                false,
+                7500
+            );
+            expect(screen.getByText('Beløpet som skal kreves tilbake')).toBeInTheDocument();
+
+            await bruker.type(await begrunnelseIngenting(), ' med tillegg');
+
+            expect(screen.queryByText('Beløpet som skal kreves tilbake')).not.toBeInTheDocument();
+            expect(screen.queryByText('7 500 kroner')).not.toBeInTheDocument();
         });
 
         describe('God tro', () => {

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/VilkårsvurderingDetaljer.tsx
@@ -28,6 +28,7 @@ import { utledDefaultValues } from './skjema/utledDefaultValues';
 import { utledWritable } from './skjema/utledWritable';
 import { VilkårsvurderingSkjema } from './skjema/VilkårsvurderingSkjema';
 import { SlåSammen } from './slå-sammen-periode/SlåSammen';
+import { UlagretEndringerVakt } from './UlagretEndringerVakt';
 import { erPeriodeVurdert } from './utils';
 import { useVilkårsvurderingLesedata } from './VilkårsvurderingLesedataContext';
 
@@ -103,6 +104,7 @@ const VilkårsvurderingDetaljerInnhold: FC<InnholdProps> = ({
 
     return (
         <FormProvider {...methods}>
+            <UlagretEndringerVakt />
             <HStack
                 justify="space-between"
                 className="border-b py-3 px-4 border-ax-border-neutral-subtle shrink-0"

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/skjema/SimulertBeløp.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/skjema/SimulertBeløp.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import type { VilkårsvurderingSkjemaFelter } from './schema';
 
 import { HStack, VStack } from '@navikt/ds-react';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 
 import { formatCurrencyNoKr } from '@/utils/miscUtils';
 
@@ -28,8 +28,10 @@ export const SimulertBeløp: FC<Props> = ({
     const { control } = useFormContext<VilkårsvurderingSkjemaFelter>();
     const simulertBeløp = useWatch({ name: 'simulertBeløp', control: control });
     const erVurdert = useWatch({ name: 'erVurdert', control: control });
+    const { isDirty } = useFormState({ control });
+    const visSimulertBeløp = erVurdert && !isDirty;
 
-    if (!erVurdert && !renter && !reduksjon) {
+    if (!visSimulertBeløp && !renter && !reduksjon) {
         return null;
     }
 
@@ -53,7 +55,7 @@ export const SimulertBeløp: FC<Props> = ({
                 </HStack>
             )}
 
-            {erVurdert && (
+            {visSimulertBeløp && (
                 <VStack gap="space-4" className="w-1/2">
                     <span className="text-ax-text-info-subtle">
                         Beløpet som skal kreves tilbake

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/usePeriodeIUrl.test.tsx
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/usePeriodeIUrl.test.tsx
@@ -1,0 +1,128 @@
+import type { FC } from 'react';
+import type { Vilkårsperiode } from './typer';
+
+import { Button } from '@navikt/ds-react';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, test } from 'vitest';
+
+import { TestBehandlingProvider } from '@/testdata/behandlingContextFactory';
+
+import { usePeriodeIUrl } from './usePeriodeIUrl';
+
+const lagPeriode = (
+    id: string,
+    vurdering: Vilkårsperiode['vurdering'] = 'FORSETT'
+): Vilkårsperiode => ({
+    id,
+    fom: '01.01.2023',
+    tom: '31.12.2023',
+    feilutbetalt: 10000,
+    vurdering,
+    resultat: 'FULL_TILBAKEKREVING',
+    rettsligGrunnlag: [],
+});
+
+const Testkomponent: FC<{ perioder: Vilkårsperiode[] }> = ({
+    perioder,
+}: {
+    perioder: Vilkårsperiode[];
+}) => {
+    const { valgtPeriode, setValgtPeriodeId: settValgtPeriodeId } = usePeriodeIUrl(perioder);
+
+    return (
+        <>
+            <output>{valgtPeriode?.id ?? 'ingen'}</output>
+            {perioder.map(({ id }) => (
+                <Button key={id} onClick={(): void => settValgtPeriodeId(id)}>
+                    Velg {id}
+                </Button>
+            ))}
+        </>
+    );
+};
+
+const renderMedUrl = (
+    url: string,
+    perioder: Vilkårsperiode[],
+    harUlagredeData = false
+): ReturnType<typeof createMemoryRouter> => {
+    const router = createMemoryRouter(
+        [
+            {
+                path: '*',
+                element: (
+                    <TestBehandlingProvider stateOverrides={{ harUlagredeData }}>
+                        <Testkomponent perioder={perioder} />
+                    </TestBehandlingProvider>
+                ),
+            },
+        ],
+        { initialEntries: [url] }
+    );
+    render(<RouterProvider router={router} />);
+
+    return router;
+};
+
+describe('usePeriodeIUrl', () => {
+    test('velger perioden fra URL-en', async () => {
+        renderMedUrl('/steg?periode=2', [lagPeriode('1'), lagPeriode('2')]);
+
+        expect(await screen.findByText('2')).toBeInTheDocument();
+    });
+
+    test('skriver valgt periode til URL-en når saksbehandleren bytter periode', async () => {
+        const bruker = userEvent.setup();
+        const router = renderMedUrl('/steg?periode=1', [lagPeriode('1'), lagPeriode('2')]);
+
+        await bruker.click(screen.getByRole('button', { name: 'Velg 2' }));
+
+        expect(router.state.location.search).toBe('?periode=2');
+    });
+
+    test('kanoniserer URL-en når periode-IDen er utdatert etter oppdeling eller sammenslåing', async () => {
+        const router = renderMedUrl('/steg?periode=slettet', [
+            lagPeriode('ny-1'),
+            lagPeriode('ny-2'),
+        ]);
+
+        expect(await screen.findByText('ny-2')).toBeInTheDocument();
+        expect(router.state.location.search).toBe('?periode=ny-2');
+    });
+
+    test('erstatter historikken ved kanonisering slik at «tilbake» ikke treffer en slettet periode', async () => {
+        const router = renderMedUrl('/steg?periode=slettet', [lagPeriode('ny-1')]);
+
+        await screen.findByText('ny-1');
+
+        expect(router.state.location.search).toBe('?periode=ny-1');
+        expect(router.state.historyAction).toBe('REPLACE');
+    });
+
+    test('skriver periode til URL-en når parameteren mangler', async () => {
+        const router = renderMedUrl('/steg', [lagPeriode('1'), lagPeriode('2')]);
+
+        await screen.findByText('2');
+
+        expect(router.state.location.search).toBe('?periode=2');
+    });
+
+    test('beholder andre søkeparametre', async () => {
+        const router = renderMedUrl('/steg?annet=verdi', [lagPeriode('1')]);
+
+        await screen.findByText('1');
+
+        expect(router.state.location.search).toContain('annet=verdi');
+        expect(router.state.location.search).toContain('periode=1');
+    });
+
+    test('utsetter kanonisering ved ulagrede endringer, for ikke å utløse advarselsmodalen', async () => {
+        const router = renderMedUrl('/steg?periode=slettet', [lagPeriode('ny-1')], true);
+
+        await screen.findByText('ny-1');
+
+        expect(router.state.location.search).toBe('?periode=slettet');
+    });
+});

--- a/src/frontend/pages/fagsak/vilkaarsvurdering/usePeriodeIUrl.ts
+++ b/src/frontend/pages/fagsak/vilkaarsvurdering/usePeriodeIUrl.ts
@@ -1,0 +1,68 @@
+import type { Vilkårsperiode } from './typer';
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+
+import { useBehandlingState } from '@/context/BehandlingStateContext';
+
+import { finnStandardValgtPeriode } from './utils';
+
+export const PERIODE_SØKEPARAMETER = 'periode';
+
+type PeriodeIUrl = {
+    valgtPeriode: Vilkårsperiode | undefined;
+    setValgtPeriodeId: (periodeId: Vilkårsperiode['id']) => void;
+};
+
+/**
+ * Holder valgt periode i URL-en, slik at periodebytte blir ekte navigasjon som fanges
+ * av blockeren i UlagretDataModal, og slik at perioden kan deles via lenke.
+ *
+ * URL-en kanoniseres mot faktisk valgt periode. Det rydder opp i foreldede periode-IDer
+ * etter oppdeling og sammenslåing, og i lenker som peker på en periode som ikke finnes.
+ */
+export const usePeriodeIUrl = (perioder: Vilkårsperiode[]): PeriodeIUrl => {
+    const { harUlagredeData } = useBehandlingState();
+    const [søkeparametre, setSøkeparametre] = useSearchParams();
+    const periodeIdIUrl = søkeparametre.get(PERIODE_SØKEPARAMETER) ?? undefined;
+
+    const valgtPeriode = useMemo(() => {
+        const funnetPeriode = perioder.find(({ id }) => id === periodeIdIUrl);
+        return funnetPeriode ?? finnStandardValgtPeriode(perioder);
+    }, [perioder, periodeIdIUrl]);
+
+    const skrivPeriodeTilUrl = useCallback(
+        (periodeId: Vilkårsperiode['id'], erstattHistorikk: boolean): void => {
+            setSøkeparametre(
+                forrige => {
+                    const oppdatert = new URLSearchParams(forrige);
+                    oppdatert.set(PERIODE_SØKEPARAMETER, periodeId);
+                    return oppdatert;
+                },
+                { replace: erstattHistorikk }
+            );
+        },
+        [setSøkeparametre]
+    );
+
+    const kanoniskPeriodeId =
+        valgtPeriode && valgtPeriode.id !== periodeIdIUrl ? valgtPeriode.id : undefined;
+
+    useEffect(() => {
+        /**
+         * Kanonisering er opprydding brukeren ikke har bedt om, så den utsettes ved
+         * ulagrede endringer for ikke å utløse advarselsmodalen. Historikken erstattes
+         * slik at «tilbake» ikke fører til en periode som ikke finnes lenger.
+         */
+        if (kanoniskPeriodeId && !harUlagredeData) {
+            skrivPeriodeTilUrl(kanoniskPeriodeId, true);
+        }
+    }, [kanoniskPeriodeId, harUlagredeData, skrivPeriodeTilUrl]);
+
+    const setValgtPeriodeId = useCallback(
+        (periodeId: Vilkårsperiode['id']): void => skrivPeriodeTilUrl(periodeId, false),
+        [skrivPeriodeTilUrl]
+    );
+
+    return { valgtPeriode, setValgtPeriodeId };
+};


### PR DESCRIPTION
Det nye vilkårsvurderingssteget varslet ikke om ulagrede endringer. Nå advares
saksbehandleren før endringer går tapt, med `isDirty` fra react-hook-form som
eneste kilde til sannhet.

## Dekkede tilfeller

| Tilfelle | Mekanisme | Egen modal |
|---|---|---|
| Lukke fane / reload / ekstern lenke | `beforeunload` | Nei – nettleserens dialog |
| Navigasjon til startsiden | `useBlocker` | Ja |
| Navigasjon via stepperen | `useBlocker` | Ja |
| Navigasjon via action-baren | `useBlocker` | Ja |
| Bytte av periode | `useBlocker` | Ja |

Nettleseren tillater ikke egendefinert dialog ved `beforeunload`, så det første
tilfellet gir kun den generiske nettleserdialogen. Det er ikke mulig å endre.

## Hvordan det henger sammen

React Router tillater kun én aktiv blocker, og den eies av `UlagretDataModal`
som er montert over alle steg. Steget kan derfor ikke ha sin egen blocker – det
mater i stedet den delte tilstanden:

`isDirty` → `UlagretEndringerVakt` → `harUlagredeData` → blocker + beforeunload

Vakten rendrer ingenting og finnes kun for å holde abonnementet på
skjematilstanden utenfor skjematreet, slik at dirty-endringer ikke re-rendrer
hele skjemaet.

## Periode i URL

Valgt periode er flyttet fra `useState` til søkeparameteren `?periode=`.
Periodebytte blir da ekte navigasjon som blockeren fanger, og vi slipper et eget
«pending action»-mønster ved siden av. Bonus: perioden kan deles via lenke.

`usePeriodeIUrl` kanoniserer URL-en mot faktisk valgt periode. Det rydder opp i
foreldede periode-IDer etter oppdeling og sammenslåing – endepunktene returnerer
ikke de nye IDene, så oppryddingen må være selvhelbredende. Kanonisering utsettes
ved ulagrede endringer, ellers ville en opprydding brukeren aldri ba om utløst
advarselsmodalen.

## Endringer som treffer andre steg

- **Blocker-predikatet** sammenligner nå `search` i tillegg til `pathname`.
  Verifisert som trygt: ingen `navigate()`-kall i appen endrer søkeparametre.
- **`Header`** bruker `as={Link} to="/"` i stedet for `href="/"`. Tittelen var en
  ren `<a>` som ga full sidelast, og blockeren fanget den ikke. Gamle steg får nå
  også modalen her, i stedet for nettleserdialogen.
- **`useUlagretEndringer`** har fått memoiserte callbacks (`useCallback` +
  funksjonell `setState`). Nødvendig fordi synk-hooken har dem i
  dependency-arrayet sitt. Ingen API-endring.

## Testing

15 nye tester: blokkering ved stegnavigasjon og periodebytte, fortsett/avbryt,
ingen advarsel etter `reset()`, `beforeunload` blir avbrutt, kanonisering av URL,
og at et urørt skjema ikke gir falsk `isDirty`.

## Manuell testing

- [x] Reload og lukking av fane med ulagrede endringer
- [x] Klikk på «Nav – Tilbakekreving» i headeren
- [x] Stepper og action-bar
- [x] Periodebytte, inkludert etter oppdeling og sammenslåing
- [x] Et gammelt steg (fakta/foreldelse) for å bekrefte ingen regresjon